### PR TITLE
Add instruction for granting raw USB access on Linux for Chromium users

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -548,6 +548,7 @@
         <ol>
           <li>Use Chrome or Edge on macOS, Windows, Linux, or ChromeOS.</li>
           <li>Connect the device with a USB data cable.</li>
+          <li>On Linux, if you use Chromium from Snap (for example on Ubuntu), grant raw USB access once by running <code>sudo snap connect chromium:raw-usb</code> in a terminal, then restart Chromium.</li>
           <li>If the installer cannot connect, hold <code>BOOT</code>, tap reset or power-cycle, then try again.</li>
           <li>After flashing, place books on the SD card under <code>/books</code>.</li>
         </ol>


### PR DESCRIPTION
This pull request adds an instruction for Linux users running Chromium from Snap, clarifying how to grant raw USB access before installation.

Installation instructions update:

* Added a step to the installation instructions in `web/index.html` explaining that Linux users running Chromium from Snap need to run `sudo snap connect chromium:raw-usb` and restart Chromium to grant USB access.