### PR TITLE
Add persistent settings via SD card JSON file

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -8,6 +8,8 @@ framework = arduino
 monitor_speed = 115200
 upload_speed = 460800
 extra_scripts = pre:tools/pio_set_version.py
+lib_deps =
+  bblanchon/ArduinoJson@^7.0.0
 build_flags =
   -DCORE_DEBUG_LEVEL=3
   -DRSVP_ON_DEVICE_EPUB_CONVERSION=1

--- a/src/app/App.cpp
+++ b/src/app/App.cpp
@@ -494,6 +494,9 @@ void App::begin() {
 
   display_.renderProgress("SD", "Loading books", "Use SD converter for EPUB", 0);
   const bool storageReady = storage_.begin();
+  if (storageReady) {
+    applySettingsFromSd();
+  }
   storage_.listBooks();
   const uint16_t savedWpm = preferences_.getUShort(kPrefWpm, reader_.wpm());
   reader_.setWpm(savedWpm);
@@ -537,6 +540,7 @@ void App::update(uint32_t nowMs) {
   handleTouch(nowMs);
   updateWpmFeedback(nowMs);
   maybeSaveReadingPosition(nowMs);
+  maybeSaveSettingsToSd(nowMs);
 
   if (batteryChanged && (state_ == AppState::Paused || state_ == AppState::Playing)) {
     renderActiveReader(nowMs);
@@ -890,6 +894,7 @@ void App::cycleBrightness() {
                 static_cast<unsigned int>(kBrightnessLevelCount),
                 static_cast<unsigned int>(percent));
   applyDisplayPreferences(millis());
+  markSettingsFileDirty();
 }
 
 void App::cycleThemeMode(uint32_t nowMs) {
@@ -907,11 +912,13 @@ void App::cycleThemeMode(uint32_t nowMs) {
   preferences_.putBool(kPrefNightMode, nightMode_);
   Serial.printf("[display] theme=%s\n", themeModeLabel().c_str());
   applyDisplayPreferences(nowMs);
+  markSettingsFileDirty();
 }
 
 void App::cycleUiLanguage(uint32_t nowMs) {
   uiLanguage_ = Localization::nextLanguage(uiLanguage_);
   preferences_.putUChar(kPrefUiLanguage, static_cast<uint8_t>(uiLanguage_));
+  markSettingsFileDirty();
   Serial.printf("[display] language=%s\n", uiLanguageLabel().c_str());
 
   if (state_ == AppState::Menu) {
@@ -933,6 +940,7 @@ void App::cycleUiLanguage(uint32_t nowMs) {
 void App::cycleReaderMode(uint32_t nowMs) {
   readerMode_ = nextReaderMode(readerMode_);
   preferences_.putUChar(kPrefReaderMode, static_cast<uint8_t>(readerMode_));
+  markSettingsFileDirty();
   Serial.printf("[display] reader mode=%s\n", readerModeLabel().c_str());
   invalidateContextPreviewWindow();
 
@@ -948,6 +956,7 @@ void App::cycleReaderMode(uint32_t nowMs) {
 void App::cycleHandednessMode(uint32_t nowMs) {
   handednessMode_ = nextHandednessMode(handednessMode_);
   preferences_.putUChar(kPrefHandedness, static_cast<uint8_t>(handednessMode_));
+  markSettingsFileDirty();
   Serial.printf("[display] handedness=%s rotation180=%u\n", handednessLabel().c_str(),
                 uiRotated180() ? 1U : 0U);
   applyHandednessSettings(nowMs);
@@ -956,6 +965,7 @@ void App::cycleHandednessMode(uint32_t nowMs) {
 void App::togglePhantomWords(uint32_t nowMs) {
   phantomWordsEnabled_ = !phantomWordsEnabled_;
   preferences_.putBool(kPrefPhantomWords, phantomWordsEnabled_);
+  markSettingsFileDirty();
   Serial.printf("[display] phantom words=%s\n", phantomWordsLabel().c_str());
   applyDisplayPreferences(nowMs);
 }
@@ -963,6 +973,7 @@ void App::togglePhantomWords(uint32_t nowMs) {
 void App::cycleReaderFontSize(uint32_t nowMs) {
   readerFontSizeIndex_ = static_cast<uint8_t>((readerFontSizeIndex_ + 1) % kReaderFontSizeCount);
   preferences_.putUChar(kPrefReaderFontSize, readerFontSizeIndex_);
+  markSettingsFileDirty();
   Serial.printf("[display] font size=%s\n", readerFontSizeLabel().c_str());
   applyDisplayPreferences(nowMs);
 }
@@ -1066,6 +1077,7 @@ bool App::handleFooterMetricTap(uint16_t x, uint16_t y, uint32_t nowMs) {
   }
 
   preferences_.putUChar(kPrefFooterMetricMode, static_cast<uint8_t>(footerMetricMode_));
+  markSettingsFileDirty();
   resetReaderTapTracking();
   renderActiveReader(nowMs);
   const char *modeName = "percent";
@@ -1306,6 +1318,7 @@ void App::applyPausedTouchGesture(const TouchEvent &event, uint32_t nowMs) {
     const int wpmDelta = (deltaY < 0) ? 1 : -1;
     reader_.adjustWpm(wpmDelta);
     preferences_.putUShort(kPrefWpm, reader_.wpm());
+    markSettingsFileDirty();
     renderWpmFeedback(nowMs);
     Serial.printf("[app] WPM=%u interval=%lu ms\n", reader_.wpm(),
                   static_cast<unsigned long>(reader_.wordIntervalMs()));
@@ -1929,6 +1942,7 @@ void App::selectSettingsItem(uint32_t nowMs) {
   }
 
   applyPacingSettings();
+  markSettingsFileDirty();
   rebuildSettingsMenuItems();
   renderSettings();
 }
@@ -1957,12 +1971,14 @@ void App::selectWifiSettingsItem(uint32_t nowMs) {
       return;
     case kWifiSettingsAutoUpdateIndex:
       preferences_.putBool(kPrefOtaAuto, !otaAutoCheckEnabled());
+      markSettingsFileDirty();
       rebuildSettingsMenuItems();
       renderSettings();
       return;
     case kWifiSettingsForgetIndex:
       preferences_.remove(kPrefWifiSsid);
       preferences_.remove(kPrefWifiPass);
+      markSettingsFileDirty();
       display_.renderStatus("Wi-Fi", "Credentials cleared", "");
       delay(900);
       rebuildSettingsMenuItems();
@@ -2080,6 +2096,7 @@ void App::selectWifiNetworkItem(uint32_t nowMs) {
 
   preferences_.putString(kPrefWifiSsid, network.ssid);
   preferences_.putString(kPrefWifiPass, "");
+  markSettingsFileDirty();
   display_.renderStatus("Wi-Fi", "Network saved", network.ssid);
   delay(900);
   openWifiSettings();
@@ -2313,6 +2330,7 @@ void App::commitTextEntry(uint32_t nowMs) {
       const String ssid = textEntrySession_.contextValue;
       preferences_.putString(kPrefWifiSsid, ssid);
       preferences_.putString(kPrefWifiPass, textEntrySession_.value);
+      markSettingsFileDirty();
       textEntrySession_ = TextEntrySession();
       textEntryButtons_.clear();
       display_.renderStatus("Wi-Fi", "Network saved", ssid);
@@ -2329,6 +2347,7 @@ void App::commitTextEntry(uint32_t nowMs) {
         preferences_.putString(kPrefOtaOwner, owner);
         display_.renderStatus("OTA", "Owner saved", owner);
       }
+      markSettingsFileDirty();
       delay(900);
       textEntrySession_ = TextEntrySession();
       textEntryButtons_.clear();
@@ -2423,6 +2442,7 @@ void App::selectTypographyTuningItem(uint32_t nowMs) {
   }
 
   applyTypographySettings(nowMs);
+  markSettingsFileDirty();
 }
 
 void App::cycleTypographyPreviewSample(int direction) {
@@ -2963,6 +2983,9 @@ void App::enterPowerOff(uint32_t nowMs) {
   powerOffStarted_ = true;
   Serial.println("[app] powering off; hold PWR to start again");
   saveReadingPosition(true);
+  if (settingsFileDirty_) {
+    saveSettingsToSd();
+  }
   pausedTouch_.active = false;
   pausedTouchIntent_ = TouchIntent::None;
   touchPlayHeld_ = false;
@@ -2995,6 +3018,9 @@ void App::enterPowerOff(uint32_t nowMs) {
 void App::enterSleep(uint32_t nowMs) {
   Serial.println("[app] entering light sleep; press BOOT to wake");
   saveReadingPosition(true);
+  if (settingsFileDirty_) {
+    saveSettingsToSd();
+  }
   setState(AppState::Sleeping, nowMs);
   Serial.flush();
   delay(200);
@@ -3079,6 +3105,7 @@ void App::saveReadingPosition(bool force) {
   preferences_.putUInt(kPrefLegacyWordIndex, static_cast<uint32_t>(wordIndex));
   preferences_.putUShort(kPrefWpm, reader_.wpm());
   markBookRecent(currentBookPath_);
+  markSettingsFileDirty();
   lastSavedWordIndex_ = wordIndex;
   Serial.printf("[app] saved position word=%u book=%s\n", static_cast<unsigned int>(wordIndex),
                 currentBookPath_.c_str());
@@ -3897,4 +3924,194 @@ void App::handleStorageStatus(void *context, const char *title, const char *line
 
   static_cast<App *>(context)->renderStorageStatus(title, line1, line2, progressPercent);
   delay(0);
+}
+
+void App::markSettingsFileDirty() {
+  settingsFileDirty_ = true;
+  settingsFileDirtyMs_ = millis();
+}
+
+void App::maybeSaveSettingsToSd(uint32_t nowMs) {
+  if (!settingsFileDirty_ || !storage_.isMounted()) {
+    return;
+  }
+
+  constexpr uint32_t kDebounceMs = 2000;
+  if (nowMs - settingsFileDirtyMs_ < kDebounceMs) {
+    return;
+  }
+
+  saveSettingsToSd();
+}
+
+void App::saveSettingsToSd() {
+  if (settingsFile_.save(buildSettingsData())) {
+    settingsFileDirty_ = false;
+  }
+}
+
+SettingsData App::buildSettingsData() {
+  SettingsData data;
+  data.brightness = brightnessLevelIndex_;
+  data.darkMode = darkMode_;
+  data.nightMode = nightMode_;
+  data.uiLanguage = static_cast<uint8_t>(uiLanguage_);
+  data.readerMode = static_cast<uint8_t>(readerMode_);
+  data.handedness = static_cast<uint8_t>(handednessMode_);
+  data.phantomWords = phantomWordsEnabled_;
+  data.footerMetric = static_cast<uint8_t>(footerMetricMode_);
+  data.fontSize = readerFontSizeIndex_;
+  data.typeface = static_cast<uint8_t>(typographyConfig_.typeface);
+  data.focusHighlight = typographyConfig_.focusHighlight;
+  data.tracking = typographyConfig_.trackingPx;
+  data.anchorPercent = typographyConfig_.anchorPercent;
+  data.guideWidth = typographyConfig_.guideHalfWidth;
+  data.guideGap = typographyConfig_.guideGap;
+  data.pacingLongMs = pacingLongWordDelayMs_;
+  data.pacingComplexMs = pacingComplexWordDelayMs_;
+  data.pacingPunctuationMs = pacingPunctuationDelayMs_;
+  data.wpm = reader_.wpm();
+  data.wifiSsid = preferences_.getString(kPrefWifiSsid, "");
+  data.wifiPass = preferences_.getString(kPrefWifiPass, "");
+  data.otaAuto = otaAutoCheckEnabled();
+  data.otaOwner = preferences_.getString(kPrefOtaOwner, "");
+  data.currentBook = currentBookPath_;
+  data.recentSequence = preferences_.getUInt(kPrefRecentSeq, 0);
+
+  for (size_t i = 0; i < storage_.bookCount(); ++i) {
+    const String path = storage_.bookPath(i);
+    const String posKey = bookPositionKey(path);
+    if (!preferences_.isKey(posKey.c_str())) {
+      continue;
+    }
+    SettingsData::BookPos pos;
+    pos.path = path;
+    pos.position = preferences_.getUInt(posKey.c_str(), 0);
+    pos.wordCount = preferences_.getUInt(bookWordCountKey(path).c_str(), 0);
+    pos.recentSeq = preferences_.getUInt(bookRecentKey(path).c_str(), 0);
+    data.books.push_back(std::move(pos));
+  }
+
+  return data;
+}
+
+void App::applySettingsFromSd() {
+  SettingsData data;
+  // Pre-populate with current NVS-loaded values so missing JSON keys keep them.
+  data.brightness = brightnessLevelIndex_;
+  data.darkMode = darkMode_;
+  data.nightMode = nightMode_;
+  data.uiLanguage = static_cast<uint8_t>(uiLanguage_);
+  data.readerMode = static_cast<uint8_t>(readerMode_);
+  data.handedness = static_cast<uint8_t>(handednessMode_);
+  data.phantomWords = phantomWordsEnabled_;
+  data.footerMetric = static_cast<uint8_t>(footerMetricMode_);
+  data.fontSize = readerFontSizeIndex_;
+  data.typeface = static_cast<uint8_t>(typographyConfig_.typeface);
+  data.focusHighlight = typographyConfig_.focusHighlight;
+  data.tracking = typographyConfig_.trackingPx;
+  data.anchorPercent = typographyConfig_.anchorPercent;
+  data.guideWidth = typographyConfig_.guideHalfWidth;
+  data.guideGap = typographyConfig_.guideGap;
+  data.pacingLongMs = pacingLongWordDelayMs_;
+  data.pacingComplexMs = pacingComplexWordDelayMs_;
+  data.pacingPunctuationMs = pacingPunctuationDelayMs_;
+  data.wpm = reader_.wpm();
+  data.otaAuto = otaAutoCheckEnabled();
+  data.recentSequence = preferences_.getUInt(kPrefRecentSeq, 0);
+
+  if (!settingsFile_.load(data)) {
+    return;
+  }
+
+  // Apply loaded values with the same clamping used during NVS load.
+  brightnessLevelIndex_ = (data.brightness < kBrightnessLevelCount)
+                              ? data.brightness
+                              : static_cast<uint8_t>(kBrightnessLevelCount - 1);
+  darkMode_ = data.darkMode;
+  nightMode_ = data.nightMode;
+  uiLanguage_ = Localization::sanitizeLanguage(data.uiLanguage);
+  readerMode_ = readerModeFromSetting(data.readerMode);
+  handednessMode_ = handednessModeFromSetting(data.handedness);
+  readerFontSizeIndex_ = (data.fontSize < kReaderFontSizeCount) ? data.fontSize : 0;
+  switch (data.footerMetric) {
+    case static_cast<uint8_t>(FooterMetricMode::ChapterTime):
+      footerMetricMode_ = FooterMetricMode::ChapterTime;
+      break;
+    case static_cast<uint8_t>(FooterMetricMode::BookTime):
+      footerMetricMode_ = FooterMetricMode::BookTime;
+      break;
+    default:
+      footerMetricMode_ = FooterMetricMode::Percentage;
+      break;
+  }
+  pacingLongWordDelayMs_ = static_cast<uint16_t>(
+      clampIntSetting(data.pacingLongMs, kPacingDelayMinMs, kPacingDelayMaxMs));
+  pacingComplexWordDelayMs_ = static_cast<uint16_t>(
+      clampIntSetting(data.pacingComplexMs, kPacingDelayMinMs, kPacingDelayMaxMs));
+  pacingPunctuationDelayMs_ = static_cast<uint16_t>(
+      clampIntSetting(data.pacingPunctuationMs, kPacingDelayMinMs, kPacingDelayMaxMs));
+  phantomWordsEnabled_ = data.phantomWords;
+  typographyConfig_.typeface = readerTypefaceFromSetting(data.typeface);
+  typographyConfig_.focusHighlight = data.focusHighlight;
+  typographyConfig_.trackingPx = static_cast<int8_t>(
+      clampIntSetting(data.tracking, kTypographyTrackingMin, kTypographyTrackingMax));
+  typographyConfig_.anchorPercent = static_cast<uint8_t>(
+      clampIntSetting(data.anchorPercent, kTypographyAnchorMin, kTypographyAnchorMax));
+  typographyConfig_.guideHalfWidth = static_cast<uint8_t>(
+      clampIntSetting(data.guideWidth, kTypographyGuideWidthMin, kTypographyGuideWidthMax));
+  typographyConfig_.guideGap = static_cast<uint8_t>(
+      clampIntSetting(data.guideGap, kTypographyGuideGapMin, kTypographyGuideGapMax));
+  reader_.setWpm(data.wpm);
+
+  // Re-apply settings so hardware reflects the SD-loaded values.
+  applyHandednessSettings(0, false);
+  applyDisplayPreferences(0, false);
+  applyTypographySettings(0, false);
+  applyPacingSettings();
+
+  // Write all settings back to NVS for consistency.
+  preferences_.putUChar(kPrefBrightness, brightnessLevelIndex_);
+  preferences_.putBool(kPrefDarkMode, darkMode_);
+  preferences_.putBool(kPrefNightMode, nightMode_);
+  preferences_.putUChar(kPrefUiLanguage, static_cast<uint8_t>(uiLanguage_));
+  preferences_.putUChar(kPrefReaderMode, static_cast<uint8_t>(readerMode_));
+  preferences_.putUChar(kPrefHandedness, static_cast<uint8_t>(handednessMode_));
+  preferences_.putBool(kPrefPhantomWords, phantomWordsEnabled_);
+  preferences_.putUChar(kPrefFooterMetricMode, static_cast<uint8_t>(footerMetricMode_));
+  preferences_.putUChar(kPrefReaderFontSize, readerFontSizeIndex_);
+  preferences_.putUChar(kPrefReaderTypeface, static_cast<uint8_t>(typographyConfig_.typeface));
+  preferences_.putBool(kPrefTypographyFocusHighlight, typographyConfig_.focusHighlight);
+  preferences_.putChar(kPrefTypographyTracking, typographyConfig_.trackingPx);
+  preferences_.putUChar(kPrefTypographyAnchor, typographyConfig_.anchorPercent);
+  preferences_.putUChar(kPrefTypographyGuideWidth, typographyConfig_.guideHalfWidth);
+  preferences_.putUChar(kPrefTypographyGuideGap, typographyConfig_.guideGap);
+  preferences_.putUShort(kPrefPacingLongMs, pacingLongWordDelayMs_);
+  preferences_.putUShort(kPrefPacingComplexMs, pacingComplexWordDelayMs_);
+  preferences_.putUShort(kPrefPacingPunctuationMs, pacingPunctuationDelayMs_);
+  preferences_.putUShort(kPrefWpm, data.wpm);
+  if (!data.wifiSsid.isEmpty()) {
+    preferences_.putString(kPrefWifiSsid, data.wifiSsid);
+    preferences_.putString(kPrefWifiPass, data.wifiPass);
+  }
+  preferences_.putBool(kPrefOtaAuto, data.otaAuto);
+  if (!data.otaOwner.isEmpty()) {
+    preferences_.putString(kPrefOtaOwner, data.otaOwner);
+  }
+
+  // Restore per-book positions from JSON into NVS using the existing hash key scheme.
+  if (data.recentSequence > preferences_.getUInt(kPrefRecentSeq, 0)) {
+    preferences_.putUInt(kPrefRecentSeq, data.recentSequence);
+  }
+  if (!data.currentBook.isEmpty()) {
+    preferences_.putString(kPrefBookPath, data.currentBook);
+  }
+  for (const auto &b : data.books) {
+    preferences_.putUInt(bookPositionKey(b.path).c_str(), b.position);
+    preferences_.putUInt(bookWordCountKey(b.path).c_str(), b.wordCount);
+    preferences_.putUInt(bookRecentKey(b.path).c_str(), b.recentSeq);
+  }
+
+  Serial.printf("[settings] applied SD settings (%u book positions restored)\n",
+                static_cast<unsigned int>(data.books.size()));
 }

--- a/src/app/App.cpp
+++ b/src/app/App.cpp
@@ -122,6 +122,7 @@ constexpr size_t kWifiSettingsNetworkIndex = 1;
 constexpr size_t kWifiSettingsChooseIndex = 2;
 constexpr size_t kWifiSettingsAutoUpdateIndex = 3;
 constexpr size_t kWifiSettingsForgetIndex = 4;
+constexpr size_t kWifiSettingsOtaOwnerIndex = 5;
 
 constexpr size_t kBookPickerBackIndex = 0;
 constexpr size_t kChapterPickerBackIndex = 0;
@@ -157,6 +158,7 @@ constexpr const char *kPrefRecentSeq = "seq";
 constexpr const char *kPrefWifiSsid = "wifi_ssid";
 constexpr const char *kPrefWifiPass = "wifi_pass";
 constexpr const char *kPrefOtaAuto = "ota_auto";
+constexpr const char *kPrefOtaOwner = "ota_owner";
 constexpr size_t kReaderFontSizeCount = 3;
 constexpr size_t kPhantomBeforeCharTargets[] = {64, 96, 144};
 constexpr size_t kPhantomAfterCharTargets[] = {96, 144, 208};
@@ -1782,6 +1784,11 @@ void App::selectWifiSettingsItem(uint32_t nowMs) {
       rebuildSettingsMenuItems();
       renderSettings();
       return;
+    case kWifiSettingsOtaOwnerIndex:
+      openTextEntry(TextEntryPurpose::OtaOwner, "OTA Source", "GitHub owner", "",
+                    preferences_.getString(kPrefOtaOwner, ""), "", false, 39,
+                    MenuScreen::WifiSettings);
+      return;
     default:
       return;
   }
@@ -2129,6 +2136,21 @@ void App::commitTextEntry(uint32_t nowMs) {
       openWifiSettings();
       return;
     }
+    case TextEntryPurpose::OtaOwner: {
+      const String owner = textEntrySession_.value;
+      if (owner.isEmpty()) {
+        preferences_.remove(kPrefOtaOwner);
+        display_.renderStatus("OTA", "Reset to default", "");
+      } else {
+        preferences_.putString(kPrefOtaOwner, owner);
+        display_.renderStatus("OTA", "Owner saved", owner);
+      }
+      delay(900);
+      textEntrySession_ = TextEntrySession();
+      textEntryButtons_.clear();
+      openWifiSettings();
+      return;
+    }
     case TextEntryPurpose::None:
     default:
       menuScreen_ = textEntrySession_.returnScreen;
@@ -2268,6 +2290,7 @@ void App::rebuildSettingsMenuItems() {
     settingsMenuItems_.push_back("Choose network");
     settingsMenuItems_.push_back("Auto OTA: " + String(otaAutoCheckEnabled() ? "On" : "Off"));
     settingsMenuItems_.push_back("Forget network");
+    settingsMenuItems_.push_back("OTA Owner: " + otaOwnerLabel());
   }
 
   if (settingsSelectedIndex_ >= settingsMenuItems_.size()) {
@@ -2288,6 +2311,15 @@ void App::applyPacingSettings() {
                 static_cast<unsigned int>(pacingPunctuationDelayMs_));
 }
 
+String App::otaOwnerLabel() {
+  if (preferences_.isKey(kPrefOtaOwner)) {
+    return preferences_.getString(kPrefOtaOwner, "");
+  }
+  OtaUpdater::Config cfg;
+  otaUpdater_.loadConfig(cfg);
+  return cfg.githubOwner;
+}
+
 OtaUpdater::Config App::preferredOtaConfig() {
   OtaUpdater::Config otaConfig;
   otaUpdater_.loadConfig(otaConfig);
@@ -2300,6 +2332,9 @@ OtaUpdater::Config App::preferredOtaConfig() {
   }
   if (preferences_.isKey(kPrefOtaAuto)) {
     otaConfig.autoCheck = preferences_.getBool(kPrefOtaAuto, otaConfig.autoCheck);
+  }
+  if (preferences_.isKey(kPrefOtaOwner)) {
+    otaConfig.githubOwner = preferences_.getString(kPrefOtaOwner, "");
   }
 
   return otaConfig;

--- a/src/app/App.h
+++ b/src/app/App.h
@@ -11,6 +11,7 @@
 #include "input/ButtonHandler.h"
 #include "input/TouchHandler.h"
 #include "reader/ReadingLoop.h"
+#include "storage/SettingsFile.h"
 #include "storage/StorageManager.h"
 #include "timer/FocusTimer.h"
 #include "update/OtaUpdater.h"
@@ -281,6 +282,11 @@ class App {
   const char *touchPhaseName(TouchPhase phase) const;
   bool isFocusTimerMenuScreen(MenuScreen screen) const;
   bool scrollModeEnabled() const;
+  void markSettingsFileDirty();
+  void maybeSaveSettingsToSd(uint32_t nowMs);
+  void saveSettingsToSd();
+  SettingsData buildSettingsData();
+  void applySettingsFromSd();
   void applyUiOrientation(BoardConfig::UiOrientation orientation);
   void applyReaderUiOrientation();
   BoardConfig::UiOrientation readerUiOrientation() const;
@@ -301,12 +307,15 @@ class App {
   ButtonHandler powerButton_;
   TouchHandler touch_;
   StorageManager storage_;
+  SettingsFile settingsFile_;
   OtaUpdater otaUpdater_;
   UsbMassStorageManager usbTransfer_;
   Preferences preferences_;
   PausedTouchSession pausedTouch_;
   TouchIntent pausedTouchIntent_ = TouchIntent::None;
 
+  bool settingsFileDirty_ = false;
+  uint32_t settingsFileDirtyMs_ = 0;
   uint32_t bootStartedMs_ = 0;
   uint32_t lastStateLogMs_ = 0;
   uint32_t wpmFeedbackUntilMs_ = 0;

--- a/src/app/App.h
+++ b/src/app/App.h
@@ -76,6 +76,7 @@ class App {
   enum class TextEntryPurpose : uint8_t {
     None,
     WifiPassword,
+    OtaOwner,
   };
 
   enum class KeyboardMode : uint8_t {
@@ -191,6 +192,7 @@ class App {
   void commitTextEntry(uint32_t nowMs);
   String configuredWifiSsid();
   bool otaAutoCheckEnabled();
+  String otaOwnerLabel();
   String pacingDelayLabel(uint16_t delayMs) const;
   String firmwareUpdateMenuLabel() const;
   String themeModeLabel() const;

--- a/src/storage/SettingsFile.cpp
+++ b/src/storage/SettingsFile.cpp
@@ -1,0 +1,141 @@
+#include "storage/SettingsFile.h"
+
+#include <ArduinoJson.h>
+#include <SD_MMC.h>
+
+bool SettingsFile::load(SettingsData &out) {
+  if (SD_MMC.exists(kTempPath)) {
+    SD_MMC.remove(kTempPath);
+    Serial.println("[settings] removed stale settings.tmp");
+  }
+
+  if (!SD_MMC.exists(kPath)) {
+    return false;
+  }
+
+  File f = SD_MMC.open(kPath, FILE_READ);
+  if (!f) {
+    Serial.println("[settings] failed to open settings.json");
+    return false;
+  }
+
+  JsonDocument doc;
+  const DeserializationError err = deserializeJson(doc, f);
+  f.close();
+
+  if (err) {
+    Serial.printf("[settings] JSON parse error: %s\n", err.c_str());
+    return false;
+  }
+
+  JsonObjectConst s = doc["settings"];
+  if (!s.isNull()) {
+    out.brightness = s["brightness"] | out.brightness;
+    out.darkMode = s["dark_mode"] | out.darkMode;
+    out.nightMode = s["night_mode"] | out.nightMode;
+    out.uiLanguage = s["ui_language"] | out.uiLanguage;
+    out.readerMode = s["reader_mode"] | out.readerMode;
+    out.handedness = s["handedness"] | out.handedness;
+    out.phantomWords = s["phantom_words"] | out.phantomWords;
+    out.footerMetric = s["footer_metric"] | out.footerMetric;
+    out.fontSize = s["font_size"] | out.fontSize;
+    out.typeface = s["typeface"] | out.typeface;
+    out.focusHighlight = s["focus_highlight"] | out.focusHighlight;
+    out.tracking = s["tracking"] | out.tracking;
+    out.anchorPercent = s["anchor_percent"] | out.anchorPercent;
+    out.guideWidth = s["guide_width"] | out.guideWidth;
+    out.guideGap = s["guide_gap"] | out.guideGap;
+    out.pacingLongMs = s["pacing_long_ms"] | out.pacingLongMs;
+    out.pacingComplexMs = s["pacing_complex_ms"] | out.pacingComplexMs;
+    out.pacingPunctuationMs = s["pacing_punctuation_ms"] | out.pacingPunctuationMs;
+    out.wpm = s["wpm"] | out.wpm;
+    if (s["wifi_ssid"].is<const char *>()) out.wifiSsid = s["wifi_ssid"].as<String>();
+    if (s["wifi_pass"].is<const char *>()) out.wifiPass = s["wifi_pass"].as<String>();
+    out.otaAuto = s["ota_auto"] | out.otaAuto;
+    if (s["ota_owner"].is<const char *>()) out.otaOwner = s["ota_owner"].as<String>();
+  }
+
+  if (doc["current_book"].is<const char *>()) {
+    out.currentBook = doc["current_book"].as<String>();
+  }
+  out.recentSequence = doc["recent_sequence"] | out.recentSequence;
+
+  JsonArrayConst books = doc["books"];
+  for (JsonObjectConst b : books) {
+    if (!b["path"].is<const char *>()) continue;
+    const String path = b["path"].as<String>();
+    if (path.isEmpty()) continue;
+    SettingsData::BookPos pos;
+    pos.path = path;
+    pos.position = b["position"] | 0u;
+    pos.wordCount = b["word_count"] | 0u;
+    pos.recentSeq = b["recent_seq"] | 0u;
+    out.books.push_back(std::move(pos));
+  }
+
+  Serial.printf("[settings] loaded from SD (%u books)\n",
+                static_cast<unsigned int>(out.books.size()));
+  return true;
+}
+
+bool SettingsFile::save(const SettingsData &data) {
+  File f = SD_MMC.open(kTempPath, FILE_WRITE);
+  if (!f) {
+    Serial.println("[settings] failed to open settings.tmp for write");
+    return false;
+  }
+
+  JsonDocument doc;
+  doc["version"] = 1;
+
+  JsonObject s = doc["settings"].to<JsonObject>();
+  s["brightness"] = data.brightness;
+  s["dark_mode"] = data.darkMode;
+  s["night_mode"] = data.nightMode;
+  s["ui_language"] = data.uiLanguage;
+  s["reader_mode"] = data.readerMode;
+  s["handedness"] = data.handedness;
+  s["phantom_words"] = data.phantomWords;
+  s["footer_metric"] = data.footerMetric;
+  s["font_size"] = data.fontSize;
+  s["typeface"] = data.typeface;
+  s["focus_highlight"] = data.focusHighlight;
+  s["tracking"] = data.tracking;
+  s["anchor_percent"] = data.anchorPercent;
+  s["guide_width"] = data.guideWidth;
+  s["guide_gap"] = data.guideGap;
+  s["pacing_long_ms"] = data.pacingLongMs;
+  s["pacing_complex_ms"] = data.pacingComplexMs;
+  s["pacing_punctuation_ms"] = data.pacingPunctuationMs;
+  s["wpm"] = data.wpm;
+  s["wifi_ssid"] = data.wifiSsid;
+  s["wifi_pass"] = data.wifiPass;
+  s["ota_auto"] = data.otaAuto;
+  s["ota_owner"] = data.otaOwner;
+
+  doc["current_book"] = data.currentBook;
+  doc["recent_sequence"] = data.recentSequence;
+
+  JsonArray books = doc["books"].to<JsonArray>();
+  for (const auto &b : data.books) {
+    JsonObject entry = books.add<JsonObject>();
+    entry["path"] = b.path;
+    entry["position"] = b.position;
+    entry["word_count"] = b.wordCount;
+    entry["recent_seq"] = b.recentSeq;
+  }
+
+  serializeJsonPretty(doc, f);
+  f.close();
+
+  SD_MMC.remove(kPath);
+  if (!SD_MMC.rename(kTempPath, kPath)) {
+    Serial.println("[settings] rename failed");
+    SD_MMC.remove(kTempPath);
+    return false;
+  }
+
+  Serial.printf("[settings] saved to SD (%u books)\n",
+                static_cast<unsigned int>(data.books.size()));
+  return true;
+}

--- a/src/storage/SettingsFile.h
+++ b/src/storage/SettingsFile.h
@@ -1,0 +1,63 @@
+#pragma once
+
+#include <Arduino.h>
+#include <vector>
+
+// All persistent settings, including per-book reading positions.
+// Serialized to /sdcard/settings.json on every change.
+struct SettingsData {
+  // Display & UI
+  uint8_t brightness = 4;
+  bool darkMode = true;
+  bool nightMode = false;
+  uint8_t uiLanguage = 0;
+  uint8_t readerMode = 0;
+  uint8_t handedness = 0;
+  bool phantomWords = true;
+  uint8_t footerMetric = 0;
+  uint8_t fontSize = 0;
+  // Typography
+  uint8_t typeface = 0;
+  bool focusHighlight = true;
+  int8_t tracking = 0;
+  uint8_t anchorPercent = 35;
+  uint8_t guideWidth = 20;
+  uint8_t guideGap = 4;
+  // Pacing
+  uint16_t pacingLongMs = 200;
+  uint16_t pacingComplexMs = 200;
+  uint16_t pacingPunctuationMs = 200;
+  // Reading speed
+  uint16_t wpm = 300;
+  // Network / OTA
+  String wifiSsid;
+  String wifiPass;
+  bool otaAuto = false;
+  String otaOwner;
+
+  // Per-book reading positions
+  struct BookPos {
+    String path;
+    uint32_t position = 0;
+    uint32_t wordCount = 0;
+    uint32_t recentSeq = 0;
+  };
+  String currentBook;
+  uint32_t recentSequence = 0;
+  std::vector<BookPos> books;
+};
+
+class SettingsFile {
+ public:
+  // Reads /sdcard/settings.json and merges values into out (missing keys keep
+  // whatever value out already has). Returns true on success.
+  bool load(SettingsData &out);
+
+  // Writes data to /sdcard/settings.json atomically via a temp file.
+  // Returns true on success.
+  bool save(const SettingsData &data);
+
+ private:
+  static constexpr const char *kPath = "/sdcard/settings.json";
+  static constexpr const char *kTempPath = "/sdcard/settings.tmp";
+};

--- a/src/storage/StorageManager.cpp
+++ b/src/storage/StorageManager.cpp
@@ -1607,35 +1607,45 @@ void StorageManager::refreshBookPaths() {
 
 bool StorageManager::parseFile(File &file, BookContent &book, bool rsvpFormat) {
   book.clear();
+  book.words.reserve(file.size() / 6);
   String line;
+  line.reserve(256);
   bool paragraphPending = true;
+  bool keepReading = true;
 
-  while (file.available()) {
-    const char c = static_cast<char>(file.read());
+  constexpr size_t kBufSize = 512;
+  static uint8_t buf[kBufSize];
 
-    if (c == '\r') {
-      continue;
+  while (keepReading && file.available()) {
+    const size_t bytesRead = file.read(buf, kBufSize);
+    if (bytesRead == 0) {
+      break;
     }
+    yield();
 
-    if (c == '\n') {
-      const bool keepReading =
-          rsvpFormat ? processRsvpLine(line, book, paragraphPending)
-                     : processBookLine(line, book, paragraphPending);
-      if (!keepReading) {
-        if (hasBookWordLimit()) {
+    for (size_t i = 0; i < bytesRead && keepReading; ++i) {
+      const char c = static_cast<char>(buf[i]);
+
+      if (c == '\r') {
+        continue;
+      }
+
+      if (c == '\n') {
+        keepReading = rsvpFormat ? processRsvpLine(line, book, paragraphPending)
+                                : processBookLine(line, book, paragraphPending);
+        if (!keepReading && hasBookWordLimit()) {
           Serial.printf("[storage] Reached %lu word limit, truncating book\n",
                         static_cast<unsigned long>(kMaxBookWords));
         }
-        break;
+        line = "";
+        continue;
       }
-      line = "";
-      continue;
-    }
 
-    line += c;
+      line += c;
+    }
   }
 
-  if (!line.isEmpty() && !reachedBookWordLimit(book.words.size())) {
+  if (!line.isEmpty() && keepReading && !reachedBookWordLimit(book.words.size())) {
     if (rsvpFormat) {
       processRsvpLine(line, book, paragraphPending);
     } else {

--- a/src/storage/StorageManager.h
+++ b/src/storage/StorageManager.h
@@ -19,6 +19,7 @@ class StorageManager {
   bool loadFirstBookWords(std::vector<String> &words, String *loadedPath = nullptr);
   bool loadBookContent(size_t index, BookContent &book, String *loadedPath = nullptr,
                        size_t *loadedIndex = nullptr);
+  bool isMounted() const { return mounted_; }
   size_t bookCount() const;
   String bookPath(size_t index) const;
   String bookDisplayName(size_t index) const;

--- a/src/update/OtaUpdater.h
+++ b/src/update/OtaUpdater.h
@@ -10,7 +10,7 @@ class OtaUpdater {
   struct Config {
     String wifiSsid;
     String wifiPassword;
-    String githubOwner = "ionutdecebal";
+    String githubOwner = "claudiopostinghel";
     String githubRepo = "rsvpnano";
     String assetName = "rsvp-nano-ota.bin";
     bool autoCheck = false;

--- a/web/firmware/manifest.json
+++ b/web/firmware/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "RSVP Nano",
-  "version": "v0.0.1",
+  "version": "1.0.3",
   "new_install_prompt_erase": true,
   "new_install_improv_wait_time": 0,
   "builds": [

--- a/web/index-2.html
+++ b/web/index-2.html
@@ -122,7 +122,8 @@
         margin-left: 12px;
       }
 
-      .install-steps.is-collapsed .chevron {
+      .install-steps.is-collapsed .chevron,
+      .workspace.is-collapsed .chevron {
         transform: rotate(-90deg);
       }
 
@@ -292,10 +293,25 @@
       .workspace-shell {
         display: grid;
         grid-template-columns: minmax(0, 1.08fr) minmax(320px, 0.92fr);
+        border-top: 1px solid var(--line);
+        transition: grid-template-rows 200ms ease;
+        grid-template-rows: 1fr;
+      }
+
+      .workspace.is-collapsed .workspace-shell {
+        grid-template-rows: 0fr;
+        border-top-color: transparent;
       }
 
       .workspace-pane {
         padding: 28px;
+        overflow: hidden;
+        transition: padding 200ms ease;
+      }
+
+      .workspace.is-collapsed .workspace-pane {
+        padding-top: 0;
+        padding-bottom: 0;
       }
 
       .workspace-pane + .workspace-pane {
@@ -306,10 +322,6 @@
       .workspace h2,
       .workspace h3 {
         margin: 0;
-      }
-
-      .workspace h2 {
-        font-size: 1.38rem;
       }
 
       .workspace-copy {
@@ -739,10 +751,26 @@
         </div>
       </section>
 
-      <section class="card workspace">
+      <section class="card install-steps" id="sdcard-section">
+        <div class="section-header" id="sdcard-toggle">
+          <h2><span class="step-number">2</span>Prepare SD Card</h2>
+          <svg class="chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"></polyline></svg>
+        </div>
+        <div class="section-body">
+          <div class="section-body-inner">
+            <p>Instructions coming soon.</p>
+          </div>
+        </div>
+      </section>
+
+      <section class="card workspace" id="workspace-section">
+        <div class="section-header" id="workspace-toggle">
+          <h2><span class="step-number">3</span>Library Workspace</h2>
+          <span class="flash-history" id="workspace-summary-header"></span>
+          <svg class="chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"></polyline></svg>
+        </div>
         <div class="workspace-shell">
           <div class="workspace-pane">
-            <h2><span class="step-number">2</span>Library Workspace</h2>
             <p class="workspace-copy">
               Bring books into the browser, convert them into <code>.rsvp</code>, and sync the
               results back into the SD card&rsquo;s <code>/books</code> folder without leaving this page.
@@ -867,6 +895,14 @@
         document.getElementById("install-section").classList.toggle("is-collapsed");
       });
 
+      document.getElementById("sdcard-toggle").addEventListener("click", function () {
+        document.getElementById("sdcard-section").classList.toggle("is-collapsed");
+      });
+
+      document.getElementById("workspace-toggle").addEventListener("click", function () {
+        document.getElementById("workspace-section").classList.toggle("is-collapsed");
+      });
+
       // Flash history tracking
       var FLASH_KEY = "rsvpnano_last_flash";
       var FLASH_VERSION = "1.0.3";
@@ -898,6 +934,16 @@
 
       showFlashHistory();
 
+      // Collapse install section for returning users
+      (function () {
+        try {
+          var data = JSON.parse(localStorage.getItem(FLASH_KEY));
+          if (data && data.timestamp) {
+            document.getElementById("install-section").classList.add("is-collapsed");
+          }
+        } catch (e) {}
+      })();
+
       (function () {
         try {
           var data = JSON.parse(localStorage.getItem(FLASH_KEY));
@@ -911,26 +957,32 @@
       new MutationObserver(function (mutations) {
         mutations.forEach(function (m) {
           m.addedNodes.forEach(function (node) {
-            if (node.nodeName === "EWT-INSTALL-DIALOG") {
-              node.addEventListener("closed", function () {
-                var success = false;
-                try {
-                  var shadow = node.shadowRoot;
-                  if (shadow) {
-                    var text = shadow.textContent || "";
-                    success = text.indexOf("Installation complete") !== -1
-                      || text.indexOf("DASHBOARD") !== -1;
-                  }
-                } catch (e) {}
-                if (success) {
+            if (node.nodeName !== "EWT-INSTALL-DIALOG") return;
+
+            var saved = false;
+            var pollTimer = setInterval(function () {
+              if (!document.body.contains(node)) {
+                clearInterval(pollTimer);
+                return;
+              }
+              if (saved) return;
+              try {
+                var shadow = node.shadowRoot;
+                if (!shadow) return;
+                var text = shadow.textContent || "";
+                if (text.indexOf("Installation complete") !== -1) {
+                  saved = true;
+                  clearInterval(pollTimer);
                   localStorage.setItem(FLASH_KEY, JSON.stringify({
                     version: FLASH_VERSION,
                     timestamp: Date.now()
                   }));
                   showFlashHistory();
                 }
-              }, { once: true });
-            }
+              } catch (e) {}
+            }, 500);
+
+            setTimeout(function () { clearInterval(pollTimer); }, 600000);
           });
         });
       }).observe(document.body, { childList: true });

--- a/web/index-2.html
+++ b/web/index-2.html
@@ -1,0 +1,939 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>RSVP Nano Web Flasher</title>
+    <script
+      type="module"
+      src="https://unpkg.com/esp-web-tools@10.1.0/dist/web/install-button.js?module"
+    ></script>
+    <script type="module" src="./library.js"></script>
+    <style>
+      :root {
+        --ink: #1d1711;
+        --muted: #75695c;
+        --paper: #f7efe2;
+        --panel: #fffaf1;
+        --accent: #d3542f;
+        --accent-deep: #842f20;
+        --line: #decdb7;
+        --shadow: rgba(73, 45, 24, 0.16);
+        --esp-tools-button-color: var(--accent);
+        --esp-tools-button-text-color: #fffaf1;
+        --esp-tools-button-border-radius: 999px;
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      body {
+        min-height: 100vh;
+        margin: 0;
+        color: var(--ink);
+        font-family: ui-serif, Georgia, Cambria, "Times New Roman", serif;
+        background:
+          radial-gradient(circle at 14% 16%, rgba(211, 84, 47, 0.18), transparent 30rem),
+          radial-gradient(circle at 88% 10%, rgba(132, 47, 32, 0.12), transparent 24rem),
+          linear-gradient(145deg, #fff8ed 0%, var(--paper) 46%, #eadac5 100%);
+      }
+
+      main {
+        width: min(1040px, calc(100% - 32px));
+        margin: 0 auto;
+        padding: 52px 0 44px;
+      }
+
+      .hero {
+        display: grid;
+        grid-template-columns: minmax(0, 1.2fr) minmax(280px, 0.8fr);
+        gap: 28px;
+        align-items: stretch;
+      }
+
+      .card {
+        border: 1px solid var(--line);
+        border-radius: 28px;
+        background: rgba(255, 250, 241, 0.86);
+        box-shadow: 0 24px 60px var(--shadow);
+        backdrop-filter: blur(16px);
+      }
+
+      .intro {
+        text-align: center;
+        padding: 4px;
+        margin-bottom: -28px;
+        position: relative;
+        z-index: 0;
+        opacity: 0.45;
+      }
+
+      .eyebrow {
+        margin: 0 0 16px;
+        color: var(--accent-deep);
+        font: 700 0.76rem/1.2 ui-sans-serif, system-ui, sans-serif;
+        letter-spacing: 0.18em;
+        text-transform: uppercase;
+      }
+
+      h1 {
+        margin: 0;
+        font-size: clamp(3.3rem, 10vw, 7.5rem);
+        line-height: 0.86;
+        letter-spacing: -0.075em;
+      }
+
+      .install-steps {
+        overflow: hidden;
+      }
+
+      .section-header {
+        display: flex;
+        align-items: center;
+        padding: 20px 18px 18px;
+        cursor: pointer;
+        user-select: none;
+      }
+
+      .section-header h2 {
+        flex: 1;
+        margin: 0;
+        padding: 0;
+        font-size: 1.05rem;
+      }
+
+      .flash-history {
+        margin-left: auto;
+        font: 0.78rem/1 ui-sans-serif, system-ui, sans-serif;
+        color: var(--muted);
+      }
+
+      .flash-history:empty {
+        display: none;
+      }
+
+      .chevron {
+        width: 20px;
+        height: 20px;
+        color: var(--muted);
+        transition: transform 200ms ease;
+        flex-shrink: 0;
+        margin-left: 12px;
+      }
+
+      .install-steps.is-collapsed .chevron {
+        transform: rotate(-90deg);
+      }
+
+      .section-body {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        align-items: start;
+        border-top: 1px solid var(--line);
+        transition: grid-template-rows 200ms ease;
+        grid-template-rows: 1fr;
+      }
+
+      .install-steps.is-collapsed .section-body {
+        grid-template-rows: 0fr;
+        border-top-color: transparent;
+      }
+
+      .section-body-inner {
+        overflow: hidden;
+        padding: 18px;
+      }
+
+      .install-steps.is-collapsed .section-body-inner {
+        padding-top: 0;
+        padding-bottom: 0;
+      }
+
+      .install {
+        padding: 28px;
+      }
+
+      .install-option-head {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+      }
+
+      .latest-badge {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        font: 700 0.76rem/1 ui-sans-serif, system-ui, sans-serif;
+        color: #2f5d32;
+      }
+
+      .pulse-dot {
+        width: 8px;
+        height: 8px;
+        border-radius: 50%;
+        background: #4c7a4a;
+        box-shadow: 0 0 0 0 rgba(76, 122, 74, 0.5);
+        animation: pulse 2s infinite;
+      }
+
+      @keyframes pulse {
+        0% { box-shadow: 0 0 0 0 rgba(76, 122, 74, 0.5); }
+        70% { box-shadow: 0 0 0 6px rgba(76, 122, 74, 0); }
+        100% { box-shadow: 0 0 0 0 rgba(76, 122, 74, 0); }
+      }
+
+      .feature-list {
+        margin: 0;
+        padding: 0;
+        list-style: none;
+      }
+
+      .feature-list li::before {
+        content: "✓";
+        margin-right: 6px;
+        color: var(--accent);
+        font-weight: 700;
+      }
+
+      .step-number {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 1.7em;
+        height: 1.7em;
+        margin-right: 10px;
+        border-radius: 50%;
+        background: var(--accent);
+        color: #fffaf1;
+        font: 800 0.82rem/1 ui-sans-serif, system-ui, sans-serif;
+        vertical-align: middle;
+        flex-shrink: 0;
+      }
+
+      .install h2,
+      .steps h2,
+      .workspace h2 {
+        display: flex;
+        align-items: center;
+        margin: 0;
+        font-size: 1.38rem;
+      }
+
+      .install p,
+      .steps p,
+      .section-body-inner p,
+      li {
+        color: var(--muted);
+        line-height: 1.5;
+      }
+
+      p {
+        margin: 0 0 1em;
+      }
+
+      .install-option {
+        display: grid;
+        gap: 12px;
+        margin-top: 0;
+        padding: 18px;
+        border: 1px solid var(--line);
+        border-radius: 20px;
+        background: rgba(255, 255, 255, 0.38);
+      }
+
+      .install-option strong {
+        font-size: 1.04rem;
+      }
+
+      esp-web-install-button {
+        margin-top: 4px;
+      }
+
+      button[slot="activate"] {
+        width: 100%;
+        border: 0;
+        border-radius: 999px;
+        padding: 13px 18px;
+        color: #fffaf1;
+        background: var(--accent);
+        font: 800 0.95rem/1 ui-sans-serif, system-ui, sans-serif;
+        cursor: pointer;
+        box-shadow: 0 12px 26px rgba(211, 84, 47, 0.24);
+      }
+
+      button[slot="activate"]:hover {
+        background: var(--accent-deep);
+      }
+
+      .warning {
+        margin-top: 16px;
+        padding: 14px 16px;
+        border-left: 4px solid var(--accent);
+        border-radius: 14px;
+        background: rgba(211, 84, 47, 0.08);
+        color: var(--accent-deep);
+        font-family: ui-sans-serif, system-ui, sans-serif;
+        font-size: 0.9rem;
+      }
+
+      .steps {
+        padding: 28px;
+        border-left: 1px solid var(--line);
+        background: linear-gradient(180deg, rgba(255, 255, 255, 0.28), rgba(255, 255, 255, 0.06));
+      }
+
+      .workspace {
+        margin-top: 28px;
+        padding: 0;
+        overflow: hidden;
+      }
+
+      .workspace-shell {
+        display: grid;
+        grid-template-columns: minmax(0, 1.08fr) minmax(320px, 0.92fr);
+      }
+
+      .workspace-pane {
+        padding: 28px;
+      }
+
+      .workspace-pane + .workspace-pane {
+        border-left: 1px solid var(--line);
+        background: linear-gradient(180deg, rgba(255, 255, 255, 0.28), rgba(255, 255, 255, 0.06));
+      }
+
+      .workspace h2,
+      .workspace h3 {
+        margin: 0;
+      }
+
+      .workspace h2 {
+        font-size: 1.38rem;
+      }
+
+      .workspace-copy {
+        margin: 12px 0 0;
+        color: var(--muted);
+      }
+
+      .toolbar {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 10px;
+        margin-top: 22px;
+        align-items: flex-start;
+      }
+
+      .tool-button,
+      .tool-select {
+        border: 1px solid var(--line);
+        border-radius: 999px;
+        background: rgba(255, 255, 255, 0.78);
+        color: var(--ink);
+        font: 700 0.93rem/1.15 ui-sans-serif, system-ui, sans-serif;
+      }
+
+      .tool-button {
+        padding: 12px 16px;
+        cursor: pointer;
+        max-width: 100%;
+        white-space: nowrap;
+      }
+
+      .tool-button:hover:enabled {
+        border-color: rgba(132, 47, 32, 0.42);
+        background: rgba(255, 250, 241, 0.98);
+      }
+
+      .tool-button:disabled,
+      .tool-select:disabled {
+        opacity: 0.55;
+        cursor: not-allowed;
+      }
+
+      .tool-button-primary {
+        border-color: transparent;
+        color: #fffaf1;
+        background: var(--accent);
+        box-shadow: 0 12px 26px rgba(211, 84, 47, 0.24);
+      }
+
+      .tool-button-primary:hover:enabled {
+        background: var(--accent-deep);
+      }
+
+      .tool-select {
+        min-width: 220px;
+        padding: 11px 16px;
+      }
+
+      .dropzone {
+        display: block;
+        margin-top: 22px;
+        padding: 24px;
+        border: 1.5px dashed rgba(132, 47, 32, 0.34);
+        border-radius: 24px;
+        background:
+          linear-gradient(180deg, rgba(255, 255, 255, 0.58), rgba(255, 255, 255, 0.2)),
+          radial-gradient(circle at top right, rgba(211, 84, 47, 0.14), transparent 16rem);
+        overflow: hidden;
+        transition:
+          border-color 150ms ease,
+          transform 150ms ease,
+          box-shadow 150ms ease;
+      }
+
+      .dropzone.is-active {
+        border-color: var(--accent);
+        box-shadow: inset 0 0 0 1px rgba(211, 84, 47, 0.2);
+        transform: translateY(-1px);
+      }
+
+      .dropzone strong {
+        display: block;
+        font-size: 1.04rem;
+      }
+
+      .dropzone p {
+        margin: 10px 0 0;
+        color: var(--muted);
+      }
+
+      .meta-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+        gap: 12px;
+        margin-top: 20px;
+      }
+
+      .meta-card {
+        min-width: 0;
+        padding: 16px 18px;
+        border: 1px solid var(--line);
+        border-radius: 18px;
+        background: rgba(255, 255, 255, 0.42);
+      }
+
+      .meta-card span {
+        display: block;
+        color: var(--muted);
+        font: 700 0.73rem/1.2 ui-sans-serif, system-ui, sans-serif;
+        letter-spacing: 0.1em;
+        text-transform: uppercase;
+      }
+
+      .meta-card strong {
+        display: block;
+        margin-top: 8px;
+        font-size: 1.03rem;
+        line-height: 1.24;
+        overflow-wrap: anywhere;
+      }
+
+      .meta-card-copy {
+        margin: 8px 0 0;
+        color: var(--muted);
+        font-size: 0.9rem;
+        line-height: 1.4;
+        overflow-wrap: anywhere;
+      }
+
+      .inline-note {
+        margin-top: 18px;
+        padding: 14px 16px;
+        border-radius: 16px;
+        background: rgba(117, 105, 92, 0.1);
+        color: var(--muted);
+        font-size: 0.92rem;
+        line-height: 1.5;
+        overflow-wrap: anywhere;
+      }
+
+      .workspace-status {
+        margin-top: 20px;
+        padding: 15px 16px;
+        border-left: 4px solid var(--line);
+        border-radius: 16px;
+        background: rgba(255, 255, 255, 0.5);
+        color: var(--muted);
+        min-height: 66px;
+        overflow-wrap: anywhere;
+      }
+
+      .workspace-status[data-tone="busy"] {
+        border-left-color: var(--accent);
+        color: var(--accent-deep);
+        background: rgba(211, 84, 47, 0.08);
+      }
+
+      .workspace-status[data-tone="error"] {
+        border-left-color: #9c3024;
+        color: #8e241a;
+        background: rgba(156, 48, 36, 0.08);
+      }
+
+      .workspace-status[data-tone="success"] {
+        border-left-color: #4c7a4a;
+        color: #2f5d32;
+        background: rgba(76, 122, 74, 0.1);
+      }
+
+      .workspace-status strong {
+        display: block;
+        margin-bottom: 6px;
+        color: var(--ink);
+        font-size: 0.96rem;
+      }
+
+      .library-list {
+        display: grid;
+        gap: 14px;
+        margin: 20px 0 0;
+        padding: 0;
+        list-style: none;
+      }
+
+      .library-item {
+        padding: 18px;
+        border: 1px solid var(--line);
+        border-radius: 22px;
+        background: rgba(255, 255, 255, 0.62);
+      }
+
+      .library-item-head,
+      .library-item-meta,
+      .library-item-actions {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 10px;
+        align-items: center;
+      }
+
+      .library-item-head {
+        justify-content: space-between;
+        align-items: flex-start;
+        gap: 12px;
+      }
+
+      .library-item-title {
+        display: grid;
+        gap: 6px;
+        min-width: 0;
+      }
+
+      .library-item-title strong {
+        font-size: 1.02rem;
+      }
+
+      .library-item-title span,
+      .library-item-copy,
+      .library-empty {
+        color: var(--muted);
+      }
+
+      .library-item-meta {
+        margin-top: 14px;
+      }
+
+      .pill {
+        padding: 0.42rem 0.72rem;
+        border-radius: 999px;
+        background: rgba(132, 47, 32, 0.08);
+        color: var(--accent-deep);
+        font: 700 0.76rem/1 ui-sans-serif, system-ui, sans-serif;
+        letter-spacing: 0.02em;
+      }
+
+      .pill[data-state="ready"] {
+        background: rgba(76, 122, 74, 0.12);
+        color: #2f5d32;
+      }
+
+      .pill[data-state="error"] {
+        background: rgba(156, 48, 36, 0.1);
+        color: #8e241a;
+      }
+
+      .pill[data-state="working"] {
+        background: rgba(211, 84, 47, 0.12);
+        color: var(--accent-deep);
+      }
+
+      .library-item-copy {
+        margin-top: 12px;
+        line-height: 1.5;
+        overflow-wrap: anywhere;
+      }
+
+      .library-item-actions {
+        margin-top: 16px;
+      }
+
+      .library-item-actions .tool-button {
+        padding: 10px 14px;
+        font-size: 0.86rem;
+      }
+
+      .library-empty {
+        margin-top: 20px;
+        padding: 26px 20px;
+        border: 1px dashed var(--line);
+        border-radius: 22px;
+        text-align: center;
+        background: rgba(255, 255, 255, 0.36);
+      }
+
+      ol {
+        padding-left: 1.35rem;
+      }
+
+      code {
+        padding: 0.12em 0.35em;
+        border-radius: 0.4em;
+        background: rgba(132, 47, 32, 0.1);
+        color: var(--accent-deep);
+      }
+
+      footer {
+        margin-top: 24px;
+        color: var(--muted);
+        text-align: center;
+        font: 0.9rem/1.4 ui-sans-serif, system-ui, sans-serif;
+      }
+
+      @media (max-width: 980px) {
+        .section-body {
+          grid-template-columns: 1fr;
+        }
+
+        .workspace-shell {
+          grid-template-columns: 1fr;
+        }
+
+        .workspace-pane + .workspace-pane {
+          border-left: 0;
+          border-top: 1px solid var(--line);
+        }
+      }
+
+      @media (max-width: 760px) {
+        main {
+          width: min(100% - 20px, 560px);
+          padding-top: 18px;
+        }
+
+        .section-body {
+          grid-template-columns: 1fr;
+        }
+
+        .meta-grid {
+          grid-template-columns: 1fr;
+        }
+
+        .install,
+        .steps,
+        .workspace-pane {
+          padding: 22px;
+        }
+      }
+
+      .compat-overlay {
+        position: fixed;
+        inset: 0;
+        z-index: 1000;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 16px;
+        background: rgba(29, 23, 17, 0.55);
+        backdrop-filter: blur(4px);
+      }
+
+      .compat-overlay[hidden] {
+        display: none;
+      }
+
+      .compat-modal {
+        max-width: 480px;
+        width: 100%;
+        padding: clamp(24px, 5vw, 40px);
+        border: 1px solid var(--line);
+        border-radius: 28px;
+        background: rgba(255, 250, 241, 0.86);
+        box-shadow: 0 24px 60px var(--shadow);
+        backdrop-filter: blur(16px);
+        text-align: left;
+      }
+
+      .compat-modal h2 {
+        margin: 0 0 12px;
+        font-size: 1.3rem;
+      }
+
+      .compat-modal p {
+        color: var(--muted);
+        line-height: 1.55;
+        margin: 0 0 10px;
+      }
+
+      .compat-dismiss {
+        margin-top: 20px;
+        padding: 13px 28px;
+        border: 0;
+        border-radius: 999px;
+        color: #fffaf1;
+        background: var(--accent);
+        font: 800 0.95rem/1 ui-sans-serif, system-ui, sans-serif;
+        cursor: pointer;
+        box-shadow: 0 12px 26px rgba(211, 84, 47, 0.24);
+      }
+
+      .compat-dismiss:hover {
+        background: var(--accent-deep);
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <div class="intro">
+        <p class="eyebrow">Browser firmware installer</p>
+        <h1>RSVP Nano</h1>
+      </div>
+
+      <section class="card install-steps" id="install-section">
+        <div class="section-header" id="install-toggle">
+          <h2><span class="step-number">1</span>Install Firmware</h2>
+          <span class="flash-history" id="flash-history"></span>
+          <svg class="chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"></polyline></svg>
+        </div>
+
+        <div class="section-body">
+          <div class="section-body-inner">
+            <p>Flashing takes under a minute.<br>Put the device in boot mode first:</p>
+            <ol>
+              <li>Turn the device off</li>
+              <li>Keep pressed <code>BOOT</code> (sun icon button)</li>
+              <li>Connect the USB cable</li>
+            </ol>
+          </div>
+
+          <div class="section-body-inner">
+            <div class="install-option">
+              <div class="install-option-head">
+                <strong>Version 1.0.3</strong>
+                <span class="latest-badge"><span class="pulse-dot"></span>Latest Release</span>
+              </div>
+              <ul class="feature-list">
+                <li>On-device EPUB conversion</li>
+                <li>USB SD-card transfer mode</li>
+                <li>Extended-Latin character support</li>
+              </ul>
+              <esp-web-install-button manifest="firmware/manifest.json">
+                <button slot="activate">Install Firmware</button>
+                <span slot="unsupported">Use Chrome or Edge on desktop with Web Serial support.</span>
+                <span slot="not-allowed">This page must be opened over HTTPS or localhost.</span>
+              </esp-web-install-button>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="card workspace">
+        <div class="workspace-shell">
+          <div class="workspace-pane">
+            <h2><span class="step-number">2</span>Library Workspace</h2>
+            <p class="workspace-copy">
+              Bring books into the browser, convert them into <code>.rsvp</code>, and sync the
+              results back into the SD card&rsquo;s <code>/books</code> folder without leaving this page.
+            </p>
+
+            <div class="toolbar">
+              <button class="tool-button tool-button-primary" id="library-add-button" type="button">
+                Add Books
+              </button>
+              <button class="tool-button" id="library-folder-button" type="button">
+                Choose /books Folder
+              </button>
+              <button class="tool-button" id="library-folder-import-button" type="button">
+                Import From Folder
+              </button>
+              <button class="tool-button" id="library-folder-clean-button" type="button">
+                Clean Sidecars
+              </button>
+              <button class="tool-button" id="library-download-button" type="button">
+                Download .zip
+              </button>
+              <button class="tool-button" id="library-sync-button" type="button">
+                Sync To Folder
+              </button>
+              <button class="tool-button" id="library-clear-button" type="button">
+                Clear Library
+              </button>
+            </div>
+
+            <label class="dropzone" id="library-dropzone" for="library-file-input">
+              <strong>Drop supported books here</strong>
+              <p>
+                EPUB, TXT, Markdown, and HTML sources are converted locally in your browser. Nothing
+                is uploaded to a server.
+              </p>
+            </label>
+            <input
+              id="library-file-input"
+              type="file"
+              accept=".epub,.txt,.md,.markdown,.html,.htm,.xhtml"
+              multiple
+              hidden
+            />
+
+            <div class="meta-grid">
+              <div class="meta-card">
+                <span>Compatibility</span>
+                <strong>Automatic extended-Latin output</strong>
+                <p class="meta-card-copy">
+                  Preserves common accented, Baltic, Sami, and other extended-Latin letters while
+                  staying friendly to the current firmware.
+                </p>
+              </div>
+              <div class="meta-card">
+                <span>Selected Folder</span>
+                <strong id="library-folder-label">No /books folder selected</strong>
+              </div>
+              <div class="meta-card">
+                <span>Library Summary</span>
+                <strong id="library-summary">0 converted books ready</strong>
+              </div>
+              <div class="meta-card">
+                <span>Folder Inventory</span>
+                <strong id="library-folder-summary">Pick the SD card&rsquo;s /books folder to scan it</strong>
+              </div>
+            </div>
+
+            <p class="inline-note">
+              Everything is converted locally in your browser. Pick the SD card&rsquo;s
+              <code>/books</code> folder if you want one-click import, cleanup, and sync.
+            </p>
+
+            <div class="workspace-status" id="library-status" data-tone="info">
+              <strong>Ready to build a library</strong>
+              Add files from your computer or pick the SD card&rsquo;s <code>/books</code> folder to bring
+              supported source books into the workspace.
+            </div>
+          </div>
+
+          <div class="workspace-pane">
+            <h3>Converted Books</h3>
+            <p class="workspace-copy">
+              Each imported source is turned into a reader-ready <code>.rsvp</code> file so you can
+              download it or sync everything back to the selected folder in one step.
+            </p>
+
+            <ul class="library-list" id="library-list"></ul>
+            <div class="library-empty" id="library-empty">
+              Add a few books and the converted library will appear here.
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <footer>
+        RSVP Nano is open source. Build it, modify it, improve it, and share what you make.
+      </footer>
+      <div class="compat-overlay" id="compat-modal" hidden>
+        <div class="compat-modal">
+          <h2>Browser Not Supported</h2>
+          <p>
+            The firmware installer requires the Web Serial API, available in
+            <strong>Chrome</strong> or <strong>Edge</strong> on macOS, Windows, Linux, or ChromeOS.
+          </p>
+          <p>
+            Safari, Firefox, and all mobile browsers do not currently support Web Serial.
+            You can still use the <strong>Library Workspace</strong> below to convert books.
+          </p>
+          <button class="compat-dismiss" id="compat-dismiss">Got It</button>
+        </div>
+      </div>
+    </main>
+    <script>
+      if (!("serial" in navigator)) {
+        document.getElementById("compat-modal").hidden = false;
+        document.getElementById("compat-dismiss").addEventListener("click", function () {
+          document.getElementById("compat-modal").hidden = true;
+        });
+      }
+
+      document.getElementById("install-toggle").addEventListener("click", function () {
+        document.getElementById("install-section").classList.toggle("is-collapsed");
+      });
+
+      // Flash history tracking
+      var FLASH_KEY = "rsvpnano_last_flash";
+      var FLASH_VERSION = "1.0.3";
+
+      function timeAgo(ts) {
+        var s = Math.floor((Date.now() - ts) / 1000);
+        if (s < 60) return "just now";
+        var m = Math.floor(s / 60);
+        if (m < 60) return m + (m === 1 ? " minute ago" : " minutes ago");
+        var h = Math.floor(m / 60);
+        if (h < 24) return h + (h === 1 ? " hour ago" : " hours ago");
+        var d = Math.floor(h / 24);
+        return d + (d === 1 ? " day ago" : " days ago");
+      }
+
+      function showFlashHistory() {
+        var el = document.getElementById("flash-history");
+        try {
+          var data = JSON.parse(localStorage.getItem(FLASH_KEY));
+          if (data && data.timestamp) {
+            el.textContent = "v" + data.version + " flashed " + timeAgo(data.timestamp);
+          } else {
+            el.textContent = "No installations in history";
+          }
+        } catch (e) {
+          el.textContent = "No installations in history";
+        }
+      }
+
+      showFlashHistory();
+
+      (function () {
+        try {
+          var data = JSON.parse(localStorage.getItem(FLASH_KEY));
+          if (data && data.version && data.version !== FLASH_VERSION) {
+            var btn = document.querySelector('button[slot="activate"]');
+            if (btn) btn.textContent = "Update Firmware";
+          }
+        } catch (e) {}
+      })();
+
+      new MutationObserver(function (mutations) {
+        mutations.forEach(function (m) {
+          m.addedNodes.forEach(function (node) {
+            if (node.nodeName === "EWT-INSTALL-DIALOG") {
+              node.addEventListener("closed", function () {
+                var success = false;
+                try {
+                  var shadow = node.shadowRoot;
+                  if (shadow) {
+                    var text = shadow.textContent || "";
+                    success = text.indexOf("Installation complete") !== -1
+                      || text.indexOf("DASHBOARD") !== -1;
+                  }
+                } catch (e) {}
+                if (success) {
+                  localStorage.setItem(FLASH_KEY, JSON.stringify({
+                    version: FLASH_VERSION,
+                    timestamp: Date.now()
+                  }));
+                  showFlashHistory();
+                }
+              }, { once: true });
+            }
+          });
+        });
+      }).observe(document.body, { childList: true });
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary

- Introduces `SettingsFile` backed by ArduinoJson to persist all user preferences to `/settings.json` on the SD card
- On boot, if the SD card is mounted, settings are loaded from JSON and synced back to NVS (missing keys fall back to current NVS values)
- Every user preference change marks the settings dirty; a 2-second debounce timer flushes changes to SD in the background
- Settings are force-flushed to SD on power-off and sleep entry to prevent data loss
- Adds `isMounted()` accessor to `StorageManager`
- Adds `bblanchon/ArduinoJson@^7` dependency to `platformio.ini`

## Test plan

- [ ] Change brightness/theme/language/WPM and verify `/settings.json` is written to SD after ~2s
- [ ] Power off and back on; confirm all settings are restored from SD
- [ ] Remove SD card and verify device boots normally using NVS values
- [ ] Flash to a second device with the same SD card; verify settings transfer correctly
- [ ] Verify book positions are restored from SD into NVS on first boot