### PR TITLE
Modular ESP32-S3 Arduino bring-up scaffold for RSVP device

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -1,0 +1,9 @@
+[env:waveshare_esp32s3]
+platform = espressif32
+board = esp32-s3-devkitc-1
+framework = arduino
+monitor_speed = 115200
+lib_deps =
+  bodmer/TFT_eSPI @ ^2.5.43
+build_flags =
+  -DCORE_DEBUG_LEVEL=1

--- a/src/app/App.cpp
+++ b/src/app/App.cpp
@@ -1,0 +1,64 @@
+#include "app/App.h"
+
+#include "board/BoardConfig.h"
+
+App::App() : button_(BoardConfig::PIN_BOOT_BUTTON) {}
+
+void App::begin() {
+  BoardConfig::begin();
+  button_.begin();
+  display_.begin();
+  touch_.begin();
+  storage_.begin();
+
+  display_.renderCenteredWord("READY");
+  storage_.listBooks();
+
+  state_ = button_.isHeld() ? AppState::Playing : AppState::Paused;
+}
+
+void App::update(uint32_t nowMs) {
+  button_.update(nowMs);
+  updateState();
+  handleTouch(nowMs);
+
+  // TODO: App heartbeat/log throttling can be expanded if needed for diagnostics.
+  if (nowMs - lastStateLogMs_ > 1500) {
+    lastStateLogMs_ = nowMs;
+    Serial.printf("[app] state=%d\n", static_cast<int>(state_));
+  }
+}
+
+void App::updateState() {
+  const AppState nextState = button_.isHeld() ? AppState::Playing : AppState::Paused;
+  if (nextState == state_) {
+    return;
+  }
+
+  state_ = nextState;
+  if (state_ == AppState::Playing) {
+    display_.renderCenteredWord("PLAY");
+  } else if (state_ == AppState::Paused) {
+    display_.renderCenteredWord("PAUSE");
+  }
+
+  // TODO: Add transitions for Menu and Sleeping states when those features are implemented.
+}
+
+void App::handleTouch(uint32_t nowMs) {
+  (void)nowMs;
+  TouchEvent ev;
+  if (!touch_.poll(ev)) {
+    return;
+  }
+
+  Serial.printf("[touch] gesture=%u x=%u y=%u state=%d\n", ev.gesture, ev.x, ev.y,
+                static_cast<int>(state_));
+
+  if (state_ == AppState::Playing) {
+    // Interaction model requirement: ignore touch while playing.
+    return;
+  }
+
+  // TODO: While paused, map raw touch events to swipe/long-press actions.
+}

--- a/src/app/App.h
+++ b/src/app/App.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <Arduino.h>
+
+#include "app/AppState.h"
+#include "display/DisplayManager.h"
+#include "input/ButtonHandler.h"
+#include "input/TouchHandler.h"
+#include "storage/StorageManager.h"
+
+class App {
+ public:
+  App();
+
+  void begin();
+  void update(uint32_t nowMs);
+
+ private:
+  void updateState();
+  void handleTouch(uint32_t nowMs);
+
+  AppState state_ = AppState::Booting;
+  DisplayManager display_;
+  ButtonHandler button_;
+  TouchHandler touch_;
+  StorageManager storage_;
+
+  uint32_t lastStateLogMs_ = 0;
+};

--- a/src/app/AppState.h
+++ b/src/app/AppState.h
@@ -1,0 +1,9 @@
+#pragma once
+
+enum class AppState {
+  Booting,
+  Paused,
+  Playing,
+  Menu,
+  Sleeping,
+};

--- a/src/board/BoardConfig.cpp
+++ b/src/board/BoardConfig.cpp
@@ -1,0 +1,12 @@
+#include "board/BoardConfig.h"
+
+#include <Wire.h>
+
+namespace BoardConfig {
+
+void begin() {
+  pinMode(PIN_BOOT_BUTTON, INPUT_PULLUP);
+  Wire.begin(PIN_I2C_SDA, PIN_I2C_SCL);
+}
+
+}  // namespace BoardConfig

--- a/src/board/BoardConfig.h
+++ b/src/board/BoardConfig.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <Arduino.h>
+
+namespace BoardConfig {
+
+// TODO: Verify these pins against the exact Waveshare ESP32-S3 AMOLED 1.91" schematic.
+constexpr int PIN_BOOT_BUTTON = 0;
+constexpr int PIN_SD_CS = 10;
+constexpr int PIN_I2C_SDA = 8;
+constexpr int PIN_I2C_SCL = 9;
+
+void begin();
+
+}  // namespace BoardConfig

