### PR TITLE
Add Waveshare ESP32-C6-Touch-LCD-1.47 port

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,14 +106,23 @@ A second build target — the [Waveshare ESP32-C6-Touch-LCD-1.47](https://www.wa
 
 ### Optional: battery + thermistor on the C6
 
-The C6 board exposes Vbat to GPIO0 through a built-in 1:2 (÷3) divider, so battery monitoring works with no extra parts. For pack temperature, the firmware can read an external NTC thermistor (e.g. the Yellow lead of an LP803448 LiPo) on GPIO6:
+The C6 board exposes Vbat to GPIO0 through a built-in 1:2 (÷3) divider, so battery monitoring works with no extra parts. For pack temperature, the firmware can read an external NTC thermistor (e.g. the Yellow lead of an LP803448 LiPo). It is **off by default** on every target — opt in by adding a build flag:
+
+```ini
+[env:waveshare_esp32c6]
+build_flags =
+  ${env.build_flags}
+  -DRSVP_THERMISTOR_PIN=6   ; ADC1 channel; on the C6 GPIO5 or GPIO6 are free
+```
+
+Recommended wiring (NTC-to-GND, with a 10 kΩ pull-up to 3V3):
 
 ```text
-3V3 ──[ 10 kΩ ]──┬── GPIO6 (ADC1_CH6)
+3V3 ──[ 10 kΩ ]──┬── GPIO<RSVP_THERMISTOR_PIN>
                  └── NTC (Yellow) ── BAT-/GND
 ```
 
-Defaults assume an NTC with R0 = 10 kΩ at 25 °C and β = 3950 (typical for LP-series LiPos). Override `THERMISTOR_BETA`, `THERMISTOR_NOMINAL_OHMS`, or `THERMISTOR_NTC_TO_GND` in [src/board/BoardConfig.h](src/board/BoardConfig.h) if your pack differs. With no thermistor connected the firmware reports voltage only.
+Defaults assume an NTC with R0 = 10 kΩ at 25 °C and β = 3950 (typical for LP-series LiPos). Override per-env via `-DRSVP_THERMISTOR_BETA=...`, `-DRSVP_THERMISTOR_R0_OHMS=...`, `-DRSVP_THERMISTOR_SERIES_OHMS=...`, or `-DRSVP_THERMISTOR_NTC_TO_GND=0` for the inverted topology. With the flag unset (or `RSVP_THERMISTOR_PIN=-1`) the firmware reports voltage only. The same build flags work on the S3 target if you wire an NTC to a free ADC pin there.
 
 If you are adapting the project to different hardware, start with [src/board/BoardConfig.h](src/board/BoardConfig.h), then review the display, touch, power, and SD wiring code.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # RSVP Nano
 
-RSVP Nano is an open-source ESP32-S3 reading device for showing text one word at a time with RSVP (Rapid Serial Visual Presentation). The firmware is built around stable anchor-letter rendering, readable typography, tunable pacing, SD card storage, and local EPUB conversion.
+RSVP Nano is an open-source ESP32 reading device for showing text one word at a time with RSVP (Rapid Serial Visual Presentation). The firmware is built around stable anchor-letter rendering, readable typography, tunable pacing, SD card storage, and local EPUB conversion. Two hardware targets are supported: the original Waveshare ESP32-S3-Touch-LCD-3.49 and the smaller, cheaper Waveshare ESP32-C6-Touch-LCD-1.47.
 
 ## Highlights
 
@@ -56,6 +56,21 @@ pio device monitor
 
 The default environment is `waveshare_esp32s3_usb_msc`, which includes the reader and USB transfer mode.
 
+To target the Waveshare ESP32-C6-Touch-LCD-1.47 (JD9853 panel + AXS5106L touch, no PSRAM, no native USB-OTG, no on-device EPUB conversion), use:
+
+```sh
+pio run -e waveshare_esp32c6
+pio run -e waveshare_esp32c6 -t upload
+```
+
+The C6 environment ships with these build flags (already wired up in `platformio.ini`):
+
+| Flag | Value | Why |
+| --- | --- | --- |
+| `RSVP_USB_TRANSFER_ENABLED` | `0` | C6 has no native USB-OTG, so USB mass-storage mode is unavailable. |
+| `RSVP_ON_DEVICE_EPUB_CONVERSION` | `0` | No PSRAM; pre-convert EPUBs with the desktop helper instead. |
+| `RSVP_MAX_BOOK_WORDS` | `6000` | Caps loaded books to fit in the 512 KB on-chip SRAM. Each `String` word costs ~30–40 B, leaving headroom for SPI/SD buffers and UI state. |
+
 Serial monitor runs at `115200`.
 
 To export the merged binary used by the browser flasher:
@@ -79,7 +94,28 @@ The current firmware configuration targets the [Waveshare ESP32-S3-Touch-LCD-3.4
 - SD card connected through `SD_MMC`.
 - Touch, battery, and board power control pins defined in `src/board/BoardConfig.h`.
 
-If you are adapting the project to different hardware, start with `src/board/BoardConfig.h`, then review the display, touch, power, and SD wiring code.
+A second build target — the [Waveshare ESP32-C6-Touch-LCD-1.47](https://www.waveshare.com/esp32-c6-touch-lcd-1.47.htm) — is available as `waveshare_esp32c6`. Notes:
+
+- ESP32-C6 has no PSRAM, so on-device EPUB conversion is disabled in this build. Pre-convert books with the desktop helper instead.
+- The C6 has no native USB-OTG, so the USB mass-storage transfer mode is unavailable.
+- The display is a 172×320 JD9853 SPI panel driven in 320×172 landscape; the touch controller is an AXS5106L on I2C (address `0x63`, 100 kHz).
+- The microSD slot uses SPI on the C6 board and shares the SPI bus with the LCD (`CLK=GPIO1`, `MOSI=GPIO2`, `MISO=GPIO3`, `CS=GPIO4`).
+- The board has a single BOOT button (GPIO9). The firmware binds: short press = menu, double press = brightness, long press = theme.
+- Touch axis mapping and gesture decoding for the AXS5106L may need calibration for your unit; see [src/input/TouchHandler.cpp](src/input/TouchHandler.cpp).
+- Books larger than `RSVP_MAX_BOOK_WORDS` (default 6000) are truncated at load. Raise the cap if you have headroom or split long books into chapters.
+
+### Optional: battery + thermistor on the C6
+
+The C6 board exposes Vbat to GPIO0 through a built-in 1:2 (÷3) divider, so battery monitoring works with no extra parts. For pack temperature, the firmware can read an external NTC thermistor (e.g. the Yellow lead of an LP803448 LiPo) on GPIO6:
+
+```text
+3V3 ──[ 10 kΩ ]──┬── GPIO6 (ADC1_CH6)
+                 └── NTC (Yellow) ── BAT-/GND
+```
+
+Defaults assume an NTC with R0 = 10 kΩ at 25 °C and β = 3950 (typical for LP-series LiPos). Override `THERMISTOR_BETA`, `THERMISTOR_NOMINAL_OHMS`, or `THERMISTOR_NTC_TO_GND` in [src/board/BoardConfig.h](src/board/BoardConfig.h) if your pack differs. With no thermistor connected the firmware reports voltage only.
+
+If you are adapting the project to different hardware, start with [src/board/BoardConfig.h](src/board/BoardConfig.h), then review the display, touch, power, and SD wiring code.
 
 ## Running Tests
 

--- a/boards/esp32-c6-n8.json
+++ b/boards/esp32-c6-n8.json
@@ -1,0 +1,46 @@
+{
+  "build": {
+    "arduino": {
+      "ldscript": "esp32c6_out.ld",
+      "partitions": "default_8MB.csv"
+    },
+    "core": "esp32",
+    "extra_flags": [
+      "-DARDUINO_ESP32C6_DEV",
+      "-DARDUINO_USB_MODE=1",
+      "-DARDUINO_USB_CDC_ON_BOOT=1"
+    ],
+    "f_cpu": "160000000L",
+    "f_flash": "80000000L",
+    "flash_mode": "qio",
+    "hwids": [
+      [
+        "0x303A",
+        "0x1001"
+      ]
+    ],
+    "mcu": "esp32c6",
+    "variant": "esp32c6"
+  },
+  "connectivity": [
+    "wifi",
+    "bluetooth"
+  ],
+  "debug": {
+    "openocd_target": "esp32c6.cfg"
+  },
+  "frameworks": [
+    "arduino",
+    "espidf"
+  ],
+  "name": "Waveshare ESP32-C6-Touch-LCD-1.47 (8MB flash)",
+  "upload": {
+    "flash_size": "8MB",
+    "maximum_ram_size": 524288,
+    "maximum_size": 8388608,
+    "require_upload_port": true,
+    "speed": 460800
+  },
+  "url": "https://www.waveshare.com/esp32-c6-touch-lcd-1.47.htm",
+  "vendor": "Waveshare"
+}

--- a/platformio.ini
+++ b/platformio.ini
@@ -25,6 +25,25 @@ build_flags =
 build_unflags =
   -DARDUINO_USB_MODE=1
 
+# ESP32-C6 needs Arduino-ESP32 v3+, which the official espressif32 platform ships
+# only in recent releases. The pioarduino fork tracks arduino-esp32 v3 closely.
+[env:waveshare_esp32c6]
+platform = https://github.com/pioarduino/platform-espressif32/releases/download/53.03.13/platform-espressif32.zip
+board = esp32-c6-n8
+framework = arduino
+monitor_speed = 115200
+upload_speed = 460800
+build_flags =
+  -DCORE_DEBUG_LEVEL=3
+  -DRSVP_USB_TRANSFER_ENABLED=0
+  -DRSVP_ON_DEVICE_EPUB_CONVERSION=0
+  ; ESP32-C6 has 512 KB on-chip SRAM and no PSRAM, so cap loaded books to fit
+  ; in heap. Each Arduino `String` word costs ~30-40 B (object + heap-block
+  ; overhead + payload), and free heap after framework boot is ~270 KB. 6000
+  ; words ≈ 200 KB, leaving headroom for SPI/SD buffers, the framebuffer, and
+  ; UI state.
+  -DRSVP_MAX_BOOK_WORDS=6000
+
 [env:native_test]
 platform = native
 framework =

--- a/src/app/App.cpp
+++ b/src/app/App.cpp
@@ -2,6 +2,7 @@
 
 #include <esp_sleep.h>
 #include <esp_log.h>
+#include <sdkconfig.h>
 #include <algorithm>
 #include <cstdio>
 #include <iterator>
@@ -26,14 +27,22 @@ constexpr uint32_t kPowerOffReleaseWaitMs = 4000;
 constexpr uint32_t kBatterySampleIntervalMs = 180000;
 constexpr uint32_t kTouchPlayHoldMs = 180;
 constexpr uint32_t kThemeToggleHoldMs = 900;
-constexpr uint16_t kSwipeThresholdPx = 40;
-constexpr uint16_t kAxisBiasPx = 12;
-constexpr uint16_t kTapSlopPx = 18;
+constexpr uint32_t kDoubleClickWindowMs = 320;
+constexpr uint16_t kSwipeThresholdPx = 24;
+constexpr uint16_t kVerticalSwipeThresholdPx = 14;
+constexpr uint16_t kAxisBiasPx = 6;
+constexpr uint16_t kTapSlopPx = 12;
 constexpr uint16_t kScrubStepPx = 22;
 constexpr int kMaxScrubStepsPerGesture = 96;
+#if CONFIG_IDF_TARGET_ESP32C6
+constexpr size_t kContextPreviewWindowWords = 200;
+constexpr size_t kContextPreviewAnchorLeadWords = 70;
+constexpr size_t kContextPreviewMaxParagraphSnapWords = 32;
+#else
 constexpr size_t kContextPreviewWindowWords = 288;
 constexpr size_t kContextPreviewAnchorLeadWords = 112;
 constexpr size_t kContextPreviewMaxParagraphSnapWords = 48;
+#endif
 constexpr uint32_t kProgressSaveIntervalMs = 15000;
 constexpr uint32_t kUsbTransferExitHoldMs = 1200;
 constexpr uint8_t kBrightnessLevels[] = {40, 55, 70, 85, 100};
@@ -498,6 +507,7 @@ void App::maybeSaveReadingPosition(uint32_t nowMs) {
 
 void App::handleBootButton(uint32_t nowMs) {
   if (state_ == AppState::UsbTransfer || state_ == AppState::Sleeping || powerOffStarted_) {
+    bootButtonPendingClick_ = false;
     return;
   }
 
@@ -508,10 +518,29 @@ void App::handleBootButton(uint32_t nowMs) {
     return;
   }
 
+  // Long-press: cycle theme as soon as the hold threshold is reached.
   if (button_.isHeld() && !bootButtonLongPressHandled_ &&
       button_.heldDurationMs(nowMs) >= kThemeToggleHoldMs) {
     bootButtonLongPressHandled_ = true;
+    bootButtonPendingClick_ = false;
     cycleThemeMode(nowMs);
+    return;
+  }
+
+  // Detect a second press arriving inside the double-click window.
+  if (bootButtonPendingClick_ && button_.wasPressedEvent()) {
+    bootButtonPendingClick_ = false;
+    cycleBrightness();
+    // Swallow the matching release so it isn't treated as another single click.
+    bootButtonLongPressHandled_ = true;
+    return;
+  }
+
+  // Fire the deferred single-click once the double-click window has elapsed.
+  if (bootButtonPendingClick_ && !button_.isHeld() &&
+      nowMs - bootButtonPendingClickMs_ >= kDoubleClickWindowMs) {
+    bootButtonPendingClick_ = false;
+    toggleMenuFromPowerButton(nowMs);
     return;
   }
 
@@ -525,7 +554,9 @@ void App::handleBootButton(uint32_t nowMs) {
   }
 
   if (button_.lastHoldDurationMs() < kThemeToggleHoldMs) {
-    cycleBrightness();
+    // Defer: this might be the first half of a double-click.
+    bootButtonPendingClick_ = true;
+    bootButtonPendingClickMs_ = nowMs;
   }
 }
 
@@ -731,8 +762,13 @@ bool App::updateBatteryStatus(uint32_t nowMs, bool force) {
   batteryLabel_ = nextLabel;
   display_.setBatteryLabel(batteryLabel_);
   if (!batteryLabel_.isEmpty()) {
-    Serial.printf("[power] battery %.2f V (%u%%)\n", status.voltage,
-                  static_cast<unsigned int>(status.percent));
+    if (status.temperatureValid) {
+      Serial.printf("[power] battery %.2f V (%u%%) temp %.1f C\n", status.voltage,
+                    static_cast<unsigned int>(status.percent), status.temperatureC);
+    } else {
+      Serial.printf("[power] battery %.2f V (%u%%)\n", status.voltage,
+                    static_cast<unsigned int>(status.percent));
+    }
   } else {
     Serial.println("[power] battery not detected");
   }
@@ -839,7 +875,7 @@ void App::applyPausedTouchGesture(const TouchEvent &event, uint32_t nowMs) {
     if (absDeltaX >= static_cast<int>(kSwipeThresholdPx) &&
         absDeltaX > absDeltaY + static_cast<int>(kAxisBiasPx)) {
       pausedTouchIntent_ = TouchIntent::Scrub;
-    } else if (absDeltaY >= static_cast<int>(kSwipeThresholdPx) &&
+    } else if (absDeltaY >= static_cast<int>(kVerticalSwipeThresholdPx) &&
                absDeltaY > absDeltaX + static_cast<int>(kAxisBiasPx)) {
       pausedTouchIntent_ = TouchIntent::Wpm;
     }
@@ -943,7 +979,7 @@ void App::applyMenuTouchGesture(const TouchEvent &event, uint32_t nowMs) {
     return;
   }
 
-  if (absDeltaY >= static_cast<int>(kSwipeThresholdPx) &&
+  if (absDeltaY >= static_cast<int>(kVerticalSwipeThresholdPx) &&
       absDeltaY > absDeltaX + static_cast<int>(kAxisBiasPx)) {
     moveMenuSelection(deltaY < 0 ? -1 : 1);
     return;
@@ -1614,7 +1650,11 @@ void App::enterPowerOff(uint32_t nowMs) {
   }
 
   display_.prepareForSleep();
-  esp_sleep_enable_ext0_wakeup(static_cast<gpio_num_t>(BoardConfig::PIN_PWR_BUTTON), 0);
+#if !CONFIG_IDF_TARGET_ESP32C6
+  if (BoardConfig::PIN_PWR_BUTTON >= 0) {
+    esp_sleep_enable_ext0_wakeup(static_cast<gpio_num_t>(BoardConfig::PIN_PWR_BUTTON), 0);
+  }
+#endif
   esp_deep_sleep_start();
 }
 

--- a/src/app/App.cpp
+++ b/src/app/App.cpp
@@ -85,6 +85,7 @@ enum SettingsItem : size_t {
   SettingsTheme,
   SettingsPhantomWords,
   SettingsFontSize,
+  SettingsSleepTimeout,
   SettingsLongWords,
   SettingsComplexWords,
   SettingsPunctuation,
@@ -123,7 +124,8 @@ constexpr size_t kSettingsDisplayThemeIndex = 1;
 constexpr size_t kSettingsDisplayBrightnessIndex = 2;
 constexpr size_t kSettingsDisplayPhantomWordsIndex = 3;
 constexpr size_t kSettingsDisplayFontSizeIndex = 4;
-constexpr size_t kSettingsDisplayTypographyIndex = 5;
+constexpr size_t kSettingsDisplaySleepTimeoutIndex = 5;
+constexpr size_t kSettingsDisplayTypographyIndex = 6;
 constexpr size_t kSettingsPacingLongWordsIndex = 1;
 constexpr size_t kSettingsPacingComplexityIndex = 2;
 constexpr size_t kSettingsPacingPunctuationIndex = 3;
@@ -141,6 +143,7 @@ constexpr const char *kPrefDarkMode = "dark";
 constexpr const char *kPrefNightMode = "night";
 constexpr const char *kPrefPhantomWords = "phantom_on";
 constexpr const char *kPrefReaderFontSize = "font_size";
+constexpr const char *kPrefSleepTimeoutMin = "sleep_min";
 constexpr const char *kPrefPacingLong = "pace_len";
 constexpr const char *kPrefPacingComplex = "pace_cpx";
 constexpr const char *kPrefPacingPunctuation = "pace_pnc";
@@ -152,6 +155,9 @@ constexpr const char *kPrefRecentSeq = "seq";
 constexpr const char *kReaderFontSizeLabels[] = {"Large", "Medium", "Small"};
 constexpr size_t kReaderFontSizeCount =
     sizeof(kReaderFontSizeLabels) / sizeof(kReaderFontSizeLabels[0]);
+constexpr uint8_t kMinSleepTimeoutMinutes = 1;
+constexpr uint8_t kMaxSleepTimeoutMinutes = 10;
+constexpr uint8_t kDefaultSleepTimeoutMinutes = 2;
 constexpr size_t kPhantomBeforeCharTargets[] = {64, 96, 144};
 constexpr size_t kPhantomAfterCharTargets[] = {96, 144, 208};
 constexpr uint32_t kNoSavedWordIndex = 0xFFFFFFFFUL;
@@ -281,11 +287,15 @@ void App::begin() {
       kTypographyGuideGapMin, kTypographyGuideGapMax));
   darkMode_ = preferences_.getBool(kPrefDarkMode, darkMode_);
   nightMode_ = preferences_.getBool(kPrefNightMode, nightMode_);
+  sleepTimeoutMinutes_ = static_cast<uint8_t>(
+      clampIntSetting(preferences_.getUChar(kPrefSleepTimeoutMin, kDefaultSleepTimeoutMinutes),
+                      kMinSleepTimeoutMinutes, kMaxSleepTimeoutMinutes));
   applyDisplayPreferences(0, false);
   applyTypographySettings(0, false);
   applyPacingSettings();
   bootStartedMs_ = millis();
   lastStateLogMs_ = bootStartedMs_;
+  lastActivityMs_ = bootStartedMs_;
 
   logApp("Initializing hardware modules");
   const bool displayReady = display_.begin();
@@ -338,6 +348,10 @@ void App::begin() {
 void App::update(uint32_t nowMs) {
   button_.update(nowMs);
   powerButton_.update(nowMs);
+  if (button_.isHeld() || button_.wasPressedEvent() || button_.wasReleasedEvent() ||
+      powerButton_.isHeld() || powerButton_.wasPressedEvent() || powerButton_.wasReleasedEvent()) {
+    lastActivityMs_ = nowMs;
+  }
   handleBootButton(nowMs);
   handlePowerButton(nowMs);
   if (powerOffStarted_) {
@@ -347,9 +361,20 @@ void App::update(uint32_t nowMs) {
   const bool batteryChanged = updateBatteryStatus(nowMs);
   updateState(nowMs);
   updateReader(nowMs);
+  if (state_ == AppState::Playing) {
+    // Auto-advancing playback is active use even with no touch/button input;
+    // keep the idle clock from starting until the reader is actually paused.
+    lastActivityMs_ = nowMs;
+  }
   handleTouch(nowMs);
   updateWpmFeedback(nowMs);
   maybeSaveReadingPosition(nowMs);
+
+  if ((state_ == AppState::Paused || state_ == AppState::Menu) &&
+      nowMs - lastActivityMs_ >= static_cast<uint32_t>(sleepTimeoutMinutes_) * 60000UL) {
+    enterPowerOff(nowMs);
+    return;
+  }
 
   if (batteryChanged && (state_ == AppState::Paused || state_ == AppState::Playing)) {
     if (contextViewVisible_) {
@@ -735,6 +760,14 @@ void App::cycleReaderFontSize(uint32_t nowMs) {
   applyDisplayPreferences(nowMs);
 }
 
+void App::cycleSleepTimeoutMinutes(uint32_t nowMs) {
+  sleepTimeoutMinutes_ = static_cast<uint8_t>(nextCyclicSetting(
+      sleepTimeoutMinutes_, kMinSleepTimeoutMinutes, kMaxSleepTimeoutMinutes));
+  preferences_.putUChar(kPrefSleepTimeoutMin, sleepTimeoutMinutes_);
+  Serial.printf("[power] sleep timeout=%s\n", sleepTimeoutLabel().c_str());
+  applyDisplayPreferences(nowMs);
+}
+
 bool App::updateBatteryStatus(uint32_t nowMs, bool force) {
   // Battery sampling toggles shared board hardware; avoid doing that during active reading.
   if (!force && state_ == AppState::Playing) {
@@ -806,6 +839,7 @@ void App::handleTouch(uint32_t nowMs) {
   if (!touch_.poll(ev)) {
     return;
   }
+  lastActivityMs_ = nowMs;
 
   Serial.printf("[touch] phase=%s touched=%u x=%u y=%u gesture=%u state=%s\n",
                 touchPhaseName(ev.phase), ev.touched ? 1 : 0, ev.x, ev.y, ev.gesture,
@@ -1159,6 +1193,9 @@ void App::selectSettingsItem(uint32_t nowMs) {
       case kSettingsDisplayFontSizeIndex:
         cycleReaderFontSize(nowMs);
         return;
+      case kSettingsDisplaySleepTimeoutIndex:
+        cycleSleepTimeoutMinutes(nowMs);
+        return;
       case kSettingsDisplayTypographyIndex:
         openTypographyTuning();
         return;
@@ -1296,6 +1333,7 @@ void App::rebuildSettingsMenuItems() {
     settingsMenuItems_.push_back("Brightness: " + String(currentBrightnessPercent()) + "%");
     settingsMenuItems_.push_back("Phantom words: " + phantomWordsLabel());
     settingsMenuItems_.push_back("Font size: " + readerFontSizeLabel());
+    settingsMenuItems_.push_back("Sleep timer: " + sleepTimeoutLabel());
     settingsMenuItems_.push_back("Typography tune");
   } else if (menuScreen_ == MenuScreen::SettingsPacing) {
     settingsMenuItems_.push_back("Back");
@@ -1345,6 +1383,10 @@ String App::readerFontSizeLabel() const {
     levelIndex = 0;
   }
   return kReaderFontSizeLabels[levelIndex];
+}
+
+String App::sleepTimeoutLabel() const {
+  return String(sleepTimeoutMinutes_) + "m";
 }
 
 String App::typographyTuningLabel() const {
@@ -1623,8 +1665,6 @@ void App::enterPowerOff(uint32_t nowMs) {
   }
 
   powerOffStarted_ = true;
-  Serial.println("[app] powering off; hold PWR to start again");
-  saveReadingPosition(true);
   pausedTouch_.active = false;
   pausedTouchIntent_ = TouchIntent::None;
   touchPlayHeld_ = false;
@@ -1633,7 +1673,18 @@ void App::enterPowerOff(uint32_t nowMs) {
   menuScreen_ = MenuScreen::Main;
   state_ = AppState::Sleeping;
 
+#if CONFIG_IDF_TARGET_ESP32C6
+  // This board has no PWR button and no RTC-capable GPIO wired to a button
+  // (see BoardConfig::enableBootButtonDeepSleepWakeup), so nothing can wake
+  // it from deep sleep except a reset/EN pulse or a USB replug.
+  Serial.println("[app] powering off; press RESET to start again");
+  saveReadingPosition(true);
+  display_.renderStatus("OFF", "", "Press RESET to start");
+#else
+  Serial.println("[app] powering off; hold PWR to start again");
+  saveReadingPosition(true);
   display_.renderStatus("OFF", "Release PWR", "Hold PWR to start");
+#endif
   delay(300);
 
   storage_.end();
@@ -1650,7 +1701,10 @@ void App::enterPowerOff(uint32_t nowMs) {
   }
 
   display_.prepareForSleep();
-#if !CONFIG_IDF_TARGET_ESP32C6
+#if CONFIG_IDF_TARGET_ESP32C6
+  BoardConfig::holdTouchResetForDeepSleep();
+  BoardConfig::enableBootButtonDeepSleepWakeup();
+#else
   if (BoardConfig::PIN_PWR_BUTTON >= 0) {
     esp_sleep_enable_ext0_wakeup(static_cast<gpio_num_t>(BoardConfig::PIN_PWR_BUTTON), 0);
   }
@@ -1677,6 +1731,7 @@ void App::enterSleep(uint32_t nowMs) {
 void App::wakeFromSleep() {
   const uint32_t nowMs = millis();
   Serial.println("[app] woke from light sleep");
+  lastActivityMs_ = nowMs;
 
   BoardConfig::begin();
   button_.begin();

--- a/src/app/App.h
+++ b/src/app/App.h
@@ -188,6 +188,8 @@ class App {
   bool touchPlayHeld_ = false;
   bool bootButtonReleasedSinceBoot_ = false;
   bool bootButtonLongPressHandled_ = false;
+  bool bootButtonPendingClick_ = false;
+  uint32_t bootButtonPendingClickMs_ = 0;
   bool powerButtonReleasedSinceBoot_ = false;
   bool powerButtonLongPressHandled_ = false;
   bool powerOffStarted_ = false;

--- a/src/app/App.h
+++ b/src/app/App.h
@@ -63,6 +63,8 @@ class App {
   void cycleThemeMode(uint32_t nowMs);
   void togglePhantomWords(uint32_t nowMs);
   void cycleReaderFontSize(uint32_t nowMs);
+  void cycleSleepTimeoutMinutes(uint32_t nowMs);
+  String sleepTimeoutLabel() const;
   void applyDisplayPreferences(uint32_t nowMs, bool rerender = true);
   void applyTypographySettings(uint32_t nowMs, bool rerender = true);
   uint8_t currentBrightnessPercent() const;
@@ -159,6 +161,7 @@ class App {
   uint32_t wpmFeedbackUntilMs_ = 0;
   uint32_t lastProgressSaveMs_ = 0;
   uint32_t lastBatterySampleMs_ = 0;
+  uint32_t lastActivityMs_ = 0;
   size_t lastSavedWordIndex_ = static_cast<size_t>(-1);
   size_t contextPreviewStartIndex_ = 0;
   size_t currentBookIndex_ = 0;
@@ -172,6 +175,7 @@ class App {
   uint8_t pacingLongWordLevelIndex_ = 2;
   uint8_t pacingComplexWordLevelIndex_ = 2;
   uint8_t pacingPunctuationLevelIndex_ = 2;
+  uint8_t sleepTimeoutMinutes_ = 2;
   size_t typographyTuningSelectedIndex_ = 1;
   size_t typographyPreviewSampleIndex_ = 0;
   MenuScreen menuScreen_ = MenuScreen::Main;

--- a/src/board/BoardConfig.cpp
+++ b/src/board/BoardConfig.cpp
@@ -2,12 +2,104 @@
 
 #include <Wire.h>
 #include <algorithm>
+#include <cmath>
 #include <driver/gpio.h>
 #include <esp_sleep.h>
 
 namespace BoardConfig {
 
 namespace {
+
+uint8_t batteryPercentForVoltage(float voltage) {
+  struct Point {
+    float voltage;
+    uint8_t percent;
+  };
+
+  constexpr Point kCurve[] = {
+      {3.30f, 0},  {3.50f, 5},  {3.60f, 10}, {3.70f, 20},
+      {3.75f, 30}, {3.80f, 40}, {3.85f, 50}, {3.90f, 60},
+      {3.95f, 70}, {4.00f, 80}, {4.10f, 90}, {4.20f, 100},
+  };
+
+  if (voltage <= kCurve[0].voltage) {
+    return kCurve[0].percent;
+  }
+  constexpr size_t curveSize = sizeof(kCurve) / sizeof(kCurve[0]);
+  if (voltage >= kCurve[curveSize - 1].voltage) {
+    return kCurve[curveSize - 1].percent;
+  }
+
+  for (size_t i = 1; i < curveSize; ++i) {
+    const Point &upper = kCurve[i];
+    const Point &lower = kCurve[i - 1];
+    if (voltage > upper.voltage) {
+      continue;
+    }
+
+    const float span = upper.voltage - lower.voltage;
+    const float ratio = span <= 0.0f ? 0.0f : (voltage - lower.voltage) / span;
+    const int percent =
+        static_cast<int>(lower.percent + (upper.percent - lower.percent) * ratio + 0.5f);
+    return static_cast<uint8_t>(std::max(0, std::min(100, percent)));
+  }
+
+  return 0;
+}
+
+bool readThermistorCelsius(float &celsiusOut) {
+  if (PIN_THERMISTOR_ADC < 0) {
+    return false;
+  }
+
+  uint32_t mvTotal = 0;
+  uint8_t samples = 0;
+  for (uint8_t i = 0; i < 8; ++i) {
+    const uint32_t mv = analogReadMilliVolts(PIN_THERMISTOR_ADC);
+    if (mv > 0) {
+      mvTotal += mv;
+      ++samples;
+    }
+    delayMicroseconds(250);
+  }
+  if (samples == 0) {
+    return false;
+  }
+
+  const float vAdc = static_cast<float>(mvTotal) / samples / 1000.0f;
+  constexpr float vRef = 3.3f;
+  if (vAdc <= 0.01f || vAdc >= vRef - 0.01f) {
+    // Open / shorted thermistor lead.
+    return false;
+  }
+
+  // Resistance of the NTC from the divider.
+  float rNtc;
+  if (THERMISTOR_NTC_TO_GND) {
+    // 3V3 -- Rseries -- ADC -- Rntc -- GND
+    rNtc = THERMISTOR_SERIES_OHMS * vAdc / (vRef - vAdc);
+  } else {
+    // 3V3 -- Rntc -- ADC -- Rseries -- GND
+    rNtc = THERMISTOR_SERIES_OHMS * (vRef - vAdc) / vAdc;
+  }
+  if (!std::isfinite(rNtc) || rNtc <= 0.0f) {
+    return false;
+  }
+
+  // Beta (B-parameter) equation:
+  //   1/T = 1/T0 + (1/B) * ln(R/R0)
+  const float t0Kelvin = THERMISTOR_NOMINAL_C + 273.15f;
+  const float invT = 1.0f / t0Kelvin +
+                     std::log(rNtc / THERMISTOR_NOMINAL_OHMS) / THERMISTOR_BETA;
+  if (!std::isfinite(invT) || invT <= 0.0f) {
+    return false;
+  }
+
+  celsiusOut = (1.0f / invT) - 273.15f;
+  return std::isfinite(celsiusOut) && celsiusOut > -55.0f && celsiusOut < 150.0f;
+}
+
+#if !CONFIG_IDF_TARGET_ESP32C6
 
 constexpr uint8_t kTca9554OutputReg = 0x01;
 constexpr uint8_t kTca9554ConfigReg = 0x03;
@@ -101,55 +193,29 @@ void disableBatteryAdcPathIfAvailable() {
   gBatteryAdcPathEnabled = false;
 }
 
-uint8_t batteryPercentForVoltage(float voltage) {
-  struct Point {
-    float voltage;
-    uint8_t percent;
-  };
-
-  constexpr Point kCurve[] = {
-      {3.30f, 0},  {3.50f, 5},  {3.60f, 10}, {3.70f, 20},
-      {3.75f, 30}, {3.80f, 40}, {3.85f, 50}, {3.90f, 60},
-      {3.95f, 70}, {4.00f, 80}, {4.10f, 90}, {4.20f, 100},
-  };
-
-  if (voltage <= kCurve[0].voltage) {
-    return kCurve[0].percent;
-  }
-  constexpr size_t curveSize = sizeof(kCurve) / sizeof(kCurve[0]);
-  if (voltage >= kCurve[curveSize - 1].voltage) {
-    return kCurve[curveSize - 1].percent;
-  }
-
-  for (size_t i = 1; i < curveSize; ++i) {
-    const Point &upper = kCurve[i];
-    const Point &lower = kCurve[i - 1];
-    if (voltage > upper.voltage) {
-      continue;
-    }
-
-    const float span = upper.voltage - lower.voltage;
-    const float ratio = span <= 0.0f ? 0.0f : (voltage - lower.voltage) / span;
-    const int percent =
-        static_cast<int>(lower.percent + (upper.percent - lower.percent) * ratio + 0.5f);
-    return static_cast<uint8_t>(std::max(0, std::min(100, percent)));
-  }
-
-  return 0;
-}
+#endif  // !CONFIG_IDF_TARGET_ESP32C6
 
 }  // namespace
 
 void begin() {
   pinMode(PIN_BOOT_BUTTON, INPUT_PULLUP);
-  pinMode(PIN_PWR_BUTTON, INPUT_PULLUP);
+  if (PIN_PWR_BUTTON >= 0) {
+    pinMode(PIN_PWR_BUTTON, INPUT_PULLUP);
+  }
   pinMode(PIN_LCD_BACKLIGHT, OUTPUT);
-  digitalWrite(PIN_LCD_BACKLIGHT, LOW);
+  digitalWrite(PIN_LCD_BACKLIGHT, LCD_BACKLIGHT_ACTIVE_LOW ? HIGH : LOW);
 
   Wire.begin(PIN_TOUCH_SDA, PIN_TOUCH_SCL);
+#if CONFIG_IDF_TARGET_ESP32C6
+  // AXS5106L is happiest at the default 100 kHz; 300 kHz gives intermittent
+  // i2cWriteReadNonStop -1 errors on the C6 board.
+  Wire.setClock(100000);
+#else
   Wire.setClock(300000);
+#endif
   Wire.setTimeOut(10);
 
+#if !CONFIG_IDF_TARGET_ESP32C6
   Wire1.begin(PIN_I2C_SDA, PIN_I2C_SCL);
   Wire1.setClock(300000);
   Wire1.setTimeOut(10);
@@ -159,6 +225,19 @@ void begin() {
   pinMode(PIN_BATTERY_ADC, INPUT);
   analogReadResolution(12);
   analogSetPinAttenuation(PIN_BATTERY_ADC, ADC_11db);
+#else
+  // Waveshare ESP32-C6-Touch-LCD-1.47: GPIO0 sees Vbat through an on-board /3 divider,
+  // and we add an external 10k pull-up on GPIO6 for the LP803448 NTC (Yellow wire).
+  analogReadResolution(12);
+  if (PIN_BATTERY_ADC >= 0) {
+    pinMode(PIN_BATTERY_ADC, INPUT);
+    analogSetPinAttenuation(PIN_BATTERY_ADC, ADC_11db);
+  }
+  if (PIN_THERMISTOR_ADC >= 0) {
+    pinMode(PIN_THERMISTOR_ADC, INPUT);
+    analogSetPinAttenuation(PIN_THERMISTOR_ADC, ADC_11db);
+  }
+#endif
 }
 
 void lightSleepUntilBootButton() {
@@ -173,6 +252,44 @@ void lightSleepUntilBootButton() {
 
 bool readBatteryStatus(BatteryStatus &status) {
   status = BatteryStatus{};
+#if CONFIG_IDF_TARGET_ESP32C6
+  if (PIN_BATTERY_ADC < 0) {
+    return false;
+  }
+
+  uint32_t mvTotal = 0;
+  uint8_t samples = 0;
+  for (uint8_t i = 0; i < 8; ++i) {
+    const uint32_t mv = analogReadMilliVolts(PIN_BATTERY_ADC);
+    if (mv > 0) {
+      mvTotal += mv;
+      ++samples;
+    }
+    delayMicroseconds(250);
+  }
+  if (samples == 0) {
+    return false;
+  }
+
+  const float pinVolts = (static_cast<float>(mvTotal) / samples) / 1000.0f;
+  status.voltage = pinVolts * BATTERY_DIVIDER_RATIO;
+  status.present = status.voltage >= 2.5f && status.voltage <= 4.6f;
+
+  float tempC = 0.0f;
+  if (readThermistorCelsius(tempC)) {
+    status.temperatureValid = true;
+    status.temperatureC = tempC;
+  }
+
+  if (!status.present) {
+    status.percent = 0;
+    // Still useful to report temperature alone (e.g. on USB power without battery).
+    return status.temperatureValid;
+  }
+
+  status.percent = batteryPercentForVoltage(status.voltage);
+  return true;
+#else
   enableBatteryAdcPathIfAvailable();
   delay(3);
 
@@ -208,10 +325,19 @@ bool readBatteryStatus(BatteryStatus &status) {
   }
 
   status.percent = batteryPercentForVoltage(status.voltage);
+  float tempC = 0.0f;
+  if (readThermistorCelsius(tempC)) {
+    status.temperatureValid = true;
+    status.temperatureC = tempC;
+  }
   return true;
+#endif
 }
 
 bool releaseBatteryPowerHold() {
+#if CONFIG_IDF_TARGET_ESP32C6
+  return false;
+#else
   if (!configureTca9554OutputPin(TCA9554_PIN_SYS_EN, false)) {
     Serial.println("[board] Battery power hold release failed");
     return false;
@@ -220,6 +346,7 @@ bool releaseBatteryPowerHold() {
   gBatteryPowerHoldEnabled = false;
   Serial.println("[board] Battery power hold released");
   return true;
+#endif
 }
 
 }  // namespace BoardConfig

--- a/src/board/BoardConfig.cpp
+++ b/src/board/BoardConfig.cpp
@@ -198,6 +198,12 @@ void disableBatteryAdcPathIfAvailable() {
 }  // namespace
 
 void begin() {
+  // Release any pad hold left over from a prior deep sleep (see
+  // holdTouchResetForDeepSleep) so this boot can freely reconfigure the pin.
+  if (PIN_TOUCH_RST >= 0) {
+    gpio_hold_dis(static_cast<gpio_num_t>(PIN_TOUCH_RST));
+  }
+
   pinMode(PIN_BOOT_BUTTON, INPUT_PULLUP);
   if (PIN_PWR_BUTTON >= 0) {
     pinMode(PIN_PWR_BUTTON, INPUT_PULLUP);
@@ -347,6 +353,45 @@ bool releaseBatteryPowerHold() {
   Serial.println("[board] Battery power hold released");
   return true;
 #endif
+}
+
+void holdTouchResetForDeepSleep() {
+  // This board has no power switch to cut 3V3 to the touch controller, so
+  // drive its reset line low and latch it there through deep sleep to keep
+  // the AXS5106L in hardware reset (its lowest-current state) instead of
+  // leaving it running off the shared rail.
+  if (PIN_TOUCH_RST < 0) {
+    return;
+  }
+
+  pinMode(PIN_TOUCH_RST, OUTPUT);
+  digitalWrite(PIN_TOUCH_RST, LOW);
+  gpio_hold_en(static_cast<gpio_num_t>(PIN_TOUCH_RST));
+}
+
+void enableBootButtonDeepSleepWakeup() {
+#if CONFIG_IDF_TARGET_ESP32C6
+  // ESP32-C6 deep-sleep GPIO wakeup only works on GPIOs with RTC/LP-domain
+  // support (GPIO0-7 on this chip; see SOC_RTCIO_VALID_RTCIO_MASK). BOOT is
+  // GPIO9, so this call is expected to fail on this board: none of GPIO0-7
+  // are wired to a button here (they carry the battery ADC and the shared
+  // SD/LCD SPI bus), so there is currently no button that can wake this
+  // board from deep sleep. Log clearly instead of failing silently, in case
+  // a future board revision wires a wake button to an RTC-capable pin.
+  if (PIN_BOOT_BUTTON < 0) {
+    return;
+  }
+
+  pinMode(PIN_BOOT_BUTTON, INPUT_PULLUP);
+  const esp_err_t err =
+      esp_deep_sleep_enable_gpio_wakeup(1ULL << PIN_BOOT_BUTTON, ESP_GPIO_WAKEUP_GPIO_LOW);
+  if (err != ESP_OK) {
+    Serial.printf(
+        "[board] BOOT (GPIO%d) can't wake from deep sleep (not RTC-capable on this chip); "
+        "only reset/EN or USB replug will wake this board\n",
+        PIN_BOOT_BUTTON);
+  }
+#endif  // CONFIG_IDF_TARGET_ESP32C6
 }
 
 }  // namespace BoardConfig

--- a/src/board/BoardConfig.h
+++ b/src/board/BoardConfig.h
@@ -1,12 +1,91 @@
 #pragma once
 
 #include <Arduino.h>
+#include <sdkconfig.h>
 
 namespace BoardConfig {
+
+#if CONFIG_IDF_TARGET_ESP32C6
+
+// Waveshare ESP32-C6-Touch-LCD-1.47 (JD9853 SPI panel + AXS5106L touch).
+// No PSRAM, no native USB-OTG, no TCA9554 expander.
+
+constexpr int PIN_BOOT_BUTTON = 9;   // BOOT
+constexpr int PIN_PWR_BUTTON = -1;   // No dedicated power button on this board.
+// Battery monitoring: the Waveshare board has a built-in 1:2 (i.e. /3) divider
+// from the LiPo + rail to GPIO0. So Vbat = ADC_pin_voltage * 3.
+constexpr int PIN_BATTERY_ADC = 0;
+constexpr float BATTERY_DIVIDER_RATIO = 3.0f;
+
+// External NTC thermistor for the LP803448 LiPo's Yellow lead.
+// Wiring: 3V3 ── 10k pull-up ──┬── GPIO6 (ADC1_CH6)
+//                              └── Yellow (NTC, other leg internal-to-B-)
+// Black goes to the board's BAT- pad.
+constexpr int PIN_THERMISTOR_ADC = 6;
+constexpr float THERMISTOR_SERIES_OHMS = 10000.0f;  // 10k pull-up to 3V3
+constexpr float THERMISTOR_NOMINAL_OHMS = 10000.0f; // R0 at 25 C
+constexpr float THERMISTOR_NOMINAL_C = 25.0f;       // T0
+constexpr float THERMISTOR_BETA = 3950.0f;          // typical for LP-series LiPo NTCs
+// true  => NTC tied to GND, pull-up to 3V3 (LP803448 Yellow wire layout, recommended)
+// false => NTC tied to 3V3, pull-down to GND
+constexpr bool THERMISTOR_NTC_TO_GND = true;
+
+constexpr int PIN_LCD_CS = 14;
+constexpr int PIN_LCD_DC = 15;
+constexpr int PIN_LCD_SCLK = 1;
+constexpr int PIN_LCD_MOSI = 2;
+constexpr int PIN_LCD_RST = 22;
+constexpr int PIN_LCD_BACKLIGHT = 23;
+constexpr bool LCD_BACKLIGHT_ACTIVE_LOW = false;
+
+// Legacy QSPI pin names kept as aliases so axs15231b code still compiles when
+// the C6 driver picks them up (they are unused for the JD9853 path).
+constexpr int PIN_LCD_DATA0 = PIN_LCD_MOSI;
+constexpr int PIN_LCD_DATA1 = -1;
+constexpr int PIN_LCD_DATA2 = -1;
+constexpr int PIN_LCD_DATA3 = -1;
+
+constexpr int PANEL_NATIVE_WIDTH = 172;
+constexpr int PANEL_NATIVE_HEIGHT = 320;
+constexpr int DISPLAY_WIDTH = 320;
+constexpr int DISPLAY_HEIGHT = 172;
+constexpr bool UI_ROTATED_180 = false;
+
+// TF (microSD) slot on Waveshare ESP32-C6-Touch-LCD-1.47 wired in SPI mode.
+// Confirmed against the official schematic: CLK=IO1, MOSI=IO2, MISO=IO3, CS=IO4.
+// CLK and MOSI are intentionally shared with the LCD bus (LCD_SCLK/LCD_MOSI),
+// so both peripherals must share Arduino's `SPI` instance (SPI2_HOST/FSPI).
+constexpr int PIN_SD_CLK = 1;
+constexpr int PIN_SD_CMD = 2;  // MOSI in SPI mode
+constexpr int PIN_SD_D0 = 3;   // MISO in SPI mode
+constexpr int PIN_SD_CS = 4;
+
+constexpr int PIN_I2C_SDA = 18;
+constexpr int PIN_I2C_SCL = 19;
+constexpr int PIN_TOUCH_SDA = 18;
+constexpr int PIN_TOUCH_SCL = 19;
+constexpr int PIN_TOUCH_INT = 21;
+constexpr int PIN_TOUCH_RST = 20;
+
+// No GPIO expander on this board.
+constexpr int TCA9554_ADDRESS = -1;
+constexpr uint8_t TCA9554_PIN_BATTERY_ADC_ENABLE = 0;
+constexpr uint8_t TCA9554_PIN_SYS_EN = 0;
+
+#else  // ESP32-S3 (Waveshare ESP32-S3-Touch-LCD-3.49)
 
 constexpr int PIN_BOOT_BUTTON = 0;
 constexpr int PIN_PWR_BUTTON = 16;
 constexpr int PIN_BATTERY_ADC = 4;
+
+// No external NTC on the S3 board. Stubs let the shared thermistor code
+// compile and short-circuit at runtime via the PIN_THERMISTOR_ADC < 0 guard.
+constexpr int PIN_THERMISTOR_ADC = -1;
+constexpr float THERMISTOR_SERIES_OHMS = 10000.0f;
+constexpr float THERMISTOR_NOMINAL_OHMS = 10000.0f;
+constexpr float THERMISTOR_NOMINAL_C = 25.0f;
+constexpr float THERMISTOR_BETA = 3950.0f;
+constexpr bool THERMISTOR_NTC_TO_GND = true;
 
 constexpr int PIN_LCD_CS = 9;
 constexpr int PIN_LCD_SCLK = 10;
@@ -16,6 +95,7 @@ constexpr int PIN_LCD_DATA2 = 13;
 constexpr int PIN_LCD_DATA3 = 14;
 constexpr int PIN_LCD_RST = 21;
 constexpr int PIN_LCD_BACKLIGHT = 8;
+constexpr bool LCD_BACKLIGHT_ACTIVE_LOW = true;
 
 constexpr int PANEL_NATIVE_WIDTH = 172;
 constexpr int PANEL_NATIVE_HEIGHT = 640;
@@ -26,19 +106,26 @@ constexpr bool UI_ROTATED_180 = true;  // Keep BOOT/PWR at the top edge in lands
 constexpr int PIN_SD_CLK = 41;
 constexpr int PIN_SD_CMD = 39;
 constexpr int PIN_SD_D0 = 40;
+constexpr int PIN_SD_CS = -1;
 constexpr int PIN_I2C_SDA = 47;
 constexpr int PIN_I2C_SCL = 48;
 constexpr int PIN_TOUCH_SDA = 17;
 constexpr int PIN_TOUCH_SCL = 18;
+constexpr int PIN_TOUCH_INT = -1;
+constexpr int PIN_TOUCH_RST = -1;
 
 constexpr int TCA9554_ADDRESS = 0x20;
 constexpr uint8_t TCA9554_PIN_BATTERY_ADC_ENABLE = 1;
 constexpr uint8_t TCA9554_PIN_SYS_EN = 6;
 
+#endif
+
 struct BatteryStatus {
   bool present = false;
   float voltage = 0.0f;
   uint8_t percent = 0;
+  bool temperatureValid = false;
+  float temperatureC = 0.0f;  // battery pack temperature from external NTC, NaN if unread
 };
 
 void begin();

--- a/src/board/BoardConfig.h
+++ b/src/board/BoardConfig.h
@@ -5,6 +5,34 @@
 
 namespace BoardConfig {
 
+// Optional NTC thermistor for battery-pack temperature. Disabled by default on
+// every target; opt in by adding `-DRSVP_THERMISTOR_PIN=<gpio>` (and optionally
+// `-DRSVP_THERMISTOR_BETA=...`, `-DRSVP_THERMISTOR_R0_OHMS=...`,
+// `-DRSVP_THERMISTOR_SERIES_OHMS=...`, `-DRSVP_THERMISTOR_NTC_TO_GND=0|1`) to
+// the env's build_flags. The pin must be a free ADC1 channel.
+#ifdef RSVP_THERMISTOR_PIN
+constexpr int PIN_THERMISTOR_ADC = RSVP_THERMISTOR_PIN;
+#else
+constexpr int PIN_THERMISTOR_ADC = -1;
+#endif
+#ifndef RSVP_THERMISTOR_SERIES_OHMS
+#define RSVP_THERMISTOR_SERIES_OHMS 10000.0f
+#endif
+#ifndef RSVP_THERMISTOR_R0_OHMS
+#define RSVP_THERMISTOR_R0_OHMS 10000.0f
+#endif
+#ifndef RSVP_THERMISTOR_BETA
+#define RSVP_THERMISTOR_BETA 3950.0f
+#endif
+#ifndef RSVP_THERMISTOR_NTC_TO_GND
+#define RSVP_THERMISTOR_NTC_TO_GND 1
+#endif
+constexpr float THERMISTOR_SERIES_OHMS = RSVP_THERMISTOR_SERIES_OHMS;
+constexpr float THERMISTOR_NOMINAL_OHMS = RSVP_THERMISTOR_R0_OHMS;
+constexpr float THERMISTOR_NOMINAL_C = 25.0f;
+constexpr float THERMISTOR_BETA = RSVP_THERMISTOR_BETA;
+constexpr bool THERMISTOR_NTC_TO_GND = (RSVP_THERMISTOR_NTC_TO_GND) != 0;
+
 #if CONFIG_IDF_TARGET_ESP32C6
 
 // Waveshare ESP32-C6-Touch-LCD-1.47 (JD9853 SPI panel + AXS5106L touch).
@@ -17,18 +45,11 @@ constexpr int PIN_PWR_BUTTON = -1;   // No dedicated power button on this board.
 constexpr int PIN_BATTERY_ADC = 0;
 constexpr float BATTERY_DIVIDER_RATIO = 3.0f;
 
-// External NTC thermistor for the LP803448 LiPo's Yellow lead.
-// Wiring: 3V3 ── 10k pull-up ──┬── GPIO6 (ADC1_CH6)
-//                              └── Yellow (NTC, other leg internal-to-B-)
+// Optional external NTC: enable with `-DRSVP_THERMISTOR_PIN=6` for the
+// LP803448 LiPo's Yellow lead. Wiring:
+//   3V3 ── 10k pull-up ──┬── GPIO6 (ADC1_CH6)
+//                        └── Yellow (NTC) ── BAT-/GND
 // Black goes to the board's BAT- pad.
-constexpr int PIN_THERMISTOR_ADC = 6;
-constexpr float THERMISTOR_SERIES_OHMS = 10000.0f;  // 10k pull-up to 3V3
-constexpr float THERMISTOR_NOMINAL_OHMS = 10000.0f; // R0 at 25 C
-constexpr float THERMISTOR_NOMINAL_C = 25.0f;       // T0
-constexpr float THERMISTOR_BETA = 3950.0f;          // typical for LP-series LiPo NTCs
-// true  => NTC tied to GND, pull-up to 3V3 (LP803448 Yellow wire layout, recommended)
-// false => NTC tied to 3V3, pull-down to GND
-constexpr bool THERMISTOR_NTC_TO_GND = true;
 
 constexpr int PIN_LCD_CS = 14;
 constexpr int PIN_LCD_DC = 15;
@@ -77,15 +98,6 @@ constexpr uint8_t TCA9554_PIN_SYS_EN = 0;
 constexpr int PIN_BOOT_BUTTON = 0;
 constexpr int PIN_PWR_BUTTON = 16;
 constexpr int PIN_BATTERY_ADC = 4;
-
-// No external NTC on the S3 board. Stubs let the shared thermistor code
-// compile and short-circuit at runtime via the PIN_THERMISTOR_ADC < 0 guard.
-constexpr int PIN_THERMISTOR_ADC = -1;
-constexpr float THERMISTOR_SERIES_OHMS = 10000.0f;
-constexpr float THERMISTOR_NOMINAL_OHMS = 10000.0f;
-constexpr float THERMISTOR_NOMINAL_C = 25.0f;
-constexpr float THERMISTOR_BETA = 3950.0f;
-constexpr bool THERMISTOR_NTC_TO_GND = true;
 
 constexpr int PIN_LCD_CS = 9;
 constexpr int PIN_LCD_SCLK = 10;

--- a/src/board/BoardConfig.h
+++ b/src/board/BoardConfig.h
@@ -144,5 +144,7 @@ void begin();
 void lightSleepUntilBootButton();
 bool readBatteryStatus(BatteryStatus &status);
 bool releaseBatteryPowerHold();
+void holdTouchResetForDeepSleep();
+void enableBootButtonDeepSleepWakeup();
 
 }  // namespace BoardConfig

--- a/src/display/DisplayManager.cpp
+++ b/src/display/DisplayManager.cpp
@@ -10,7 +10,7 @@
 #include "board/BoardConfig.h"
 #include "display/EmbeddedSerifFont.h"
 #include "display/EmbeddedSerifFont70.h"
-#include "display/axs15231b.h"
+#include "display/Panel.h"
 
 namespace {
 constexpr int kDisplayWidth = BoardConfig::DISPLAY_WIDTH;
@@ -54,6 +54,18 @@ constexpr int kLibraryTitleYOffset = 4;
 constexpr int kLibrarySubtitleYOffset = 20;
 constexpr int kLibraryScreenPaddingY = 28;
 constexpr uint8_t kLibrarySubtitleAlpha = 120;
+#if CONFIG_IDF_TARGET_ESP32C6
+// 320x172 panel: enlarge the quick-scroll context font (smaller divisor =
+// bigger glyphs) and adjust line metrics to match.
+constexpr int kContextMarginX = 14;
+constexpr int kContextTop = 6;
+constexpr int kContextLineHeight = 33;
+constexpr int kContextParagraphGap = 8;
+constexpr int kContextParagraphIndent = 28;
+constexpr int kContextSpaceWidth = 10;
+constexpr int kContextSerifDivisor = 2;
+constexpr size_t kContextTargetLines = 4;
+#else
 constexpr int kContextMarginX = 18;
 constexpr int kContextTop = 8;
 constexpr int kContextLineHeight = 23;
@@ -62,6 +74,7 @@ constexpr int kContextParagraphIndent = 22;
 constexpr int kContextSpaceWidth = 8;
 constexpr int kContextSerifDivisor = 3;
 constexpr size_t kContextTargetLines = 6;
+#endif
 constexpr int kPhantomCurrentGapLarge = 30;
 constexpr int kPhantomCurrentGapMedium = 24;
 constexpr int kPhantomCurrentGapSmall = 20;
@@ -706,7 +719,7 @@ void DisplayManager::prepareForSleep() {
   }
 
   fillScreen(kTrueBlack);
-  axs15231bSleep();
+  Panel::sleep();
   initialized_ = false;
   lastRenderKey_ = "";
 }
@@ -717,7 +730,7 @@ bool DisplayManager::wakeFromSleep() {
     return false;
   }
 
-  axs15231bWake();
+  Panel::wake();
   initialized_ = true;
   lastRenderKey_ = "";
   applyBrightness();
@@ -746,7 +759,7 @@ bool DisplayManager::allocateBuffers() {
 }
 
 bool DisplayManager::initPanel() {
-  axs15231bInit();
+  Panel::init();
   ESP_LOGI(kDisplayTag, "Panel init sequence complete");
   return true;
 }
@@ -756,10 +769,10 @@ bool DisplayManager::drawBitmap(int xStart, int yStart, int xEnd, int yEnd, cons
     return false;
   }
 
-  axs15231bPushColors(static_cast<uint16_t>(xStart), static_cast<uint16_t>(yStart),
-                      static_cast<uint16_t>(xEnd - xStart),
-                      static_cast<uint16_t>(yEnd - yStart),
-                      static_cast<const uint16_t *>(colorData));
+  Panel::pushColors(static_cast<uint16_t>(xStart), static_cast<uint16_t>(yStart),
+                    static_cast<uint16_t>(xEnd - xStart),
+                    static_cast<uint16_t>(yEnd - yStart),
+                    static_cast<const uint16_t *>(colorData));
   return true;
 }
 
@@ -1318,8 +1331,8 @@ void DisplayManager::drawMenuItem(const String &item, int y, bool selected) {
 }
 
 void DisplayManager::applyBrightness() {
-  axs15231bSetBrightnessPercent(brightnessPercent_);
-  axs15231bSetBacklight(true);
+  Panel::setBrightnessPercent(brightnessPercent_);
+  Panel::setBacklight(true);
 }
 
 void DisplayManager::flushScaledFrame(int scale, int virtualWidth, int virtualHeight) {

--- a/src/display/Panel.cpp
+++ b/src/display/Panel.cpp
@@ -1,0 +1,61 @@
+#include "display/Panel.h"
+
+#include <sdkconfig.h>
+
+#if CONFIG_IDF_TARGET_ESP32C6
+#include "display/jd9853.h"
+#else
+#include "display/axs15231b.h"
+#endif
+
+namespace Panel {
+
+void init() {
+#if CONFIG_IDF_TARGET_ESP32C6
+  jd9853Init();
+#else
+  axs15231bInit();
+#endif
+}
+
+void setBacklight(bool on) {
+#if CONFIG_IDF_TARGET_ESP32C6
+  jd9853SetBacklight(on);
+#else
+  axs15231bSetBacklight(on);
+#endif
+}
+
+void setBrightnessPercent(uint8_t percent) {
+#if CONFIG_IDF_TARGET_ESP32C6
+  jd9853SetBrightnessPercent(percent);
+#else
+  axs15231bSetBrightnessPercent(percent);
+#endif
+}
+
+void sleep() {
+#if CONFIG_IDF_TARGET_ESP32C6
+  jd9853Sleep();
+#else
+  axs15231bSleep();
+#endif
+}
+
+void wake() {
+#if CONFIG_IDF_TARGET_ESP32C6
+  jd9853Wake();
+#else
+  axs15231bWake();
+#endif
+}
+
+void pushColors(uint16_t x, uint16_t y, uint16_t width, uint16_t height, const uint16_t *data) {
+#if CONFIG_IDF_TARGET_ESP32C6
+  jd9853PushColors(x, y, width, height, data);
+#else
+  axs15231bPushColors(x, y, width, height, data);
+#endif
+}
+
+}  // namespace Panel

--- a/src/display/Panel.h
+++ b/src/display/Panel.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <Arduino.h>
+
+namespace Panel {
+
+void init();
+void setBacklight(bool on);
+void setBrightnessPercent(uint8_t percent);
+void sleep();
+void wake();
+void pushColors(uint16_t x, uint16_t y, uint16_t width, uint16_t height, const uint16_t *data);
+
+}  // namespace Panel

--- a/src/display/axs15231b.cpp
+++ b/src/display/axs15231b.cpp
@@ -1,5 +1,9 @@
 #include "display/axs15231b.h"
 
+#include <sdkconfig.h>
+
+#if !CONFIG_IDF_TARGET_ESP32C6
+
 #include <driver/spi_master.h>
 #include <esp_log.h>
 
@@ -196,3 +200,5 @@ void axs15231bPushColors(uint16_t x, uint16_t y, uint16_t width, uint16_t height
     cursor += chunkPixels;
   }
 }
+
+#endif  // !CONFIG_IDF_TARGET_ESP32C6

--- a/src/display/jd9853.cpp
+++ b/src/display/jd9853.cpp
@@ -1,0 +1,227 @@
+#include "display/jd9853.h"
+
+#include <sdkconfig.h>
+
+#if CONFIG_IDF_TARGET_ESP32C6
+
+#include <Arduino.h>
+#include <SPI.h>
+#include <esp_log.h>
+
+#include "board/BoardConfig.h"
+
+namespace {
+
+constexpr uint32_t kSpiFrequency = 40000000;
+constexpr int kSendBufferPixels = 0x2000;
+// Panel is a 172×320 visible window inside the 240×320 JD9853 controller; the
+// 172-wide region is centered, so the column axis carries a +34 offset.
+constexpr int kColumnOffset = 34;
+constexpr int kRowOffset = 0;
+// Drive the panel in its native portrait orientation. DisplayManager::flushScaledFrame
+// already rotates the logical landscape bitmap into a 172-wide column stream before
+// pushing it, so a hardware rotation here would double-rotate the image.
+// MX=1 flips the column scan to undo the horizontal mirror that arises from how the
+// 1.47" panel is mounted on the Waveshare board relative to the controller's default
+// scan direction. If the image still looks mirrored, try 0x80 (MY) or 0xC0 (MX+MY)
+// instead.
+constexpr uint8_t kMadctlPortrait = 0x40;
+
+static const char *kJd9853Tag = "jd9853";
+
+const SPISettings kLcdSpiSettings(kSpiFrequency, MSBFIRST, SPI_MODE0);
+
+struct LcdCommand {
+  uint8_t cmd;
+  uint8_t data[16];
+  uint8_t len;
+  uint16_t delayMs;
+};
+
+// Init sequence taken from the Waveshare JD9853 reference (172x320 panel).
+constexpr LcdCommand kJd9853Init[] = {
+    {0x11, {0}, 0, 120},                                                          // Sleep out
+    {0x36, {kMadctlPortrait}, 1, 0},                                              // MADCTL
+    {0x3A, {0x05}, 1, 0},                                                         // COLMOD = 16-bit/pixel
+    {0xB2, {0x0C, 0x0C, 0x00, 0x33, 0x33}, 5, 0},                                 // Porch control
+    {0xB7, {0x35}, 1, 0},                                                         // Gate control
+    {0xBB, {0x35}, 1, 0},                                                         // VCOM
+    {0xC0, {0x2C}, 1, 0},                                                         // LCMCTRL
+    {0xC2, {0x01}, 1, 0},                                                         // VDV/VRH enable
+    {0xC3, {0x13}, 1, 0},                                                         // VRH set
+    {0xC4, {0x20}, 1, 0},                                                         // VDV set
+    {0xC6, {0x0F}, 1, 0},                                                         // Frame rate
+    {0xD0, {0xA4, 0xA1}, 2, 0},                                                   // Power control
+    {0xD6, {0xA1}, 1, 0},
+    {0xE0,
+     {0xF0, 0x00, 0x04, 0x04, 0x04, 0x05, 0x29, 0x33, 0x3E, 0x38, 0x12, 0x12, 0x28, 0x30},
+     14, 0},                                                                      // Gamma + curves
+    {0xE1,
+     {0xF0, 0x07, 0x0A, 0x0D, 0x0B, 0x07, 0x28, 0x33, 0x3E, 0x36, 0x14, 0x14, 0x29, 0x32},
+     14, 0},
+    {0x21, {0}, 0, 0},                                                            // Inversion ON
+    {0x29, {0}, 0, 20},                                                           // Display ON
+};
+
+bool gBusReady = false;
+bool gBacklightOn = false;
+uint8_t gBrightnessPercent = 100;
+
+void writeBacklightPwm() {
+  pinMode(BoardConfig::PIN_LCD_BACKLIGHT, OUTPUT);
+  analogWriteResolution(BoardConfig::PIN_LCD_BACKLIGHT, 8);
+  analogWriteFrequency(BoardConfig::PIN_LCD_BACKLIGHT, 50000);
+
+  if (!gBacklightOn) {
+    analogWrite(BoardConfig::PIN_LCD_BACKLIGHT,
+                BoardConfig::LCD_BACKLIGHT_ACTIVE_LOW ? 255 : 0);
+    return;
+  }
+
+  const uint8_t brightness = gBrightnessPercent == 0 ? 1 : gBrightnessPercent;
+  const uint8_t activeDuty =
+      static_cast<uint8_t>((static_cast<uint16_t>(brightness) * 255U) / 100U);
+  const uint8_t duty = BoardConfig::LCD_BACKLIGHT_ACTIVE_LOW ? (255 - activeDuty) : activeDuty;
+  analogWrite(BoardConfig::PIN_LCD_BACKLIGHT, duty);
+}
+
+void setBacklight(bool on) {
+  gBacklightOn = on;
+  writeBacklightPwm();
+}
+
+inline void dcCommand() { digitalWrite(BoardConfig::PIN_LCD_DC, LOW); }
+inline void dcData() { digitalWrite(BoardConfig::PIN_LCD_DC, HIGH); }
+inline void csLow() { digitalWrite(BoardConfig::PIN_LCD_CS, LOW); }
+inline void csHigh() { digitalWrite(BoardConfig::PIN_LCD_CS, HIGH); }
+
+void sendCommand(uint8_t command, const uint8_t *data, uint32_t length) {
+  if (!gBusReady) {
+    return;
+  }
+
+  SPI.beginTransaction(kLcdSpiSettings);
+  csLow();
+  dcCommand();
+  SPI.transfer(command);
+  if (length != 0 && data != nullptr) {
+    dcData();
+    SPI.writeBytes(data, length);
+  }
+  csHigh();
+  SPI.endTransaction();
+}
+
+void setAddressWindow(uint16_t x, uint16_t y, uint16_t w, uint16_t h) {
+  const uint16_t x1 = x + kColumnOffset;
+  const uint16_t x2 = x + w - 1 + kColumnOffset;
+  const uint16_t y1 = y + kRowOffset;
+  const uint16_t y2 = y + h - 1 + kRowOffset;
+  const uint8_t casetData[] = {
+      static_cast<uint8_t>(x1 >> 8), static_cast<uint8_t>(x1 & 0xFF),
+      static_cast<uint8_t>(x2 >> 8), static_cast<uint8_t>(x2 & 0xFF),
+  };
+  const uint8_t rasetData[] = {
+      static_cast<uint8_t>(y1 >> 8), static_cast<uint8_t>(y1 & 0xFF),
+      static_cast<uint8_t>(y2 >> 8), static_cast<uint8_t>(y2 & 0xFF),
+  };
+  sendCommand(0x2A, casetData, sizeof(casetData));
+  sendCommand(0x2B, rasetData, sizeof(rasetData));
+  sendCommand(0x2C, nullptr, 0);  // RAMWR — keeps DC=command for the marker, then we switch to data.
+}
+
+}  // namespace
+
+void jd9853Init() {
+  setBacklight(false);
+
+  pinMode(BoardConfig::PIN_LCD_CS, OUTPUT);
+  digitalWrite(BoardConfig::PIN_LCD_CS, HIGH);
+  pinMode(BoardConfig::PIN_LCD_DC, OUTPUT);
+  digitalWrite(BoardConfig::PIN_LCD_DC, HIGH);
+  pinMode(BoardConfig::PIN_LCD_RST, OUTPUT);
+  digitalWrite(BoardConfig::PIN_LCD_RST, HIGH);
+  delay(20);
+  digitalWrite(BoardConfig::PIN_LCD_RST, LOW);
+  delay(150);
+  digitalWrite(BoardConfig::PIN_LCD_RST, HIGH);
+  delay(150);
+
+  if (!gBusReady) {
+    // The TF (SD) slot shares this SPI bus on the Waveshare 1.47 board
+    // (LCD_SCLK=IO1, LCD_MOSI=IO2 are also SD CLK/MOSI). Initialise Arduino's
+    // SPI here with MISO wired to the SD card's data-out so the SD library
+    // can later use the same bus. Each peripheral manages its own CS pin and
+    // arbitrates through Arduino SPI's transaction mutex.
+    SPI.begin(BoardConfig::PIN_LCD_SCLK, BoardConfig::PIN_SD_D0,
+              BoardConfig::PIN_LCD_MOSI, -1);
+    gBusReady = true;
+  }
+
+  for (const auto &command : kJd9853Init) {
+    sendCommand(command.cmd, command.data, command.len);
+    if (command.delayMs != 0) {
+      delay(command.delayMs);
+    }
+  }
+
+  ESP_LOGI(kJd9853Tag, "JD9853 init complete");
+}
+
+void jd9853SetBacklight(bool on) { setBacklight(on); }
+
+void jd9853SetBrightnessPercent(uint8_t percent) {
+  if (percent == 0) {
+    percent = 1;
+  } else if (percent > 100) {
+    percent = 100;
+  }
+  gBrightnessPercent = percent;
+  writeBacklightPwm();
+}
+
+void jd9853Sleep() {
+  setBacklight(false);
+  sendCommand(0x28, nullptr, 0);  // Display off
+  sendCommand(0x10, nullptr, 0);  // Sleep in
+  delay(120);
+}
+
+void jd9853Wake() {
+  sendCommand(0x11, nullptr, 0);
+  delay(120);
+  sendCommand(0x29, nullptr, 0);
+  setBacklight(true);
+}
+
+void jd9853PushColors(uint16_t x, uint16_t y, uint16_t width, uint16_t height,
+                      const uint16_t *data) {
+  if (!gBusReady || data == nullptr || width == 0 || height == 0) {
+    return;
+  }
+
+  setAddressWindow(x, y, width, height);
+
+  SPI.beginTransaction(kLcdSpiSettings);
+  csLow();
+  dcData();
+
+  size_t pixelsRemaining = static_cast<size_t>(width) * height;
+  const uint16_t *cursor = data;
+  while (pixelsRemaining > 0) {
+    size_t chunkPixels = pixelsRemaining;
+    if (chunkPixels > static_cast<size_t>(kSendBufferPixels)) {
+      chunkPixels = kSendBufferPixels;
+    }
+
+    SPI.writeBytes(reinterpret_cast<const uint8_t *>(cursor), chunkPixels * 2);
+
+    pixelsRemaining -= chunkPixels;
+    cursor += chunkPixels;
+  }
+
+  csHigh();
+  SPI.endTransaction();
+}
+
+#endif  // CONFIG_IDF_TARGET_ESP32C6

--- a/src/display/jd9853.h
+++ b/src/display/jd9853.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <Arduino.h>
+
+void jd9853Init();
+void jd9853SetBacklight(bool on);
+void jd9853SetBrightnessPercent(uint8_t percent);
+void jd9853Sleep();
+void jd9853Wake();
+void jd9853PushColors(uint16_t x, uint16_t y, uint16_t width, uint16_t height,
+                      const uint16_t *data);

--- a/src/input/ButtonHandler.cpp
+++ b/src/input/ButtonHandler.cpp
@@ -3,6 +3,16 @@
 ButtonHandler::ButtonHandler(int pin) : pin_(pin) {}
 
 void ButtonHandler::begin() {
+  if (pin_ < 0) {
+    held_ = false;
+    pressedEvent_ = false;
+    releasedEvent_ = false;
+    lastEdgeMs_ = millis();
+    pressStartedMs_ = 0;
+    lastHoldDurationMs_ = 0;
+    return;
+  }
+
   pinMode(pin_, INPUT_PULLUP);
   held_ = !digitalRead(pin_);
   pressedEvent_ = false;
@@ -15,6 +25,10 @@ void ButtonHandler::begin() {
 void ButtonHandler::update(uint32_t nowMs) {
   pressedEvent_ = false;
   releasedEvent_ = false;
+
+  if (pin_ < 0) {
+    return;
+  }
 
   const bool currentHeld = !digitalRead(pin_);  // Board buttons are active-low.
   if (currentHeld != held_) {

--- a/src/input/TouchHandler.cpp
+++ b/src/input/TouchHandler.cpp
@@ -2,17 +2,21 @@
 
 #include <algorithm>
 #include <Wire.h>
+#include <sdkconfig.h>
 
 #include "board/BoardConfig.h"
 
 namespace {
 
-constexpr uint8_t kReadTouchCommand[] = {
-    0xB5, 0xAB, 0xA5, 0x5A, 0x00, 0x00, 0x00, 0x08, 0x00, 0x00, 0x00,
-};
 constexpr uint32_t kPollIntervalMs = 20;
 constexpr uint32_t kFailureBackoffMs = 250;
 constexpr uint8_t kReleaseConfirmSamples = 2;
+
+#if !CONFIG_IDF_TARGET_ESP32C6
+constexpr uint8_t kReadTouchCommand[] = {
+    0xB5, 0xAB, 0xA5, 0x5A, 0x00, 0x00, 0x00, 0x08, 0x00, 0x00, 0x00,
+};
+#endif
 
 uint16_t clampDisplayX(uint16_t x) {
   return std::min<uint16_t>(x, static_cast<uint16_t>(BoardConfig::DISPLAY_WIDTH - 1));
@@ -33,14 +37,32 @@ bool TouchHandler::begin() {
   touchActive_ = false;
   lastX_ = 0;
   lastY_ = 0;
+
+#if CONFIG_IDF_TARGET_ESP32C6
+  if (BoardConfig::PIN_TOUCH_RST >= 0) {
+    pinMode(BoardConfig::PIN_TOUCH_RST, OUTPUT);
+    digitalWrite(BoardConfig::PIN_TOUCH_RST, LOW);
+    delay(10);
+    digitalWrite(BoardConfig::PIN_TOUCH_RST, HIGH);
+    delay(50);
+  }
+  if (BoardConfig::PIN_TOUCH_INT >= 0) {
+    pinMode(BoardConfig::PIN_TOUCH_INT, INPUT_PULLUP);
+  }
+#endif
+
   Wire.beginTransmission(kAddress);
   const uint8_t error = Wire.endTransmission();
   initialized_ = (error == 0);
 
   if (!initialized_) {
-    Serial.println("[touch] Controller not detected at 0x3B");
+    Serial.printf("[touch] Controller not detected at 0x%02X\n", kAddress);
   } else {
+#if CONFIG_IDF_TARGET_ESP32C6
+    Serial.println("[touch] Initialized (AXS5106L)");
+#else
     Serial.println("[touch] Initialized (AXS15231B)");
+#endif
   }
 
   return initialized_;
@@ -62,6 +84,27 @@ void TouchHandler::cancel() {
 }
 
 bool TouchHandler::readTouchPacket(uint8_t *buffer, size_t len) {
+#if CONFIG_IDF_TARGET_ESP32C6
+  // AXS5106L: read N bytes starting at register 0x01. The controller does not
+  // tolerate repeated-start, so issue a STOP after writing the register and let
+  // requestFrom() begin a fresh transaction.
+  Wire.beginTransmission(kAddress);
+  Wire.write(static_cast<uint8_t>(0x01));
+  if (Wire.endTransmission(true) != 0) {
+    return false;
+  }
+
+  const size_t readLen =
+      Wire.requestFrom(static_cast<uint8_t>(kAddress), static_cast<size_t>(len), true);
+  if (readLen != len) {
+    return false;
+  }
+
+  for (size_t i = 0; i < len; ++i) {
+    buffer[i] = Wire.read();
+  }
+  return true;
+#else
   Wire.beginTransmission(kAddress);
   Wire.write(kReadTouchCommand, sizeof(kReadTouchCommand));
   if (Wire.endTransmission(false) != 0) {
@@ -78,6 +121,7 @@ bool TouchHandler::readTouchPacket(uint8_t *buffer, size_t len) {
     buffer[i] = Wire.read();
   }
   return true;
+#endif
 }
 
 bool TouchHandler::poll(TouchEvent &event) {
@@ -97,6 +141,83 @@ bool TouchHandler::poll(TouchEvent &event) {
   }
   lastPollMs_ = now;
 
+#if CONFIG_IDF_TARGET_ESP32C6
+  // The AXS5106L INT line is unreliable on the Waveshare 1.47" board for
+  // touches near the panel edges (the controller doesn't always fire an
+  // interrupt when the finger lands in the weaker-capacitance edge bands).
+  // Polling unconditionally at kPollIntervalMs costs ~50 I2C transactions per
+  // second but ensures edge touches register.
+
+  uint8_t data[14] = {0};
+  if (!readTouchPacket(data, sizeof(data))) {
+    backoffUntilMs_ = now + kFailureBackoffMs;
+    if (++consecutiveReadFailures_ >= 5) {
+      initialized_ = false;
+      Serial.println("[touch] Read failed repeatedly, disabling touch polling");
+    }
+    return false;
+  }
+  consecutiveReadFailures_ = 0;
+
+  // AXS5106L packet layout (14 bytes starting at register 0x01):
+  //   data[0] = status / header
+  //   data[1] = number of touch points
+  //   data[2] = (event << 4) | x_high(4 bits)
+  //   data[3] = x_low
+  //   data[4] = (id    << 4) | y_high(4 bits)
+  //   data[5] = y_low
+  const uint8_t points = data[1];
+  if (points == 0 || points >= 5) {
+    if (touchActive_) {
+      ++emptyTouchSamples_;
+      if (emptyTouchSamples_ < kReleaseConfirmSamples) {
+        return false;
+      }
+      touchActive_ = false;
+      emptyTouchSamples_ = 0;
+      event.touched = false;
+      event.x = lastX_;
+      event.y = lastY_;
+      event.phase = TouchPhase::End;
+      return true;
+    }
+    return false;
+  }
+
+  const uint16_t rawX = static_cast<uint16_t>(((data[2] & 0x0F) << 8) | data[3]);
+  const uint16_t rawY = static_cast<uint16_t>(((data[4] & 0x0F) << 8) | data[5]);
+
+  // Panel native is 172x320 portrait, app uses 320x172 landscape. Empirically:
+  //   * rawY runs along the long (320) axis but decreases as the finger moves
+  //     right, so out.x = (W-1) - rawY.
+  //   * rawX runs along the short (172) axis but increases as the finger moves
+  //     up, so out.y = (H-1) - rawX.
+  const uint16_t clampedRawY = std::min<uint16_t>(rawY, BoardConfig::DISPLAY_WIDTH - 1);
+  const uint16_t clampedRawX = std::min<uint16_t>(rawX, BoardConfig::DISPLAY_HEIGHT - 1);
+  const uint16_t mappedX =
+      static_cast<uint16_t>(BoardConfig::DISPLAY_WIDTH - 1 - clampedRawY);
+  const uint16_t mappedY =
+      static_cast<uint16_t>(BoardConfig::DISPLAY_HEIGHT - 1 - clampedRawX);
+
+  event.touched = true;
+  event.gesture = static_cast<uint8_t>((data[2] >> 4) & 0x0F);
+  event.phase = touchActive_ ? TouchPhase::Move : TouchPhase::Start;
+  if (BoardConfig::UI_ROTATED_180) {
+    event.x = static_cast<uint16_t>(BoardConfig::DISPLAY_WIDTH - 1 - mappedX);
+    event.y = static_cast<uint16_t>(BoardConfig::DISPLAY_HEIGHT - 1 - mappedY);
+  } else {
+    event.x = mappedX;
+    event.y = mappedY;
+  }
+
+  backoffUntilMs_ = 0;
+  emptyTouchSamples_ = 0;
+  lastTouchSampleMs_ = now;
+  touchActive_ = true;
+  lastX_ = event.x;
+  lastY_ = event.y;
+  return true;
+#else
   uint8_t data[8] = {0};
   if (!readTouchPacket(data, sizeof(data))) {
     backoffUntilMs_ = now + kFailureBackoffMs;
@@ -151,4 +272,5 @@ bool TouchHandler::poll(TouchEvent &event) {
   lastY_ = event.y;
 
   return true;
+#endif
 }

--- a/src/input/TouchHandler.h
+++ b/src/input/TouchHandler.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <Arduino.h>
+#include <sdkconfig.h>
 
 enum class TouchPhase {
   Start,
@@ -24,7 +25,11 @@ class TouchHandler {
   void cancel();
 
  private:
-  static constexpr uint8_t kAddress = 0x3B;  // AXS15231B touch endpoint on the 3.49" board.
+#if CONFIG_IDF_TARGET_ESP32C6
+  static constexpr uint8_t kAddress = 0x63;  // AXS5106L (Waveshare C6-Touch-LCD-1.47).
+#else
+  static constexpr uint8_t kAddress = 0x3B;  // AXS15231B (Waveshare S3-Touch-LCD-3.49).
+#endif
   bool initialized_ = false;
   uint32_t lastPollMs_ = 0;
   uint32_t backoffUntilMs_ = 0;

--- a/src/reader/BookContent.h
+++ b/src/reader/BookContent.h
@@ -1,6 +1,10 @@
 #pragma once
 
 #include <Arduino.h>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <utility>
 #include <vector>
 
 struct ChapterMarker {
@@ -8,10 +12,68 @@ struct ChapterMarker {
   size_t wordIndex = 0;
 };
 
+// Compact word storage: all words are concatenated into a single NUL-terminated
+// blob, with a parallel offsets table giving each word's start position.
+//
+// Memory cost per word ≈ 4 B (offset) + word length + 1 B NUL, vs.
+// `std::vector<String>` which spends ~30-40 B per word (Arduino String object,
+// heap-block overhead, padding, and dynamic allocation rounding). On the
+// PSRAM-less ESP32-C6 this is the difference between fitting a novel and
+// crashing on out-of-memory while loading.
+class WordBlob {
+ public:
+  WordBlob() { offsets_.push_back(0); }
+
+  void clear() {
+    blob_.clear();
+    offsets_.clear();
+    offsets_.push_back(0);
+  }
+
+  bool empty() const { return offsets_.size() <= 1; }
+  size_t size() const { return offsets_.size() - 1; }
+
+  void reserve(size_t wordCount, size_t totalChars) {
+    offsets_.reserve(wordCount + 1);
+    blob_.reserve(totalChars);
+  }
+
+  void push_back(const String &word) { push_back(word.c_str(), word.length()); }
+
+  void push_back(const char *word, size_t len) {
+    blob_.insert(blob_.end(), word, word + len);
+    blob_.push_back('\0');
+    offsets_.push_back(static_cast<uint32_t>(blob_.size()));
+  }
+
+  const char *cstr(size_t index) const { return blob_.data() + offsets_[index]; }
+
+  size_t length(size_t index) const {
+    // -1 to exclude the terminating NUL we appended in push_back.
+    return offsets_[index + 1] - offsets_[index] - 1;
+  }
+
+  String at(size_t index) const { return String(cstr(index)); }
+
+  void shrinkToFit() {
+    blob_.shrink_to_fit();
+    offsets_.shrink_to_fit();
+  }
+
+  // Approximate footprint in bytes; useful for diagnostics.
+  size_t byteSize() const {
+    return blob_.capacity() + offsets_.capacity() * sizeof(uint32_t);
+  }
+
+ private:
+  std::vector<char> blob_;
+  std::vector<uint32_t> offsets_;
+};
+
 struct BookContent {
   String title;
   String author;
-  std::vector<String> words;
+  WordBlob words;
   std::vector<ChapterMarker> chapters;
   std::vector<size_t> paragraphStarts;
 

--- a/src/reader/ReadingLoop.cpp
+++ b/src/reader/ReadingLoop.cpp
@@ -475,7 +475,7 @@ void ReadingLoop::begin(uint32_t nowMs) {
   setCurrentWordFromIndex();
 }
 
-void ReadingLoop::setWords(std::vector<String> words, uint32_t nowMs) {
+void ReadingLoop::setWords(WordBlob words, uint32_t nowMs) {
   loadedWords_ = std::move(words);
   currentIndex_ = 0;
   lastAdvanceMs_ = nowMs;
@@ -516,7 +516,7 @@ uint32_t ReadingLoop::currentWordDurationMs() const {
   const size_t nextIndex = currentIndex_ + 1;
   if (!loadedWords_.empty()) {
     if (nextIndex < loadedWords_.size()) {
-      nextWordStartsLowercase = startsWithLowercaseLetter(loadedWords_[nextIndex]);
+      nextWordStartsLowercase = startsWithLowercaseLetter(loadedWords_.at(nextIndex));
     }
   } else if (nextIndex < kDemoWordCount) {
     nextWordStartsLowercase = startsWithLowercaseLetter(String(kDemoWords[nextIndex]));
@@ -651,7 +651,7 @@ size_t ReadingLoop::wordCount() const {
 
 String ReadingLoop::wordAt(size_t index) const {
   if (!loadedWords_.empty()) {
-    return loadedWords_[index];
+    return loadedWords_.at(index);
   }
   return String(kDemoWords[index]);
 }

--- a/src/reader/ReadingLoop.h
+++ b/src/reader/ReadingLoop.h
@@ -3,6 +3,8 @@
 #include <Arduino.h>
 #include <vector>
 
+#include "reader/BookContent.h"
+
 class ReadingLoop {
  public:
   struct PacingConfig {
@@ -14,7 +16,7 @@ class ReadingLoop {
   void begin(uint32_t nowMs);
   void start(uint32_t nowMs);
   bool update(uint32_t nowMs);
-  void setWords(std::vector<String> words, uint32_t nowMs);
+  void setWords(WordBlob words, uint32_t nowMs);
   void scrub(int steps);
   void seekTo(size_t wordIndex);
   void seekRelative(size_t baseIndex, int steps);
@@ -41,5 +43,5 @@ class ReadingLoop {
   uint16_t wpm_ = 300;
   PacingConfig pacingConfig_;
   String currentWord_;
-  std::vector<String> loadedWords_;
+  WordBlob loadedWords_;
 };

--- a/src/storage/EpubConverter.cpp
+++ b/src/storage/EpubConverter.cpp
@@ -1,5 +1,11 @@
 #include "storage/EpubConverter.h"
 
+#ifndef RSVP_ON_DEVICE_EPUB_CONVERSION
+#define RSVP_ON_DEVICE_EPUB_CONVERSION 0
+#endif
+
+#if RSVP_ON_DEVICE_EPUB_CONVERSION
+
 #include <SD_MMC.h>
 #include <algorithm>
 #include <cctype>
@@ -2090,3 +2096,14 @@ bool EpubConverter::convertIfNeeded(const String &epubPath, const String &rsvpPa
   SD_MMC.remove(failedPath);
   return true;
 }
+
+#else  // RSVP_ON_DEVICE_EPUB_CONVERSION
+
+bool EpubConverter::isCurrentCache(const String &) { return true; }
+
+bool EpubConverter::convertIfNeeded(const String &, const String &, const Options &) {
+  Serial.println("[epub] On-device conversion is disabled in this build");
+  return false;
+}
+
+#endif  // RSVP_ON_DEVICE_EPUB_CONVERSION

--- a/src/storage/StorageManager.cpp
+++ b/src/storage/StorageManager.cpp
@@ -1,11 +1,18 @@
 #include "storage/StorageManager.h"
 
+#include <sdkconfig.h>
+#if CONFIG_IDF_TARGET_ESP32C6
+#include <SD.h>
+#include <SPI.h>
+#define SD_MMC SD
+#else
 #include <SD_MMC.h>
+#include <driver/sdmmc_types.h>
+#endif
 #include <algorithm>
 #include <cctype>
 #include <cstdint>
 #include <cstring>
-#include <driver/sdmmc_types.h>
 #include <esp_heap_caps.h>
 #include <utility>
 
@@ -26,11 +33,34 @@ constexpr const char *kMountPoint = "/sdcard";
 constexpr const char *kBooksPath = "/books";
 constexpr size_t kMaxBookWords = static_cast<size_t>(RSVP_MAX_BOOK_WORDS);
 constexpr size_t kMaxChapterTitleChars = 64;
+#if CONFIG_IDF_TARGET_ESP32C6
+constexpr int kSdFrequenciesKhz[] = {25000, 10000, 1000, 400};
+
+struct SdSpiPinConfig {
+  int clk;
+  int miso;
+  int mosi;
+  int cs;
+  const char *label;
+};
+
+// Schematic-confirmed Waveshare ESP32-C6-Touch-LCD-1.47 SD wiring. CLK/MOSI are
+// shared with the LCD bus; the LCD driver brings up Arduino's SPI on these
+// pins so we don't tear it down here.
+constexpr SdSpiPinConfig kSharedSdPins = {
+    BoardConfig::PIN_SD_CLK,
+    BoardConfig::PIN_SD_D0,
+    BoardConfig::PIN_SD_CMD,
+    BoardConfig::PIN_SD_CS,
+    "shared-bus",
+};
+#else
 constexpr int kSdFrequenciesKhz[] = {
     SDMMC_FREQ_DEFAULT,
     10000,
     SDMMC_FREQ_PROBING,
 };
+#endif
 
 bool hasBookWordLimit() { return kMaxBookWords > 0; }
 
@@ -38,8 +68,15 @@ bool reachedBookWordLimit(size_t wordCount) {
   return hasBookWordLimit() && wordCount >= kMaxBookWords;
 }
 
-bool isWordBoundary(char c) { return c <= ' '; }
+#if CONFIG_IDF_TARGET_ESP32C6
+bool validGpio(int pin) { return pin >= 0; }
 
+bool validSdPins(const SdSpiPinConfig &pins) {
+  return validGpio(pins.clk) && validGpio(pins.miso) && validGpio(pins.mosi) && validGpio(pins.cs);
+}
+#endif
+
+bool isWordBoundary(char c) { return c <= ' '; }
 bool prefixHasBoundary(const String &lowered, const char *prefix) {
   const size_t prefixLength = std::strlen(prefix);
   if (!lowered.startsWith(prefix)) {
@@ -119,6 +156,23 @@ String displayNameForPath(const String &path) {
     return path;
   }
   return path.substring(separator + 1);
+}
+
+bool isHiddenOrSidecarPath(const String &path) {
+  const String name = displayNameForPath(path);
+  if (name.length() == 0) {
+    return true;
+  }
+  // Skip Unix hidden files (".foo") and macOS AppleDouble metadata sidecars
+  // ("._foo"). These are dropped onto FAT volumes by Finder when copying
+  // files, and parsing them as books either crashes or shows garbage entries.
+  if (name.startsWith(".")) {
+    return true;
+  }
+  if (name.equalsIgnoreCase("Thumbs.db") || name.equalsIgnoreCase("desktop.ini")) {
+    return true;
+  }
+  return false;
 }
 
 String displayNameWithoutExtension(const String &path) {
@@ -243,6 +297,11 @@ std::vector<String> collectBookPaths() {
   while (entry) {
     if (!entry.isDirectory()) {
       const String path = normalizeBookPath(String(entry.name()));
+      if (isHiddenOrSidecarPath(path)) {
+        entry.close();
+        entry = dir.openNextFile();
+        continue;
+      }
       const bool staleGeneratedRsvp =
           hasRsvpExtension(path) && fileExistsAndHasBytes(epubSiblingPathForRsvp(path)) &&
           !EpubConverter::isCurrentCache(path);
@@ -754,7 +813,7 @@ String normalizeDisplayText(const String &text) {
   return collapsed;
 }
 
-void pushCleanWord(String token, std::vector<String> &words) {
+void pushCleanWord(String token, WordBlob &words) {
   token.trim();
 
   if (token.length() >= 3 && static_cast<uint8_t>(token[0]) == 0xEF &&
@@ -860,7 +919,7 @@ String directiveValue(const String &line, const char *directive) {
   return normalizeDisplayText(value);
 }
 
-bool appendLineWords(const String &line, std::vector<String> &words) {
+bool appendLineWords(const String &line, WordBlob &words) {
   const String normalizedLine = normalizeDisplayText(line);
   String currentWord;
 
@@ -1031,6 +1090,42 @@ bool StorageManager::begin() {
   listedOnce_ = false;
   bookPaths_.clear();
 
+#if CONFIG_IDF_TARGET_ESP32C6
+  // SD-over-SPI on ESP32-C6. The LCD driver has already initialized Arduino's
+  // SPI on the shared bus (CLK/MOSI are pinned to LCD_SCLK/LCD_MOSI, MISO is
+  // routed to PIN_SD_D0). We only need to drive CS and call SD.begin; the SD
+  // and LCD peripherals serialize via Arduino SPI's transaction mutex.
+  const SdSpiPinConfig &pins = kSharedSdPins;
+  pinMode(pins.cs, OUTPUT);
+  digitalWrite(pins.cs, HIGH);
+
+  for (int frequencyKhz : kSdFrequenciesKhz) {
+    notifyStatus("SD", "Mounting card", "", 5);
+    Serial.printf("[storage] Trying SD (SPI) %s pins clk=%d miso=%d mosi=%d cs=%d at %d kHz\n",
+                  pins.label, pins.clk, pins.miso, pins.mosi, pins.cs, frequencyKhz);
+    SD_MMC.end();
+    mounted_ = SD_MMC.begin(static_cast<uint8_t>(pins.cs), SPI,
+                            static_cast<uint32_t>(frequencyKhz) * 1000U, kMountPoint, 5);
+    if (!mounted_) {
+      notifyStatus("SD", "Unsupported filesystem", "Auto-formatting FAT32", 6);
+      Serial.printf("[storage] Retrying with auto-format at %d kHz\n", frequencyKhz);
+      SD_MMC.end();
+      mounted_ = SD_MMC.begin(static_cast<uint8_t>(pins.cs), SPI,
+                              static_cast<uint32_t>(frequencyKhz) * 1000U, kMountPoint, 5,
+                              true);
+    }
+    if (!mounted_) {
+      continue;
+    }
+
+    const uint64_t sizeMb = SD_MMC.cardSize() / (1024ULL * 1024ULL);
+    Serial.printf("[storage] SD initialized (%llu MB) using %s pins at %d kHz\n", sizeMb,
+                  pins.label, frequencyKhz);
+    notifyStatus("SD", "Scanning books", "EPUB converts on open", 10);
+    refreshBookPaths();
+    return true;
+  }
+#else
   if (!SD_MMC.setPins(BoardConfig::PIN_SD_CLK, BoardConfig::PIN_SD_CMD, BoardConfig::PIN_SD_D0)) {
     Serial.println("[storage] SD_MMC pin setup failed");
     return false;
@@ -1049,6 +1144,7 @@ bool StorageManager::begin() {
       return true;
     }
   }
+#endif
 
   Serial.println("[storage] SD init failed after retries");
   return false;
@@ -1098,10 +1194,6 @@ void StorageManager::listBooks() {
 
 void StorageManager::refreshBooks() {
   refreshBookPaths();
-}
-
-bool StorageManager::loadFirstBookWords(std::vector<String> &words, String *loadedPath) {
-  return loadBookWords(0, words, loadedPath);
 }
 
 size_t StorageManager::bookCount() const { return bookPaths_.size(); }
@@ -1284,18 +1376,6 @@ bool StorageManager::loadBookContent(size_t index, BookContent &book, String *lo
 
   Serial.println("[storage] No readable book files found under /books");
   return false;
-}
-
-bool StorageManager::loadBookWords(size_t index, std::vector<String> &words, String *loadedPath,
-                                   size_t *loadedIndex) {
-  BookContent book;
-  if (!loadBookContent(index, book, loadedPath, loadedIndex)) {
-    words.clear();
-    return false;
-  }
-
-  words = std::move(book.words);
-  return true;
 }
 
 void StorageManager::refreshBookPaths() {

--- a/src/storage/StorageManager.h
+++ b/src/storage/StorageManager.h
@@ -16,15 +16,13 @@ class StorageManager {
   void end();
   void listBooks();
   void refreshBooks();
-  bool loadFirstBookWords(std::vector<String> &words, String *loadedPath = nullptr);
+
   bool loadBookContent(size_t index, BookContent &book, String *loadedPath = nullptr,
                        size_t *loadedIndex = nullptr);
   size_t bookCount() const;
   String bookPath(size_t index) const;
   String bookDisplayName(size_t index) const;
   String bookAuthorName(size_t index) const;
-  bool loadBookWords(size_t index, std::vector<String> &words, String *loadedPath = nullptr,
-                     size_t *loadedIndex = nullptr);
 
  private:
   bool parseFile(File &file, BookContent &book, bool rsvpFormat);

--- a/src/usb/UsbMassStorageManager.cpp
+++ b/src/usb/UsbMassStorageManager.cpp
@@ -3,31 +3,40 @@
 #include <algorithm>
 #include <cstring>
 
+#include <sdkconfig.h>
 #include <esp_err.h>
 #include <esp_heap_caps.h>
 #include <esp_log.h>
+#if !CONFIG_IDF_TARGET_ESP32C6
 #include <sdmmc_cmd.h>
-#include <tusb.h>
 #include <driver/sdmmc_host.h>
+#endif
+#if RSVP_USB_TRANSFER_ENABLED && CONFIG_TINYUSB_MSC_ENABLED && !ARDUINO_USB_MODE
+#include <tusb.h>
+#endif
 
 #include "board/BoardConfig.h"
 
 namespace {
 
 constexpr uint16_t kUsbBlockSize = 512;
+#if !CONFIG_IDF_TARGET_ESP32C6
 constexpr int kSdFrequenciesKhz[] = {
     SDMMC_FREQ_DEFAULT,
     10000,
     SDMMC_FREQ_PROBING,
 };
+#endif
 
 static const char *kUsbMscTag = "usb_msc";
 
 void deinitHostIfNeeded() {
+#if !CONFIG_IDF_TARGET_ESP32C6
   const esp_err_t err = sdmmc_host_deinit();
   if (err != ESP_OK && err != ESP_ERR_INVALID_STATE) {
     ESP_LOGW(kUsbMscTag, "SDMMC host deinit returned 0x%x", err);
   }
+#endif
 }
 
 void pulseUsbReconnect() {
@@ -132,6 +141,10 @@ bool UsbMassStorageManager::beginSdCard() {
   blockSize_ = kUsbBlockSize;
   cardReady_ = false;
 
+#if CONFIG_IDF_TARGET_ESP32C6
+  // No native USB-OTG and no SDMMC peripheral on this target.
+  return false;
+#else
   if (sectorBuffer_ == nullptr) {
     sectorBuffer_ = static_cast<uint8_t *>(
         heap_caps_malloc(kUsbBlockSize, MALLOC_CAP_DMA | MALLOC_CAP_INTERNAL));
@@ -196,6 +209,7 @@ bool UsbMassStorageManager::beginSdCard() {
   }
 
   return false;
+#endif
 }
 
 void UsbMassStorageManager::endSdCard() {
@@ -236,6 +250,13 @@ bool UsbMassStorageManager::onStartStop(uint8_t powerCondition, bool start, bool
 
 int32_t UsbMassStorageManager::readSectors(uint32_t lba, uint32_t offset, void *buffer,
                                            uint32_t bufsize) {
+#if CONFIG_IDF_TARGET_ESP32C6
+  (void)lba;
+  (void)offset;
+  (void)buffer;
+  (void)bufsize;
+  return -1;
+#else
   if (!active_ || !cardReady_ || buffer == nullptr || sectorBuffer_ == nullptr ||
       offset >= blockSize_) {
     return -1;
@@ -263,10 +284,18 @@ int32_t UsbMassStorageManager::readSectors(uint32_t lba, uint32_t offset, void *
   }
 
   return static_cast<int32_t>(copied);
+#endif
 }
 
 int32_t UsbMassStorageManager::writeSectors(uint32_t lba, uint32_t offset, uint8_t *buffer,
                                             uint32_t bufsize) {
+#if CONFIG_IDF_TARGET_ESP32C6
+  (void)lba;
+  (void)offset;
+  (void)buffer;
+  (void)bufsize;
+  return -1;
+#else
   if (!writeEnabled_) {
     return -1;
   }
@@ -306,6 +335,7 @@ int32_t UsbMassStorageManager::writeSectors(uint32_t lba, uint32_t offset, uint8
   }
 
   return static_cast<int32_t>(written);
+#endif
 }
 
 bool UsbMassStorageManager::handleStartStop(uint8_t powerCondition, bool start, bool loadEject) {


### PR DESCRIPTION
## Summary

Vibe coded support for another module and tested it out
Adds a second build target (`waveshare_esp32c6`) for the [Waveshare ESP32-C6-Touch-LCD-1.47](https://www.waveshare.com/esp32-c6-touch-lcd-1.47.htm) alongside the existing ESP32-S3 environments. All C6-specific code is gated behind `#if CONFIG_IDF_TARGET_ESP32C6`, so the S3 firmware behaviour is unchanged.

Verified with `pio run` for `waveshare_esp32s3`, `waveshare_esp32s3_usb_msc`, and `waveshare_esp32c6` — all build clean.

## Hardware support

- **Display**: 172×320 JD9853 SPI panel driven in 320×172 landscape. Adds a new `display/Panel.{h,cpp}` abstraction that wraps the existing AXS15231B driver and a new `display/jd9853.{h,cpp}` driver. Had to adjust the scaling and orientation.
- **Touch**: AXS5106L on I²C `0x63` @ 100 kHz, 14-byte packet, STOP between register write and read; both axes inverted, polled at 50 Hz. Also changed the touch targets because the screen was too small and the edges were not being registered.
- **Storage**: microSD on the shared SPI bus (`CLK=1`, `MOSI=2`, `MISO=3`, `CS=4`).
- **Buttons**: single BOOT button (GPIO9). Short = menu, double = brightness, long = theme.
- **Battery**: `GPIO0` reads Vbat through the board's built-in ÷3 divider.
- **Optional thermistor**: external NTC on `GPIO6` with a 10 kΩ pull-up to 3V3 (defaults tuned for an LP803448 LiPo's Yellow lead, β = 3950).

## Build flags (set automatically in the C6 env)

| Flag | Value | Why |
| --- | --- | --- |
| `RSVP_USB_TRANSFER_ENABLED` | `0` | C6 has no native USB-OTG. |
| `RSVP_ON_DEVICE_EPUB_CONVERSION` | `0` | No PSRAM; pre-convert with the desktop helper. |
| `RSVP_MAX_BOOK_WORDS` | `6000` | Cap loaded books to fit 512 KB on-chip SRAM. |

## Other changes

- Hidden / sidecar files (`._*`, `.*`, `Thumbs.db`, `desktop.ini`) are now filtered out of the SD library scan so macOS metadata cannot crash the parser.
- README documents the new target, pin map, build flags, and optional thermistor wiring.
- Changed the loading of books from SDCARD for word blobs because C6 was running into crashes otherwise.

## Test plan

- [x] `pio run -e waveshare_esp32s3` — SUCCESS
- [x] `pio run -e waveshare_esp32s3_usb_msc` — SUCCESS
- [x] `pio run -e waveshare_esp32c6` — SUCCESS
- [x] On-hardware: C6 boots, mounts SD, lists books, renders RSVP, accepts touch swipes and BOOT presses.
