### PR TITLE
Add configurable OTA GitHub owner from device settings

### DIFF
--- a/src/app/App.cpp
+++ b/src/app/App.cpp
@@ -125,6 +125,7 @@ constexpr size_t kWifiSettingsNetworkIndex = 1;
 constexpr size_t kWifiSettingsChooseIndex = 2;
 constexpr size_t kWifiSettingsAutoUpdateIndex = 3;
 constexpr size_t kWifiSettingsForgetIndex = 4;
+constexpr size_t kWifiSettingsOtaOwnerIndex = 5;
 
 constexpr size_t kBookPickerBackIndex = 0;
 constexpr size_t kChapterPickerBackIndex = 0;
@@ -162,6 +163,7 @@ constexpr const char *kPrefRecentSeq = "seq";
 constexpr const char *kPrefWifiSsid = "wifi_ssid";
 constexpr const char *kPrefWifiPass = "wifi_pass";
 constexpr const char *kPrefOtaAuto = "ota_auto";
+constexpr const char *kPrefOtaOwner = "ota_owner";
 constexpr size_t kReaderFontSizeCount = 3;
 constexpr size_t kPhantomBeforeCharTargets[] = {64, 96, 144};
 constexpr size_t kPhantomAfterCharTargets[] = {96, 144, 208};
@@ -1966,6 +1968,11 @@ void App::selectWifiSettingsItem(uint32_t nowMs) {
       rebuildSettingsMenuItems();
       renderSettings();
       return;
+    case kWifiSettingsOtaOwnerIndex:
+      openTextEntry(TextEntryPurpose::OtaOwner, "OTA Source", "GitHub owner", "",
+                    preferences_.getString(kPrefOtaOwner, ""), "", false, 39,
+                    MenuScreen::WifiSettings);
+      return;
     default:
       return;
   }
@@ -2313,6 +2320,21 @@ void App::commitTextEntry(uint32_t nowMs) {
       openWifiSettings();
       return;
     }
+    case TextEntryPurpose::OtaOwner: {
+      const String owner = textEntrySession_.value;
+      if (owner.isEmpty()) {
+        preferences_.remove(kPrefOtaOwner);
+        display_.renderStatus("OTA", "Reset to default", "");
+      } else {
+        preferences_.putString(kPrefOtaOwner, owner);
+        display_.renderStatus("OTA", "Owner saved", owner);
+      }
+      delay(900);
+      textEntrySession_ = TextEntrySession();
+      textEntryButtons_.clear();
+      openWifiSettings();
+      return;
+    }
     case TextEntryPurpose::None:
     default:
       menuScreen_ = textEntrySession_.returnScreen;
@@ -2452,6 +2474,7 @@ void App::rebuildSettingsMenuItems() {
     settingsMenuItems_.push_back("Choose network");
     settingsMenuItems_.push_back("Auto OTA: " + String(otaAutoCheckEnabled() ? "On" : "Off"));
     settingsMenuItems_.push_back("Forget network");
+    settingsMenuItems_.push_back("OTA Owner: " + otaOwnerLabel());
   }
 
   if (settingsSelectedIndex_ >= settingsMenuItems_.size()) {
@@ -2472,6 +2495,15 @@ void App::applyPacingSettings() {
                 static_cast<unsigned int>(pacingPunctuationDelayMs_));
 }
 
+String App::otaOwnerLabel() {
+  if (preferences_.isKey(kPrefOtaOwner)) {
+    return preferences_.getString(kPrefOtaOwner, "");
+  }
+  OtaUpdater::Config cfg;
+  otaUpdater_.loadConfig(cfg);
+  return cfg.githubOwner;
+}
+
 OtaUpdater::Config App::preferredOtaConfig() {
   OtaUpdater::Config otaConfig;
   otaUpdater_.loadConfig(otaConfig);
@@ -2484,6 +2516,9 @@ OtaUpdater::Config App::preferredOtaConfig() {
   }
   if (preferences_.isKey(kPrefOtaAuto)) {
     otaConfig.autoCheck = preferences_.getBool(kPrefOtaAuto, otaConfig.autoCheck);
+  }
+  if (preferences_.isKey(kPrefOtaOwner)) {
+    otaConfig.githubOwner = preferences_.getString(kPrefOtaOwner, "");
   }
 
   return otaConfig;

--- a/src/app/App.h
+++ b/src/app/App.h
@@ -80,6 +80,7 @@ class App {
   enum class TextEntryPurpose : uint8_t {
     None,
     WifiPassword,
+    OtaOwner,
   };
 
   enum class KeyboardMode : uint8_t {
@@ -201,6 +202,7 @@ class App {
   void commitTextEntry(uint32_t nowMs);
   String configuredWifiSsid();
   bool otaAutoCheckEnabled();
+  String otaOwnerLabel();
   String pacingDelayLabel(uint16_t delayMs) const;
   String firmwareUpdateMenuLabel() const;
   String themeModeLabel() const;

--- a/src/update/OtaUpdater.h
+++ b/src/update/OtaUpdater.h
@@ -10,7 +10,7 @@ class OtaUpdater {
   struct Config {
     String wifiSsid;
     String wifiPassword;
-    String githubOwner = "ionutdecebal";
+    String githubOwner = "claudiopostinghel";
     String githubRepo = "rsvpnano";
     String assetName = "rsvp-nano-ota.bin";
     bool autoCheck = false;

--- a/src/update/OtaUpdater.h
+++ b/src/update/OtaUpdater.h
@@ -10,7 +10,7 @@ class OtaUpdater {
   struct Config {
     String wifiSsid;
     String wifiPassword;
-    String githubOwner = "claudiopostinghel";
+    String githubOwner = "ionutdecebal";
     String githubRepo = "rsvpnano";
     String assetName = "rsvp-nano-ota.bin";
     bool autoCheck = false;


### PR DESCRIPTION
## Summary

- Adds an **OTA Owner** entry in the Wi-Fi settings menu (Settings → Wi-Fi → OTA Owner)
- Users can type any GitHub username using the existing on-screen keyboard
- The value is persisted in NVS and overrides the compiled-in default
- Clearing the field and confirming resets back to the default

## Motivation

This makes the device useful for anyone running a personal fork of RSVP Nano — they can point OTA updates to their own repo without needing to recompile the firmware.

**(👉 It also allow poor Claudio with USB-C problems to test before sending PRs)**

## Changes

- `src/app/App.h` — added `TextEntryPurpose::OtaOwner` enum value + `otaOwnerLabel()` declaration
- `src/app/App.cpp` — new `kPrefOtaOwner` NVS key, menu item in Wi-Fi screen, text entry handler, `preferredOtaConfig()` reads the override
- `src/update/OtaUpdater.h` — no structural change (default remains `ionutdecebal`)

## Test plan

- [ ] Build firmware: `pio run`
- [ ] On device: Settings → Wi-Fi → scroll to "OTA Owner"
- [ ] Type a GitHub username and confirm → menu shows the new value
- [ ] Trigger OTA update → verify it contacts `github.com/<owner>/rsvpnano`
- [ ] Clear the field and confirm → resets to default, menu shows default owner