--- a/src/display/DisplayManager.cpp
+++ b/src/display/DisplayManager.cpp
@@ -1,0 +1,22 @@
+#include "display/DisplayManager.h"
+
+bool DisplayManager::begin() {
+  tft_.init();
+  tft_.setRotation(0);
+  tft_.fillScreen(TFT_BLACK);
+  tft_.setTextDatum(MC_DATUM);
+  tft_.setTextFont(4);
+  tft_.setTextColor(TFT_WHITE, TFT_BLACK);
+  return true;
+}
+
+void DisplayManager::renderCenteredWord(const String &word, uint16_t color) {
+  if (word == lastWord_) {
+    return;
+  }
+
+  lastWord_ = word;
+  tft_.fillScreen(TFT_BLACK);
+  tft_.setTextColor(color, TFT_BLACK);
+  tft_.drawString(word, tft_.width() / 2, tft_.height() / 2);
+}

--- a/src/display/DisplayManager.h
+++ b/src/display/DisplayManager.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <Arduino.h>
+#include <TFT_eSPI.h>
+
+class DisplayManager {
+ public:
+  bool begin();
+  void renderCenteredWord(const String &word, uint16_t color = TFT_WHITE);
+
+ private:
+  TFT_eSPI tft_ = TFT_eSPI();
+  String lastWord_;
+};

--- a/src/input/ButtonHandler.cpp
+++ b/src/input/ButtonHandler.cpp
@@ -1,0 +1,30 @@
+#include "input/ButtonHandler.h"
+
+ButtonHandler::ButtonHandler(int pin) : pin_(pin) {}
+
+void ButtonHandler::begin() {
+  pinMode(pin_, INPUT_PULLUP);
+  held_ = !digitalRead(pin_);
+  lastEdgeMs_ = millis();
+}
+
+void ButtonHandler::update(uint32_t nowMs) {
+  pressedEvent_ = false;
+
+  const bool currentHeld = !digitalRead(pin_);  // Active-low BOOT button.
+  if (currentHeld != held_) {
+    held_ = currentHeld;
+    lastEdgeMs_ = nowMs;
+    if (held_) {
+      pressedEvent_ = true;
+    }
+  }
+
+  // TODO: Add multi-press detection here for triple-press sleep while paused.
+}
+
+bool ButtonHandler::isHeld() const { return held_; }
+
+bool ButtonHandler::wasPressedEvent() const { return pressedEvent_; }
+
+uint32_t ButtonHandler::lastEdgeMs() const { return lastEdgeMs_; }

--- a/src/input/ButtonHandler.h
+++ b/src/input/ButtonHandler.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <Arduino.h>
+
+class ButtonHandler {
+ public:
+  explicit ButtonHandler(int pin);
+
+  void begin();
+  void update(uint32_t nowMs);
+
+  bool isHeld() const;
+  bool wasPressedEvent() const;
+  uint32_t lastEdgeMs() const;
+
+ private:
+  int pin_;
+  bool held_ = false;
+  bool pressedEvent_ = false;
+  uint32_t lastEdgeMs_ = 0;
+};

--- a/src/input/TouchHandler.cpp
+++ b/src/input/TouchHandler.cpp
@@ -1,0 +1,67 @@
+#include "input/TouchHandler.h"
+
+#include <Wire.h>
+
+bool TouchHandler::begin() {
+  Wire.beginTransmission(kAddress);
+  const uint8_t error = Wire.endTransmission();
+  initialized_ = (error == 0);
+
+  if (!initialized_) {
+    Serial.println("[touch] Controller not detected at 0x15");
+  } else {
+    Serial.println("[touch] Initialized (CST816S-compatible)");
+  }
+
+  return initialized_;
+}
+
+bool TouchHandler::readRegister(uint8_t reg, uint8_t *buffer, size_t len) {
+  Wire.beginTransmission(kAddress);
+  Wire.write(reg);
+  if (Wire.endTransmission(false) != 0) {
+    return false;
+  }
+
+  const size_t readLen = Wire.requestFrom(static_cast<int>(kAddress), static_cast<int>(len));
+  if (readLen != len) {
+    return false;
+  }
+
+  for (size_t i = 0; i < len; ++i) {
+    buffer[i] = Wire.read();
+  }
+  return true;
+}
+
+bool TouchHandler::poll(TouchEvent &event) {
+  event = TouchEvent{};
+
+  if (!initialized_) {
+    return false;
+  }
+
+  const uint32_t now = millis();
+  if (now - lastPollMs_ < 20) {
+    return false;
+  }
+  lastPollMs_ = now;
+
+  uint8_t data[6] = {0};
+  if (!readRegister(0x01, data, sizeof(data))) {
+    return false;
+  }
+
+  // CST816S packet: [gesture, points, xh, xl, yh, yl]
+  const uint8_t points = data[1] & 0x0F;
+  if (points == 0) {
+    return false;
+  }
+
+  event.touched = true;
+  event.gesture = data[0];
+  event.x = static_cast<uint16_t>(((data[2] & 0x0F) << 8) | data[3]);
+  event.y = static_cast<uint16_t>(((data[4] & 0x0F) << 8) | data[5]);
+
+  return true;
+}

