### PR TITLE
[codex] Add left-handed mode and sentence rewind

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ Most reader settings and your current reading position are saved automatically.
 - Release after a hold: pause at the end of the current sentence.
 - Double-tap while paused: lock autoplay on.
 - Tap while locked autoplay is running: stop at the end of the current sentence.
+- Tap the far-left edge: jump to the start of the current sentence, or the previous sentence if you are already at the start. While playing, it rewinds immediately and pauses.
 - Swipe left: scrub backward through the text.
 - Swipe right: scrub forward through the text.
 - Swipe up while paused: increase WPM.
@@ -165,6 +166,7 @@ Horizontal scrubbing in RSVP mode opens a larger preview. In that preview:
 - Release after a hold: pause at the end of the current sentence.
 - Double-tap while paused: lock autoplay on.
 - Tap while locked autoplay is running: stop at the end of the current sentence.
+- Tap the far-left edge: jump to the start of the current sentence, or the previous sentence if you are already at the start. While playing, it rewinds immediately and pauses.
 - Swipe left: scrub backward through the text.
 - Swipe right: scrub forward through the text.
 - Swipe up while paused: increase WPM.
@@ -200,6 +202,7 @@ Main Menu
 |  |- Display
 |  |  |- Back
 |  |  |- Reading mode
