### PR TITLE
Fix crash during large book parsing

### DIFF
--- a/src/storage/StorageManager.cpp
+++ b/src/storage/StorageManager.cpp
@@ -1607,35 +1607,45 @@ void StorageManager::refreshBookPaths() {
 
 bool StorageManager::parseFile(File &file, BookContent &book, bool rsvpFormat) {
   book.clear();
+  book.words.reserve(file.size() / 6);
   String line;
+  line.reserve(256);
   bool paragraphPending = true;
+  bool keepReading = true;
 
-  while (file.available()) {
-    const char c = static_cast<char>(file.read());
+  constexpr size_t kBufSize = 512;
+  static uint8_t buf[kBufSize];
 
-    if (c == '\r') {
-      continue;
+  while (keepReading && file.available()) {
+    const size_t bytesRead = file.read(buf, kBufSize);
+    if (bytesRead == 0) {
+      break;
     }
+    yield();
 
-    if (c == '\n') {
-      const bool keepReading =
-          rsvpFormat ? processRsvpLine(line, book, paragraphPending)
-                     : processBookLine(line, book, paragraphPending);
-      if (!keepReading) {
-        if (hasBookWordLimit()) {
+    for (size_t i = 0; i < bytesRead && keepReading; ++i) {
+      const char c = static_cast<char>(buf[i]);
+
+      if (c == '\r') {
+        continue;
+      }
+
+      if (c == '\n') {
+        keepReading = rsvpFormat ? processRsvpLine(line, book, paragraphPending)
+                                : processBookLine(line, book, paragraphPending);
+        if (!keepReading && hasBookWordLimit()) {
           Serial.printf("[storage] Reached %lu word limit, truncating book\n",
                         static_cast<unsigned long>(kMaxBookWords));
         }
-        break;
+        line = "";
+        continue;
       }
-      line = "";
-      continue;
-    }
 
-    line += c;
+      line += c;
+    }
   }
 
-  if (!line.isEmpty() && !reachedBookWordLimit(book.words.size())) {
+  if (!line.isEmpty() && keepReading && !reachedBookWordLimit(book.words.size())) {
     if (rsvpFormat) {
       processRsvpLine(line, book, paragraphPending);
     } else {


### PR DESCRIPTION
## Summary

- Pre-allocate the words vector and switch to buffered file reads in `parseFile()` to fix a crash when loading large books

## Problem

The device crashes deterministically when loading `.rsvp` files with more than ~131,000 words (roughly 800KB+). The root cause is `std::vector<String>` reallocation during parsing.

As words are pushed one by one, the vector doubles its capacity at each growth step. The heap drops observed during debug logging confirm the doubling pattern:

| Words | Heap drop | Vector capacity |
|-------|-----------|-----------------|
| ~10K | -134KB | 16,384 |
| ~18K | -265KB | 32,768 |
| ~35K | -533KB | 65,536 |
| ~69K | -1,062KB | 131,072 |
| **~131K** | **CRASH** | **262,144** |

At ~131K words, the vector attempts to reallocate from 131,072 to 262,144 elements. With each `String` struct being 12 bytes, this requires a **3MB contiguous block** for the new allocation while the old 1.5MB block is still alive during the copy. Although 6.2MB of heap is nominally free at that point, the heap is heavily fragmented from tens of thousands of individual `String` character data allocations — no contiguous 3MB region exists, and the allocation fails, crashing the device.

Additionally, the original `parseFile()` read the file **one byte at a time** via `file.read()`, generating ~1.1 million individual SD card read calls for a 1MB file.

## Solution

Two changes in `StorageManager::parseFile()`:

1. **`book.words.reserve(file.size() / 6)`** — Pre-allocates the vector to its approximate final size in a single allocation while the heap is still clean. For a 1.1MB file this reserves ~183K slots (~2.2MB), fitting easily in the 8.4MB of free heap at parse start. No further reallocations occur during parsing.

2. **Buffered reads** — Replaces byte-by-byte `file.read()` with 512-byte chunk reads via `file.read(buf, kBufSize)`, with a `yield()` after each chunk to keep the RTOS scheduler happy. Also adds `line.reserve(256)` to reduce small String reallocations during line assembly.

## Test plan

- [x] Tested on device with 4 `.rsvp` files (~1.1MB each) that previously caused a deterministic crash
- [x] Books load successfully to completion
- [ ] Verify with a variety of file sizes (small and large)