--- a/src/input/TouchHandler.h
+++ b/src/input/TouchHandler.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <Arduino.h>
+
+struct TouchEvent {
+  bool touched = false;
+  uint16_t x = 0;
+  uint16_t y = 0;
+  uint8_t gesture = 0;
+};
+
+class TouchHandler {
+ public:
+  bool begin();
+  bool poll(TouchEvent &event);
+
+ private:
+  static constexpr uint8_t kAddress = 0x15;  // Common CST816S address.
+  bool initialized_ = false;
+  uint32_t lastPollMs_ = 0;
+
+  bool readRegister(uint8_t reg, uint8_t *buffer, size_t len);
+};

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,0 +1,15 @@
+#include <Arduino.h>
+
+#include "app/App.h"
+
+App app;
+
+void setup() {
+  Serial.begin(115200);
+  app.begin();
+}
+
+void loop() {
+  const uint32_t now = millis();
+  app.update(now);
+}

--- a/src/storage/StorageManager.cpp
+++ b/src/storage/StorageManager.cpp
@@ -1,0 +1,38 @@
+#include "storage/StorageManager.h"
+
+#include <SD.h>
+#include <SPI.h>
+
+#include "board/BoardConfig.h"
+
+bool StorageManager::begin() {
+  mounted_ = SD.begin(BoardConfig::PIN_SD_CS);
+  if (!mounted_) {
+    Serial.println("[storage] SD init failed");
+    return false;
+  }
+
+  Serial.println("[storage] SD initialized");
+  return true;
+}
+
+void StorageManager::listBooks() {
+  if (!mounted_ || listedOnce_) {
+    return;
+  }
+  listedOnce_ = true;
+
+  File dir = SD.open("/books");
+  if (!dir || !dir.isDirectory()) {
+    Serial.println("[storage] /books directory not found");
+    return;
+  }
+
+  Serial.println("[storage] Listing /books:");
+  File entry = dir.openNextFile();
+  while (entry) {
+    Serial.printf("  %s\n", entry.name());
+    entry.close();
+    entry = dir.openNextFile();
+  }
+}

--- a/src/storage/StorageManager.h
+++ b/src/storage/StorageManager.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <Arduino.h>
+
+class StorageManager {
+ public:
+  bool begin();
+  void listBooks();
+
+ private:
+  bool mounted_ = false;
+  bool listedOnce_ = false;
+};


### PR DESCRIPTION
### Motivation
- Provide a minimal, modular hardware bring-up for the RSVP one-word reader on a Waveshare ESP32-S3 AMOLED board so subsequent feature work can focus on gestures, parsing and UI without reworking low-level initialization.
- Keep the interaction model and product scope strict by only implementing boot/display/button/touch/SD initialization and raw touch logging for the first milestone.

### Description
- Added a PlatformIO Arduino target with `TFT_eSPI` dependency in `platformio.ini` and a non-blocking `millis()` driven `main.cpp` that runs the `App` state machine.
- Introduced `AppState` (`Booting`, `Paused`, `Playing`, `Menu`, `Sleeping`) and a modular app with components: `board/BoardConfig`, `input/ButtonHandler`, `input/TouchHandler`, `display/DisplayManager`, and `storage/StorageManager`.
- Implemented display initialization and centered test-word rendering (`READY` at boot, `PLAY` while BOOT button held, `PAUSE` when released) and ensured touch is explicitly ignored while `Playing` per the interaction model.
- Implemented touch controller (CST816S-compatible probe/poll) with raw touch event serial logging and SD initialization with a one-time listing of `/books`; left `TODO` markers for triple-press sleep, gesture interpretation, menu/sleep transitions, and pin verification.

### Testing
- Attempted `pio run` in this environment and it failed because the PlatformIO CLI is not available here (`pio: command not found`).
- No other automated tests were run in this environment; the code is written to be compile-oriented and should be build-verified in a local environment with PlatformIO installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d80b4139d4832ba401ef6339bd56e6)