+|  |  |- L/R Hand
 |  |  |- Theme
 |  |  |- Brightness
 |  |  `- Language
@@ -236,6 +239,7 @@ Main Menu
 #### Display
 
 - `Reading mode`: switch between anchored RSVP and page scroll.
+- `L/R Hand`: flip the device orientation for left-hand use while keeping sentence rewind on the visual left edge.
 - `Theme`: cycle `Dark`, `Light`, and `Night`.
 - `Brightness`: cycle the backlight level.
 - `Language`: cycle `English`, `Espanol`, `Francais`, `Deutsch`, `Romana`, and `Polski`.

--- a/src/app/App.cpp
+++ b/src/app/App.cpp
@@ -34,6 +34,7 @@ constexpr uint16_t kSwipeThresholdPx = 40;
 constexpr uint16_t kAxisBiasPx = 12;
 constexpr uint16_t kTapSlopPx = 18;
 constexpr uint16_t kReaderDoubleTapSlopPx = 36;
+constexpr uint16_t kPreviousSentenceTapWidthPx = 96;
 constexpr uint16_t kFooterMetricTapWidthPx = 220;
 constexpr uint16_t kFooterMetricTapHeightPx = 32;
 constexpr uint16_t kScrubStepPx = 22;
@@ -69,6 +70,7 @@ enum SettingsItem : size_t {
   SettingsDisplay,
   SettingsTypography,
   SettingsWordPacing,
+  SettingsHandedness,
   SettingsBrightness,
   SettingsTheme,
   SettingsPhantomWords,
@@ -108,9 +110,10 @@ constexpr size_t kSettingsHomePacingIndex = 3;
 constexpr size_t kSettingsHomeWifiIndex = 4;
 constexpr size_t kSettingsHomeUpdateIndex = 5;
 constexpr size_t kSettingsDisplayReadingModeIndex = 1;
-constexpr size_t kSettingsDisplayThemeIndex = 2;
-constexpr size_t kSettingsDisplayBrightnessIndex = 3;
-constexpr size_t kSettingsDisplayLanguageIndex = 4;
+constexpr size_t kSettingsDisplayHandednessIndex = 2;
+constexpr size_t kSettingsDisplayThemeIndex = 3;
+constexpr size_t kSettingsDisplayBrightnessIndex = 4;
+constexpr size_t kSettingsDisplayLanguageIndex = 5;
 constexpr size_t kSettingsPacingLongWordsIndex = 1;
 constexpr size_t kSettingsPacingComplexityIndex = 2;
 constexpr size_t kSettingsPacingPunctuationIndex = 3;
@@ -134,6 +137,7 @@ constexpr const char *kPrefDarkMode = "dark";
 constexpr const char *kPrefNightMode = "night";
 constexpr const char *kPrefUiLanguage = "ui_lang";
 constexpr const char *kPrefReaderMode = "read_mode";
+constexpr const char *kPrefHandedness = "handed";
 constexpr const char *kPrefPhantomWords = "phantom_on";
 constexpr const char *kPrefFooterMetricMode = "prog_md";
 constexpr const char *kPrefReaderFontSize = "font_size";
@@ -165,6 +169,9 @@ constexpr int8_t kTypographyTrackingMin = -2;
 constexpr int8_t kTypographyTrackingMax = 3;
 constexpr uint8_t kTypographyAnchorMin = 30;
 constexpr uint8_t kTypographyAnchorMax = 40;
+constexpr uint8_t kLeftHandAnchorOffset = 20;
+constexpr uint8_t kLeftHandAnchorMin = kTypographyAnchorMin + kLeftHandAnchorOffset;
+constexpr uint8_t kLeftHandAnchorMax = kTypographyAnchorMax + kLeftHandAnchorOffset;
 constexpr uint8_t kTypographyGuideWidthMin = 12;
 constexpr uint8_t kTypographyGuideWidthMax = 30;
 constexpr uint8_t kTypographyGuideWidthStep = 2;
@@ -320,6 +327,26 @@ App::ReaderMode readerModeFromSetting(uint8_t value) {
   }
 }
 
+App::HandednessMode handednessModeFromSetting(uint8_t value) {
+  switch (value) {
+    case static_cast<uint8_t>(App::HandednessMode::Left):
+      return App::HandednessMode::Left;
+    case static_cast<uint8_t>(App::HandednessMode::Right):
+    default:
+      return App::HandednessMode::Right;
+  }
+}
+
+App::HandednessMode nextHandednessMode(App::HandednessMode current) {
+  switch (handednessModeFromSetting(static_cast<uint8_t>(current))) {
+    case App::HandednessMode::Left:
+      return App::HandednessMode::Right;
+    case App::HandednessMode::Right:
+    default:
+      return App::HandednessMode::Left;
+  }
+}
+
 App::ReaderMode nextReaderMode(App::ReaderMode current) {
   switch (readerModeFromSetting(static_cast<uint8_t>(current))) {
     case App::ReaderMode::Rsvp:
@@ -382,6 +409,8 @@ void App::begin() {
           kPrefUiLanguage, static_cast<uint8_t>(uiLanguage_)));
   readerMode_ = readerModeFromSetting(
       preferences_.getUChar(kPrefReaderMode, static_cast<uint8_t>(readerMode_)));
+  handednessMode_ = handednessModeFromSetting(
+      preferences_.getUChar(kPrefHandedness, static_cast<uint8_t>(handednessMode_)));
   readerFontSizeIndex_ = preferences_.getUChar(kPrefReaderFontSize, readerFontSizeIndex_);
   if (readerFontSizeIndex_ >= kReaderFontSizeCount) {
     readerFontSizeIndex_ = 0;
@@ -424,6 +453,7 @@ void App::begin() {
       kTypographyGuideGapMin, kTypographyGuideGapMax));
   darkMode_ = preferences_.getBool(kPrefDarkMode, darkMode_);
   nightMode_ = preferences_.getBool(kPrefNightMode, nightMode_);
+  applyHandednessSettings(0, false);
   applyDisplayPreferences(0, false);
   applyTypographySettings(0, false);
   applyPacingSettings();
@@ -796,14 +826,31 @@ void App::applyDisplayPreferences(uint32_t nowMs, bool rerender) {
   }
 }
 
+void App::applyHandednessSettings(uint32_t nowMs, bool rerender) {
+  touch_.setUiRotated180(uiRotated180());
+  display_.setUiRotated180(uiRotated180());
+
+  if (!rerender) {
+    return;
+  }
+
+  if (state_ == AppState::Menu &&
+      (menuScreen_ == MenuScreen::SettingsHome || menuScreen_ == MenuScreen::SettingsDisplay ||
+       menuScreen_ == MenuScreen::SettingsPacing || menuScreen_ == MenuScreen::WifiSettings)) {
+    rebuildSettingsMenuItems();
+  }
+
+  applyTypographySettings(nowMs);
+}
+
 void App::applyTypographySettings(uint32_t nowMs, bool rerender) {
-  display_.setTypographyConfig(typographyConfig_);
+  display_.setTypographyConfig(effectiveTypographyConfig());
 
   Serial.printf("[typography] face=%s highlight=%s track=%d anchor=%u guideWidth=%u guideGap=%u\n",
                 readerTypefaceLabel().c_str(),
                 focusHighlightLabel().c_str(),
                 static_cast<int>(typographyConfig_.trackingPx),
-                static_cast<unsigned int>(typographyConfig_.anchorPercent),
+                static_cast<unsigned int>(effectiveAnchorPercent()),
                 static_cast<unsigned int>(typographyConfig_.guideHalfWidth),
                 static_cast<unsigned int>(typographyConfig_.guideGap));
 
@@ -885,6 +932,14 @@ void App::cycleReaderMode(uint32_t nowMs) {
   renderActiveReader(nowMs);
 }
 
+void App::cycleHandednessMode(uint32_t nowMs) {
+  handednessMode_ = nextHandednessMode(handednessMode_);
+  preferences_.putUChar(kPrefHandedness, static_cast<uint8_t>(handednessMode_));
+  Serial.printf("[display] handedness=%s rotation180=%u\n", handednessLabel().c_str(),
+                uiRotated180() ? 1U : 0U);
+  applyHandednessSettings(nowMs);
+}
+
 void App::togglePhantomWords(uint32_t nowMs) {
   phantomWordsEnabled_ = !phantomWordsEnabled_;
   preferences_.putBool(kPrefPhantomWords, phantomWordsEnabled_);
@@ -954,9 +1009,29 @@ bool App::isFooterMetricTap(uint16_t x, uint16_t y) const {
          y >= BoardConfig::DISPLAY_HEIGHT - kFooterMetricTapHeightPx;
 }
 
+bool App::isPreviousSentenceTap(uint16_t x) const { return x < kPreviousSentenceTapWidthPx; }
+
 bool App::readerFooterVisible() const {
   return scrollModeEnabled() || state_ != AppState::Playing || contextViewVisible_ ||
          wpmFeedbackVisible_;
+}
+
+void App::rewindReaderSentence(uint32_t nowMs) {
+  resetReaderTapTracking();
+  pausedTouch_.active = false;
+  pausedTouchIntent_ = TouchIntent::None;
+  wpmFeedbackVisible_ = false;
+  reader_.rewindSentence();
+
+  if (state_ == AppState::Playing) {
+    setState(AppState::Paused, nowMs);
+  } else {
+    renderActiveReader(nowMs);
+    saveReadingPosition(true);
+  }
+
+  Serial.printf("[app] sentence rewind index=%u word=%s\n",
+                static_cast<unsigned int>(reader_.currentIndex()), reader_.currentWord().c_str());
 }
 
 bool App::handleFooterMetricTap(uint16_t x, uint16_t y, uint32_t nowMs) {
@@ -1143,6 +1218,10 @@ void App::applyPausedTouchGesture(const TouchEvent &event, uint32_t nowMs) {
         if (handleFooterMetricTap(event.x, event.y, nowMs)) {
           return;
         }
+        if (isPreviousSentenceTap(event.x)) {
+          rewindReaderSentence(nowMs);
+          return;
+        }
         if (playLocked_ || pauseAtSentenceEndRequested_) {
           resetReaderTapTracking();
           requestReaderPauseAtSentenceEnd(nowMs);
@@ -1222,6 +1301,10 @@ void App::applyPausedTouchGesture(const TouchEvent &event, uint32_t nowMs) {
     pausedTouch_.active = false;
     pausedTouchIntent_ = TouchIntent::None;
     if (tapLike && handleFooterMetricTap(event.x, event.y, nowMs)) {
+      return;
+    }
+    if (tapLike && !previewBrowseMode && isPreviousSentenceTap(event.x)) {
+      rewindReaderSentence(nowMs);
       return;
     }
     if (tapLike && previewBrowseMode) {
@@ -1603,6 +1686,9 @@ void App::selectSettingsItem(uint32_t nowMs) {
         return;
       case kSettingsDisplayReadingModeIndex:
         cycleReaderMode(nowMs);
+        return;
+      case kSettingsDisplayHandednessIndex:
+        cycleHandednessMode(nowMs);
         return;
       case kSettingsDisplayThemeIndex:
         cycleThemeMode(nowMs);
@@ -2092,12 +2178,20 @@ void App::selectTypographyTuningItem(uint32_t nowMs) {
                             kTypographyTrackingMax));
       preferences_.putChar(kPrefTypographyTracking, typographyConfig_.trackingPx);
       break;
-    case TypographyTuningAnchor:
-      typographyConfig_.anchorPercent = static_cast<uint8_t>(
-          nextCyclicSetting(typographyConfig_.anchorPercent, kTypographyAnchorMin,
-                            kTypographyAnchorMax));
+    case TypographyTuningAnchor: {
+      const uint8_t anchorMin =
+          (handednessMode_ == HandednessMode::Left) ? kLeftHandAnchorMin : kTypographyAnchorMin;
+      const uint8_t anchorMax =
+          (handednessMode_ == HandednessMode::Left) ? kLeftHandAnchorMax : kTypographyAnchorMax;
+      const uint8_t nextAnchorPercent = static_cast<uint8_t>(
+          nextCyclicSetting(effectiveAnchorPercent(), anchorMin, anchorMax));
+      typographyConfig_.anchorPercent = (handednessMode_ == HandednessMode::Left)
+                                            ? static_cast<uint8_t>(nextAnchorPercent -
+                                                                   kLeftHandAnchorOffset)
+                                            : nextAnchorPercent;
       preferences_.putUChar(kPrefTypographyAnchor, typographyConfig_.anchorPercent);
       break;
+    }
     case TypographyTuningGuideWidth:
       typographyConfig_.guideHalfWidth = static_cast<uint8_t>(nextCyclicSetting(
           typographyConfig_.guideHalfWidth, kTypographyGuideWidthMin,
@@ -2154,6 +2248,7 @@ void App::rebuildSettingsMenuItems() {
   } else if (menuScreen_ == MenuScreen::SettingsDisplay) {
     settingsMenuItems_.push_back(uiText(UiText::Back));
     settingsMenuItems_.push_back(uiText(UiText::ReadingMode) + ": " + readerModeLabel());
+    settingsMenuItems_.push_back("L/R Hand: " + handednessLabel());
     settingsMenuItems_.push_back(uiText(UiText::Theme) + ": " + themeModeLabel());
     settingsMenuItems_.push_back(uiText(UiText::Brightness) + ": " +
                                  String(currentBrightnessPercent()) + "%");
@@ -2312,6 +2407,10 @@ String App::readerModeLabel() const {
   }
 }
 
+String App::handednessLabel() const {
+  return handednessMode_ == HandednessMode::Left ? "Left" : "Right";
+}
+
 String App::readerFontSizeLabel() const {
   uint8_t levelIndex = readerFontSizeIndex_;
   if (levelIndex >= kReaderFontSizeCount) {
@@ -2384,7 +2483,7 @@ String App::typographyTuningValueLabel() const {
       return String(typographyConfig_.trackingPx >= 0 ? "+" : "") +
              String(static_cast<int>(typographyConfig_.trackingPx)) + " px";
     case TypographyTuningAnchor:
-      return String(static_cast<unsigned int>(typographyConfig_.anchorPercent)) + "%";
+      return String(static_cast<unsigned int>(effectiveAnchorPercent())) + "%";
     case TypographyTuningGuideWidth:
       return String(static_cast<unsigned int>(typographyConfig_.guideHalfWidth)) + " px";
     case TypographyTuningGuideGap:
@@ -3155,6 +3254,23 @@ uint8_t App::readingProgressPercent() const {
 }
 
 bool App::scrollModeEnabled() const { return readerMode_ == ReaderMode::Scroll; }
+
+bool App::uiRotated180() const {
+  return handednessMode_ == HandednessMode::Right ? BoardConfig::UI_ROTATED_180
+                                                  : !BoardConfig::UI_ROTATED_180;
+}
+
+uint8_t App::effectiveAnchorPercent() const {
+  return handednessMode_ == HandednessMode::Left
+             ? static_cast<uint8_t>(typographyConfig_.anchorPercent + kLeftHandAnchorOffset)
+             : typographyConfig_.anchorPercent;
+}
+
+DisplayManager::TypographyConfig App::effectiveTypographyConfig() const {
+  DisplayManager::TypographyConfig config = typographyConfig_;
+  config.anchorPercent = effectiveAnchorPercent();
+  return config;
+}
 
 uint32_t App::currentReaderContentToken() const {
   return hashBookPath(currentBookPath_.isEmpty() ? String("__demo__") : currentBookPath_);

--- a/src/app/App.h
+++ b/src/app/App.h
@@ -21,6 +21,11 @@ class App {
     Scroll = 1,
   };
 
+  enum class HandednessMode : uint8_t {
+    Right = 0,
+    Left = 1,
+  };
+
   App();
 
   void begin();
@@ -132,9 +137,11 @@ class App {
   void cycleThemeMode(uint32_t nowMs);
   void cycleUiLanguage(uint32_t nowMs);
   void cycleReaderMode(uint32_t nowMs);
+  void cycleHandednessMode(uint32_t nowMs);
   void togglePhantomWords(uint32_t nowMs);
   void cycleReaderFontSize(uint32_t nowMs);
   void applyDisplayPreferences(uint32_t nowMs, bool rerender = true);
+  void applyHandednessSettings(uint32_t nowMs, bool rerender = true);
   void applyTypographySettings(uint32_t nowMs, bool rerender = true);
   uint8_t currentBrightnessPercent() const;
   bool updateBatteryStatus(uint32_t nowMs, bool force = false);
@@ -147,7 +154,9 @@ class App {
   bool shouldFinalizeReaderPause(uint32_t nowMs) const;
   void resetReaderTapTracking();
   bool isFooterMetricTap(uint16_t x, uint16_t y) const;
+  bool isPreviousSentenceTap(uint16_t x) const;
   bool readerFooterVisible() const;
+  void rewindReaderSentence(uint32_t nowMs);
   int scrubStepsForDrag(int deltaX) const;
   void applyScrubTarget(int targetSteps, uint32_t nowMs);
   int browseScrollRatePermille(uint16_t y) const;
@@ -189,6 +198,7 @@ class App {
   String focusHighlightLabel() const;
   String uiLanguageLabel() const;
   String readerModeLabel() const;
+  String handednessLabel() const;
   String readerFontSizeLabel() const;
   String readerTypefaceLabel() const;
   String typographyTuningLabel() const;
@@ -256,6 +266,9 @@ class App {
   const char *stateName(AppState state) const;
   const char *touchPhaseName(TouchPhase phase) const;
   bool scrollModeEnabled() const;
+  bool uiRotated180() const;
+  uint8_t effectiveAnchorPercent() const;
+  DisplayManager::TypographyConfig effectiveTypographyConfig() const;
   uint32_t currentReaderContentToken() const;
 
   AppState state_ = AppState::Booting;
@@ -333,5 +346,6 @@ class App {
   bool nightMode_ = false;
   UiLanguage uiLanguage_ = UiLanguage::English;
   ReaderMode readerMode_ = ReaderMode::Rsvp;
+  HandednessMode handednessMode_ = HandednessMode::Right;
   DisplayManager::TypographyConfig typographyConfig_;
 };

--- a/src/display/DisplayManager.cpp
+++ b/src/display/DisplayManager.cpp
@@ -78,7 +78,7 @@ constexpr uint8_t kPhantomAlphaSmall = 72;
 constexpr int kTypographyTrackingMin = -2;
 constexpr int kTypographyTrackingMax = 3;
 constexpr int kTypographyAnchorMin = 30;
-constexpr int kTypographyAnchorMax = 40;
+constexpr int kTypographyAnchorMax = 60;
 constexpr int kTypographyGuideHalfWidthMin = 12;
 constexpr int kTypographyGuideHalfWidthMax = 30;
 constexpr int kTypographyGuideGapMin = 2;
@@ -802,6 +802,16 @@ void DisplayManager::setNightMode(bool nightMode) {
   }
 
   nightMode_ = nightMode;
+  tickerPlaybackFrameActive_ = false;
+  lastRenderKey_ = "";
+}
+
+void DisplayManager::setUiRotated180(bool rotated180) {
+  if (uiRotated180_ == rotated180) {
+    return;
+  }
+
+  uiRotated180_ = rotated180;
   tickerPlaybackFrameActive_ = false;
   lastRenderKey_ = "";
 }
@@ -1577,7 +1587,7 @@ void DisplayManager::flushScaledFrame(int scale, int virtualWidth, int virtualHe
       for (int nativeX = 0; nativeX < kPanelNativeWidth; ++nativeX) {
         int logicalX = kDisplayWidth - 1 - nativeY;
         int logicalY = nativeX;
-        if (BoardConfig::UI_ROTATED_180) {
+        if (uiRotated180_) {
           logicalX = nativeY;
           logicalY = kDisplayHeight - 1 - nativeX;
         }
@@ -1607,10 +1617,8 @@ void DisplayManager::flushFullWidthLogicalBand(int yStart, int yEnd) {
     return;
   }
 
-  const int physicalXStart =
-      BoardConfig::UI_ROTATED_180 ? (kDisplayHeight - yEnd) : yStart;
-  const int physicalXEnd =
-      BoardConfig::UI_ROTATED_180 ? (kDisplayHeight - yStart) : yEnd;
+  const int physicalXStart = uiRotated180_ ? (kDisplayHeight - yEnd) : yStart;
+  const int physicalXEnd = uiRotated180_ ? (kDisplayHeight - yStart) : yEnd;
   const int physicalWidth = physicalXEnd - physicalXStart;
   if (physicalWidth <= 0 || txBuffer_ == nullptr) {
     return;
@@ -1628,7 +1636,7 @@ void DisplayManager::flushFullWidthLogicalBand(int yStart, int yEnd) {
         const int nativeX = physicalXStart + localNativeX;
         int logicalX = kDisplayWidth - 1 - nativeY;
         int logicalY = nativeX;
-        if (BoardConfig::UI_ROTATED_180) {
+        if (uiRotated180_) {
           logicalX = nativeY;
           logicalY = kDisplayHeight - 1 - nativeX;
         }

--- a/src/display/DisplayManager.h
+++ b/src/display/DisplayManager.h
@@ -3,6 +3,8 @@
 #include <Arduino.h>
 #include <vector>
 
+#include "board/BoardConfig.h"
+
 class DisplayManager {
  public:
   enum class ReaderTypeface : uint8_t {
@@ -48,6 +50,7 @@ class DisplayManager {
   void setBrightnessPercent(uint8_t percent);
   void setDarkMode(bool darkMode);
   void setNightMode(bool nightMode);
+  void setUiRotated180(bool rotated180);
   void setTypographyConfig(const TypographyConfig &config);
   TypographyConfig typographyConfig() const;
   bool darkMode() const;
@@ -155,6 +158,7 @@ class DisplayManager {
   uint8_t brightnessPercent_ = 100;
   bool darkMode_ = true;
   bool nightMode_ = false;
+  bool uiRotated180_ = BoardConfig::UI_ROTATED_180;
   bool tickerPlaybackFrameActive_ = false;
   String lastRenderKey_;
   String batteryLabel_;

--- a/src/input/TouchHandler.cpp
+++ b/src/input/TouchHandler.cpp
@@ -61,6 +61,15 @@ void TouchHandler::cancel() {
   emptyTouchSamples_ = 0;
 }
 
+void TouchHandler::setUiRotated180(bool rotated180) {
+  if (uiRotated180_ == rotated180) {
+    return;
+  }
+
+  uiRotated180_ = rotated180;
+  cancel();
+}
+
 bool TouchHandler::readTouchPacket(uint8_t *buffer, size_t len) {
   Wire.beginTransmission(kAddress);
   Wire.write(kReadTouchCommand, sizeof(kReadTouchCommand));
@@ -139,7 +148,7 @@ bool TouchHandler::poll(TouchEvent &event) {
   const uint16_t rawShortAxis = static_cast<uint16_t>(((data[4] & 0x0F) << 8) | data[5]);
   const uint16_t mappedX = clampDisplayX(rawLongAxis);
   const uint16_t mappedY = clampDisplayY(rawShortAxis);
-  if (BoardConfig::UI_ROTATED_180) {
+  if (uiRotated180_) {
     event.x = static_cast<uint16_t>(BoardConfig::DISPLAY_WIDTH - 1 - mappedX);
     event.y = static_cast<uint16_t>(BoardConfig::DISPLAY_HEIGHT - 1 - mappedY);
   } else {

--- a/src/input/TouchHandler.h
+++ b/src/input/TouchHandler.h
@@ -2,6 +2,8 @@
 
 #include <Arduino.h>
 
+#include "board/BoardConfig.h"
+
 enum class TouchPhase {
   Start,
   Move,
@@ -22,6 +24,7 @@ class TouchHandler {
   void end();
   bool poll(TouchEvent &event);
   void cancel();
+  void setUiRotated180(bool rotated180);
 
  private:
   static constexpr uint8_t kAddress = 0x3B;  // AXS15231B touch endpoint on the 3.49" board.
@@ -32,6 +35,7 @@ class TouchHandler {
   uint8_t consecutiveReadFailures_ = 0;
   uint8_t emptyTouchSamples_ = 0;
   bool touchActive_ = false;
+  bool uiRotated180_ = BoardConfig::UI_ROTATED_180;
   uint16_t lastX_ = 0;
   uint16_t lastY_ = 0;
 

--- a/src/reader/ReadingLoop.cpp
+++ b/src/reader/ReadingLoop.cpp
@@ -534,29 +534,7 @@ uint32_t ReadingLoop::elapsedInCurrentWordMs(uint32_t nowMs) const {
 }
 
 bool ReadingLoop::currentWordEndsSentence() const {
-  if (currentWord_.isEmpty()) {
-    return false;
-  }
-
-  bool nextWordStartsLowercase = false;
-  const size_t nextIndex = currentIndex_ + 1;
-  if (!loadedWords_.empty()) {
-    if (nextIndex < loadedWords_.size()) {
-      nextWordStartsLowercase = startsWithLowercaseLetter(loadedWords_[nextIndex]);
-    }
-  } else if (nextIndex < kDemoWordCount) {
-    nextWordStartsLowercase = startsWithLowercaseLetter(String(kDemoWords[nextIndex]));
-  }
-
-  switch (trailingRhythmChar(currentWord_)) {
-    case '!':
-    case '?':
-      return true;
-    case '.':
-      return !looksLikeAbbreviation(currentWord_, nextWordStartsLowercase);
-    default:
-      return false;
-  }
+  return wordEndsSentenceAt(currentIndex_);
 }
 
 bool ReadingLoop::atEnd() const {
@@ -610,6 +588,21 @@ void ReadingLoop::seekRelative(size_t baseIndex, int steps) {
 
   currentIndex_ = static_cast<size_t>(nextIndex);
   setCurrentWordFromIndex();
+}
+
+void ReadingLoop::rewindSentence() {
+  const size_t count = wordCount();
+  if (count == 0) {
+    return;
+  }
+
+  const size_t currentSentenceStart = sentenceStartAtOrBefore(currentIndex_);
+  if (currentSentenceStart == currentIndex_ && currentIndex_ > 0) {
+    seekTo(sentenceStartAtOrBefore(currentIndex_ - 1));
+    return;
+  }
+
+  seekTo(currentSentenceStart);
 }
 
 void ReadingLoop::adjustWpm(int delta) {
@@ -699,3 +692,53 @@ String ReadingLoop::wordAt(size_t index) const {
 }
 
 bool ReadingLoop::usingLoadedBook() const { return !loadedWords_.empty(); }
+
+bool ReadingLoop::nextWordStartsLowercaseAt(size_t wordIndex) const {
+  const size_t nextIndex = wordIndex + 1;
+  if (nextIndex >= wordCount()) {
+    return false;
+  }
+
+  return startsWithLowercaseLetter(wordAt(nextIndex));
+}
+
+bool ReadingLoop::wordEndsSentenceAt(size_t wordIndex) const {
+  if (wordIndex >= wordCount()) {
+    return false;
+  }
+
+  const String word = wordAt(wordIndex);
+  if (word.isEmpty()) {
+    return false;
+  }
+
+  switch (trailingRhythmChar(word)) {
+    case '!':
+    case '?':
+      return true;
+    case '.':
+      return !looksLikeAbbreviation(word, nextWordStartsLowercaseAt(wordIndex));
+    default:
+      return false;
+  }
+}
+
+size_t ReadingLoop::sentenceStartAtOrBefore(size_t wordIndex) const {
+  const size_t count = wordCount();
+  if (count == 0) {
+    return 0;
+  }
+
+  if (wordIndex >= count) {
+    wordIndex = count - 1;
+  }
+
+  while (wordIndex > 0) {
+    if (wordEndsSentenceAt(wordIndex - 1)) {
+      break;
+    }
+    --wordIndex;
+  }
+
+  return wordIndex;
+}

--- a/src/reader/ReadingLoop.h
+++ b/src/reader/ReadingLoop.h
@@ -21,6 +21,7 @@ class ReadingLoop {
   void scrub(int steps);
   void seekTo(size_t wordIndex);
   void seekRelative(size_t baseIndex, int steps);
+  void rewindSentence();
   void adjustWpm(int delta);
   void setWpm(uint16_t wpm);
   void setPacingConfig(const PacingConfig &config);
@@ -41,6 +42,9 @@ class ReadingLoop {
   bool advance(size_t steps);
   void setCurrentWordFromIndex();
   bool usingLoadedBook() const;
+  bool nextWordStartsLowercaseAt(size_t wordIndex) const;
+  bool wordEndsSentenceAt(size_t wordIndex) const;
+  size_t sentenceStartAtOrBefore(size_t wordIndex) const;
 
   size_t currentIndex_ = 0;
   uint32_t lastAdvanceMs_ = 0;

--- a/test/test_pacing/test_main.cpp
+++ b/test/test_pacing/test_main.cpp
@@ -347,6 +347,38 @@ void test_seek_relative_via_base_index(void) {
   TEST_ASSERT_EQUAL_STRING("d", r.currentWord().c_str());
 }
 
+void test_rewind_sentence_moves_to_current_sentence_start(void) {
+  ReadingLoop r = makeReader(300, {"One", "two.", "Three", "four", "five.", "Six"});
+  r.seekTo(3);
+  r.rewindSentence();
+  TEST_ASSERT_EQUAL(2u, r.currentIndex());
+  TEST_ASSERT_EQUAL_STRING("Three", r.currentWord().c_str());
+}
+
+void test_rewind_sentence_at_sentence_start_moves_to_previous_sentence(void) {
+  ReadingLoop r = makeReader(300, {"One", "two.", "Three", "four", "five.", "Six"});
+  r.seekTo(2);
+  r.rewindSentence();
+  TEST_ASSERT_EQUAL(0u, r.currentIndex());
+  TEST_ASSERT_EQUAL_STRING("One", r.currentWord().c_str());
+}
+
+void test_rewind_sentence_clamps_at_book_start(void) {
+  ReadingLoop r = makeReader(300, {"One", "two.", "Three"});
+  r.seekTo(0);
+  r.rewindSentence();
+  TEST_ASSERT_EQUAL(0u, r.currentIndex());
+  TEST_ASSERT_EQUAL_STRING("One", r.currentWord().c_str());
+}
+
+void test_rewind_sentence_ignores_abbreviation_periods(void) {
+  ReadingLoop r = makeReader(300, {"Mr.", "Smith", "arrived.", "Then", "left."});
+  r.seekTo(4);
+  r.rewindSentence();
+  TEST_ASSERT_EQUAL(3u, r.currentIndex());
+  TEST_ASSERT_EQUAL_STRING("Then", r.currentWord().c_str());
+}
+
 // ---------------------------------------------------------------------------
 // Word count / word access
 // ---------------------------------------------------------------------------
@@ -416,6 +448,10 @@ int main(void) {
   RUN_TEST(test_scrub_clamped_at_start);
   RUN_TEST(test_scrub_clamped_at_end);
   RUN_TEST(test_seek_relative_via_base_index);
+  RUN_TEST(test_rewind_sentence_moves_to_current_sentence_start);
+  RUN_TEST(test_rewind_sentence_at_sentence_start_moves_to_previous_sentence);
+  RUN_TEST(test_rewind_sentence_clamps_at_book_start);
+  RUN_TEST(test_rewind_sentence_ignores_abbreviation_periods);
 
   RUN_TEST(test_word_at_returns_correct_word);
 


### PR DESCRIPTION
## What changed

This PR adds two reader-facing features:

- left-handed mode in `Settings -> Display -> L/R Hand`
- sentence rewind from a tap on the far-left edge while paused or playing

The handedness work rotates the UI and touch mapping together, and adjusts the effective RSVP anchor so the reading layout still feels intentional after flipping orientation.

The sentence rewind work adds a sentence-boundary rewind path in `ReadingLoop`, wires it into the reader tap handling, and documents the gesture in the README.

## Why

These controls make one-handed reading more flexible and make it easier to quickly recover context without manual scrubbing.

## User impact

- Readers can flip the device for left-hand use.
- A far-left tap jumps to the start of the current sentence, or the previous sentence if already at the start.
- If triggered while playing, rewind happens immediately and playback pauses.

## Validation

- `~/.platformio/penv/bin/pio test -e native_test`
- 50/50 pacing tests passed, including new sentence rewind coverage
