### PR TITLE
Skip Apple Double resource fork files in book listing

### DIFF
--- a/src/storage/StorageManager.cpp
+++ b/src/storage/StorageManager.cpp
@@ -282,6 +282,11 @@ std::vector<String> collectBookPaths() {
   while (entry) {
     if (!entry.isDirectory()) {
       const String path = normalizeBookPath(String(entry.name()));
+      if (displayNameForPath(path).startsWith("._")) {
+        entry.close();
+        entry = dir.openNextFile();
+        continue;
+      }
       const bool staleGeneratedRsvp =
           hasRsvpExtension(path) && fileExistsAndHasBytes(epubSiblingPathForRsvp(path)) &&
           !EpubConverter::isCurrentCache(path);


### PR DESCRIPTION
## Summary

- Filter out macOS Apple Double resource fork files (`._*`) from the book library listing

## Problem

When copying `.rsvp` files from macOS to the SD card (FAT32/exFAT), the system automatically creates hidden `._` prefixed files (Apple Double resource forks) alongside each file. These ghost files have valid `.rsvp` extensions and pass the existing filters, appearing as corrupted duplicate entries in the book list.

## Solution

Added a filename check in `collectBookPaths()` to skip any file whose name starts with `._`, wrapping the existing extension filter logic.

## Test plan

- [x] Copy `.rsvp` files from macOS to a FAT32/exFAT SD card (which creates `._` files)
- [x] Verify that only the real books appear in the library, with no ghost entries