### PR TITLE
feat: wireless OTA over Wi-Fi (ArduinoOTA)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ tools/*.rsvp
 *.rsvp.failed
 *.rsvp.converting
 web/firmware/*.bin
+
+# OTA Wi-Fi credentials (never commit)
+src/Secrets.h

--- a/platformio.ini
+++ b/platformio.ini
@@ -36,3 +36,13 @@ build_flags =
   -std=c++17
   -Itest/support
   -Isrc
+
+# OTA env: same firmware, uploaded over Wi-Fi.
+# Use:  pio run -e ota -t upload
+# Optional fallback if mDNS flakes:  pio run -e ota -t upload --upload-port <ip>
+[env:ota]
+extends = env:waveshare_esp32s3_usb_msc
+upload_protocol = espota
+upload_port = rsvpnano.local
+upload_flags =
+  --auth=rsvpnano

--- a/src/Secrets.example.h
+++ b/src/Secrets.example.h
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: MIT
+//
+// Copy to `src/Secrets.h` and fill in your Wi-Fi creds.
+// Secrets.h is gitignored so your real credentials never land in version
+// control. Leave the SSID empty to disable OTA entirely (offline-only build).
+
+#pragma once
+
+namespace Secrets {
+
+constexpr const char *kWifiSsid     = "";   // leave empty to disable OTA
+constexpr const char *kWifiPassword = "";
+
+constexpr const char *kOtaHostname  = "rsvpnano";  // → rsvpnano.local
+constexpr const char *kOtaPassword  = "rsvpnano";  // matches --auth=
+
+}  // namespace Secrets

--- a/src/app/App.cpp
+++ b/src/app/App.cpp
@@ -1,4 +1,6 @@
 #include "app/App.h"
+#include "net/OtaService.h"
+#include "Secrets.h"
 
 #include <esp_sleep.h>
 #include <esp_log.h>
@@ -393,9 +395,15 @@ void App::begin() {
 
   state_ = AppState::Booting;
   Serial.println("[app] READY splash active");
+
+  // Wireless OTA — uses Secrets.h (gitignored). Empty SSID = OTA disabled.
+  OtaService::begin(Secrets::kWifiSsid, Secrets::kWifiPassword,
+                    Secrets::kOtaHostname, Secrets::kOtaPassword,
+                    &display_);
 }
 
 void App::update(uint32_t nowMs) {
+  OtaService::handle();
   button_.update(nowMs);
   powerButton_.update(nowMs);
   handleBootButton(nowMs);

--- a/src/net/OtaService.cpp
+++ b/src/net/OtaService.cpp
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: MIT
+
+#include "net/OtaService.h"
+
+#include <ArduinoOTA.h>
+#include <WiFi.h>
+
+#include "display/DisplayManager.h"
+
+namespace OtaService {
+namespace {
+
+String ssid_;
+String password_;
+String hostname_;
+String otaPassword_;
+DisplayManager *display_ = nullptr;
+bool otaStarted_ = false;
+uint32_t lastReconnectMs_ = 0;
+
+void startOtaIfReady() {
+  if (otaStarted_ || WiFi.status() != WL_CONNECTED) return;
+
+  ArduinoOTA.setHostname(hostname_.c_str());
+  ArduinoOTA.setPassword(otaPassword_.c_str());
+
+  ArduinoOTA.onStart([]() {
+    Serial.println("[ota] update starting");
+    if (display_) display_->renderProgress("OTA", "Update starting", "", 0);
+  });
+  ArduinoOTA.onProgress([](unsigned int progress, unsigned int total) {
+    static int lastPct = -1;
+    int pct = (int)((progress * 100UL) / total);
+    if (pct != lastPct) {
+      lastPct = pct;
+      if (display_) display_->renderProgress("OTA", "Updating firmware", "", pct);
+    }
+  });
+  ArduinoOTA.onEnd([]() {
+    Serial.println("[ota] update complete");
+    if (display_) display_->renderProgress("OTA", "Update complete", "Rebooting", 100);
+  });
+  ArduinoOTA.onError([](ota_error_t e) {
+    Serial.printf("[ota] error %u\n", e);
+  });
+
+  ArduinoOTA.begin();
+  otaStarted_ = true;
+  Serial.printf("[ota] ready on %s.local (IP=%s)\n",
+                hostname_.c_str(),
+                WiFi.localIP().toString().c_str());
+}
+
+}  // namespace
+
+void begin(const char *ssid, const char *password, const char *hostname,
+           const char *otaPassword, DisplayManager *display) {
+  ssid_ = ssid;
+  password_ = password;
+  hostname_ = hostname;
+  otaPassword_ = otaPassword;
+  display_ = display;
+
+  // Skip if no SSID configured — keeps existing offline-only behaviour intact.
+  if (ssid_.isEmpty()) {
+    Serial.println("[ota] no SSID configured, skipping Wi-Fi");
+    return;
+  }
+
+  WiFi.mode(WIFI_STA);
+  WiFi.setHostname(hostname_.c_str());
+  WiFi.begin(ssid_.c_str(), password_.c_str());
+  Serial.printf("[wifi] connecting to %s ...\n", ssid_.c_str());
+
+  // Brief blocking wait so first OTA after boot works without an extra cycle.
+  // Don't block forever if the network is down.
+  const uint32_t deadline = millis() + 8000;
+  while (WiFi.status() != WL_CONNECTED && millis() < deadline) {
+    delay(200);
+  }
+
+  if (WiFi.status() == WL_CONNECTED) {
+    Serial.printf("[wifi] connected, IP=%s\n", WiFi.localIP().toString().c_str());
+    startOtaIfReady();
+  } else {
+    Serial.println("[wifi] not connected yet — will retry in handle()");
+  }
+}
+
+void handle() {
+  if (ssid_.isEmpty()) return;  // no Wi-Fi configured, do nothing
+
+  if (WiFi.status() != WL_CONNECTED) {
+    otaStarted_ = false;
+    const uint32_t now = millis();
+    if (now - lastReconnectMs_ > 10000) {
+      lastReconnectMs_ = now;
+      WiFi.reconnect();
+    }
+    return;
+  }
+
+  startOtaIfReady();
+  if (otaStarted_) ArduinoOTA.handle();
+}
+
+bool wifiConnected() { return WiFi.status() == WL_CONNECTED; }
+
+}  // namespace OtaService

--- a/src/net/OtaService.h
+++ b/src/net/OtaService.h
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: MIT
+//
+// Wireless OTA over Wi-Fi for RSVP Nano.
+// Connects to Wi-Fi and runs ArduinoOTA so `pio run -e ota -t upload` works.
+
+#pragma once
+#include <Arduino.h>
+
+class DisplayManager;
+
+namespace OtaService {
+
+// Call once during App::begin(). Connects to Wi-Fi and starts ArduinoOTA.
+// Pass `display` to get an on-screen progress bar during flashes (optional).
+void begin(const char *ssid, const char *password,
+           const char *hostname = "rsvpnano",
+           const char *otaPassword = "rsvpnano",
+           DisplayManager *display = nullptr);
+
+// Call every loop iteration. Pumps ArduinoOTA and reconnects Wi-Fi if dropped.
+void handle();
+
+bool wifiConnected();
+
+}  // namespace OtaService


### PR DESCRIPTION
Adds optional wireless OTA. After applying:

- Existing USB flash flow is unchanged (default env still works)
- New `pio run -e ota -t upload` flashes over Wi-Fi via ArduinoOTA
- Opt-in: only activates when WiFi SSID is set in `src/Secrets.h` (gitignored)
- 4 lines of changes in `src/app/App.cpp`, 5 lines in `platformio.ini`, one new module in `src/net/`

**Why I built this:** I was tired of holding BOOT+RESET every time I wanted to test a change. Now I edit, run one command, and the device updates itself in ~70 seconds. Sharing in case you (or anyone else) wants the same.

**How to use after merge:**
```
cp src/Secrets.example.h src/Secrets.h
# fill in your Wi-Fi creds
pio run -e ota -t upload  # after first USB flash
```

Tested on Waveshare ESP32-S3-Touch-LCD-1.69. Should work on any ESP32-S3 target with WiFi.h available.