### PR TITLE
Add internet radio with NYC-area stations, Wi-Fi streaming, and touch controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ RSVP Nano is an open-source ESP32-S3 reading device for showing text one word at
 - Menu language selection for English, Spanish, French, German, Romanian, and Polish.
 - Chapter and paragraph-aware navigation.
 - SD card library under `/books`.
+- Internet radio with NYC-area FM/AM stations, SomaFM streams, swipe-to-tune, and volume control.
 - Web-first book conversion and SD-card library sync from the browser flasher.
 - Optional GitHub Release OTA updates over Wi-Fi with on-device network setup and touch keyboard entry.
 - USB mass-storage mode for copying books to the SD card.
@@ -227,12 +228,31 @@ Main Menu
 |     |- Back
 |     |- Network
 |     |- Choose network
+|     |- Test connection
 |     |- Auto OTA
 |     `- Forget network
 |  `- Firmware update
+|- Radio
 |- USB transfer (default USB build)
 `- Power off
 ```
+
+### Radio
+
+Open `Radio` from the main menu to start the internet radio player. The radio connects to
+Wi-Fi using the credentials saved in `Settings -> Wi-Fi` and streams audio through the
+on-board speaker.
+
+- Tap: play or pause the current station.
+- Swipe left or right: tune to the previous or next station.
+- Swipe up or down: adjust volume.
+- Long-press: toggle between FM and AM bands.
+
+FM presets include NYC-area stations (WNYC, HOT 97, Z100, KTU, WQXR, WBLS) and NPR national.
+AM presets include WNYC AM, WCBS, WINS, and several SomaFM streams.
+
+The radio, band, station, and volume selections are saved automatically and restored on next
+launch.
 
 ### Settings Reference
 
@@ -267,6 +287,7 @@ Main Menu
 
 - `Network`: shows the currently saved SSID and also acts as a shortcut into a fresh scan.
 - `Choose network`: scan nearby SSIDs and open the on-device keyboard for secure networks.
+- `Test connection`: connect to the saved network, show the result, and disconnect.
 - `Auto OTA`: check `releases/latest` during boot when Wi-Fi credentials are available.
 - `Forget network`: clear the stored Wi-Fi credentials from `Preferences`.
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -12,12 +12,20 @@ build_flags =
   -DCORE_DEBUG_LEVEL=3
   -DRSVP_ON_DEVICE_EPUB_CONVERSION=1
 
+[device_common]
+lib_deps =
+  https://github.com/schreibfaul1/ESP32-audioI2S.git#3.0.8
+
 [env:waveshare_esp32s3]
+lib_deps =
+  ${device_common.lib_deps}
 build_flags =
   ${env.build_flags}
   -DRSVP_USB_TRANSFER_ENABLED=0
 
 [env:waveshare_esp32s3_usb_msc]
+lib_deps =
+  ${device_common.lib_deps}
 build_flags =
   ${env.build_flags}
   -DARDUINO_USB_MODE=0

--- a/src/app/App.cpp
+++ b/src/app/App.cpp
@@ -60,6 +60,7 @@ enum MenuItem : size_t {
   MenuChapters,
   MenuChangeBook,
   MenuFocusTimer,
+  MenuRadio,
   MenuSettings,
 #if RSVP_USB_TRANSFER_ENABLED
   MenuUsbTransfer,
@@ -123,8 +124,9 @@ constexpr size_t kSettingsPacingPunctuationIndex = 3;
 constexpr size_t kSettingsPacingResetIndex = 4;
 constexpr size_t kWifiSettingsNetworkIndex = 1;
 constexpr size_t kWifiSettingsChooseIndex = 2;
-constexpr size_t kWifiSettingsAutoUpdateIndex = 3;
-constexpr size_t kWifiSettingsForgetIndex = 4;
+constexpr size_t kWifiSettingsTestIndex = 3;
+constexpr size_t kWifiSettingsAutoUpdateIndex = 4;
+constexpr size_t kWifiSettingsForgetIndex = 5;
 
 constexpr size_t kBookPickerBackIndex = 0;
 constexpr size_t kChapterPickerBackIndex = 0;
@@ -162,6 +164,10 @@ constexpr const char *kPrefRecentSeq = "seq";
 constexpr const char *kPrefWifiSsid = "wifi_ssid";
 constexpr const char *kPrefWifiPass = "wifi_pass";
 constexpr const char *kPrefOtaAuto = "ota_auto";
+constexpr const char *kPrefRadioBand = "rad_band";
+constexpr const char *kPrefRadioFmIdx = "rad_fm";
+constexpr const char *kPrefRadioAmIdx = "rad_am";
+constexpr const char *kPrefRadioVol = "rad_vol";
 constexpr size_t kReaderFontSizeCount = 3;
 constexpr size_t kPhantomBeforeCharTargets[] = {64, 96, 144};
 constexpr size_t kPhantomAfterCharTargets[] = {96, 144, 208};
@@ -482,6 +488,7 @@ void App::begin() {
   touchInitialized_ = touch_.begin();
   audio_.begin();
   focusTimer_.begin();
+  restoreRadioPreferences();
 
 #if RSVP_USB_TRANSFER_ENABLED && RSVP_USB_TRANSFER_AUTO_START
   state_ = AppState::Booting;
@@ -531,6 +538,7 @@ void App::update(uint32_t nowMs) {
   const bool batteryChanged = updateBatteryStatus(nowMs);
   updateState(nowMs);
   updateFocusTimer(nowMs);
+  updateRadio(nowMs);
   updateReader(nowMs);
   handleTouch(nowMs);
   updateWpmFeedback(nowMs);
@@ -778,6 +786,10 @@ void App::toggleMenuFromPowerButton(uint32_t nowMs) {
     } else {
       if (isFocusTimerMenuScreen(menuScreen_)) {
         resetFocusTimer();
+      }
+      if (menuScreen_ == MenuScreen::RadioPlayer) {
+        radio_.stop();
+        saveRadioPreferences();
       }
       menuScreen_ = MenuScreen::Main;
       renderMainMenu();
@@ -1171,6 +1183,8 @@ void App::handleTouch(uint32_t nowMs) {
   if (state_ == AppState::Menu) {
     if (menuScreen_ == MenuScreen::FocusTimerSession) {
       applyFocusTimerTouch(ev, nowMs);
+    } else if (menuScreen_ == MenuScreen::RadioPlayer) {
+      applyRadioTouch(ev, nowMs);
     } else {
       applyMenuTouchGesture(ev, nowMs);
     }
@@ -1724,6 +1738,9 @@ void App::moveMenuSelection(int direction) {
       case MenuFocusTimer:
         selectedLabel = "Focus Timer";
         break;
+      case MenuRadio:
+        selectedLabel = "Radio";
+        break;
       case MenuSettings:
         selectedLabel = uiText(UiText::Settings);
         break;
@@ -1775,6 +1792,9 @@ void App::selectMenuItem(uint32_t nowMs) {
   if (menuScreen_ == MenuScreen::FocusTimerSession) {
     return;
   }
+  if (menuScreen_ == MenuScreen::RadioPlayer) {
+    return;
+  }
 
   switch (menuSelectedIndex_) {
     case MenuResume:
@@ -1796,6 +1816,9 @@ void App::selectMenuItem(uint32_t nowMs) {
       return;
     case MenuFocusTimer:
       openFocusTimer();
+      return;
+    case MenuRadio:
+      openRadio();
       return;
     case MenuSettings:
       openSettings();
@@ -1953,6 +1976,45 @@ void App::selectWifiSettingsItem(uint32_t nowMs) {
     case kWifiSettingsChooseIndex:
       scanWifiNetworks();
       return;
+    case kWifiSettingsTestIndex: {
+      const OtaUpdater::Config otaCfg = preferredOtaConfig();
+      if (otaCfg.wifiSsid.isEmpty()) {
+        display_.renderStatus("Wi-Fi", "No network saved", "");
+        delay(1200);
+        renderSettings();
+        return;
+      }
+      display_.renderProgress("Wi-Fi", "Connecting...", otaCfg.wifiSsid, 10);
+      WiFi.persistent(false);
+      WiFi.setAutoReconnect(false);
+      WiFi.mode(WIFI_STA);
+      WiFi.begin(otaCfg.wifiSsid.c_str(), otaCfg.wifiPassword.c_str());
+      const uint32_t startMs = millis();
+      constexpr uint32_t kTestTimeoutMs = 12000;
+      bool connected = false;
+      while (millis() - startMs < kTestTimeoutMs) {
+        if (WiFi.status() == WL_CONNECTED) {
+          connected = true;
+          break;
+        }
+        const uint32_t elapsed = millis() - startMs;
+        const int progress = 10 + static_cast<int>((elapsed * 80) / kTestTimeoutMs);
+        display_.renderProgress("Wi-Fi", "Connecting...", otaCfg.wifiSsid, progress);
+        delay(200);
+      }
+      if (connected) {
+        const String ipStr = WiFi.localIP().toString();
+        display_.renderStatus("Wi-Fi", "Connected!", ipStr);
+      } else {
+        display_.renderStatus("Wi-Fi", "Connection failed", "Check password");
+      }
+      WiFi.disconnect(true, false);
+      WiFi.mode(WIFI_OFF);
+      delay(2000);
+      rebuildSettingsMenuItems();
+      renderSettings();
+      return;
+    }
     case kWifiSettingsAutoUpdateIndex:
       preferences_.putBool(kPrefOtaAuto, !otaAutoCheckEnabled());
       rebuildSettingsMenuItems();
@@ -2450,6 +2512,7 @@ void App::rebuildSettingsMenuItems() {
     settingsMenuItems_.push_back(uiText(UiText::Back));
     settingsMenuItems_.push_back("Network: " + storedOrFallbackLabel(configuredWifiSsid(), "Not set"));
     settingsMenuItems_.push_back("Choose network");
+    settingsMenuItems_.push_back("Test connection");
     settingsMenuItems_.push_back("Auto OTA: " + String(otaAutoCheckEnabled() ? "On" : "Off"));
     settingsMenuItems_.push_back("Forget network");
   }
@@ -3209,6 +3272,8 @@ void App::renderMenu() {
     renderFocusTimerGenres();
   } else if (menuScreen_ == MenuScreen::FocusTimerSession) {
     renderFocusTimerSession();
+  } else if (menuScreen_ == MenuScreen::RadioPlayer) {
+    renderRadioPlayer();
   } else {
     renderMainMenu();
   }
@@ -3221,6 +3286,7 @@ void App::renderMainMenu() {
   items.push_back(uiText(UiText::Chapters));
   items.push_back(uiText(UiText::Library));
   items.push_back("Focus Timer");
+  items.push_back("Radio");
   items.push_back(uiText(UiText::Settings));
 #if RSVP_USB_TRANSFER_ENABLED
   items.push_back(uiText(UiText::UsbTransfer));
@@ -3546,6 +3612,172 @@ void App::playFocusTimerCompletionCue() {
     digitalWrite(BoardConfig::PIN_LCD_BACKLIGHT, LOW);
     delay(45);
   }
+}
+
+void App::openRadio() {
+  /* release beep I2S so the Audio library can claim the port,
+     then re-configure the ES8311 codec for streaming output */
+  audio_.releaseI2s();
+  audio_.prepareCodecForStreaming();
+  menuScreen_ = MenuScreen::RadioPlayer;
+  renderRadioPlayer();
+}
+
+void App::updateRadio(uint32_t nowMs) {
+  if (state_ != AppState::Menu || menuScreen_ != MenuScreen::RadioPlayer) {
+    return;
+  }
+
+  radio_.update();
+  renderRadioPlayer();
+}
+
+void App::applyRadioTouch(const TouchEvent &event, uint32_t nowMs) {
+  if (event.phase == TouchPhase::Start) {
+    pausedTouch_.active = true;
+    pausedTouch_.startX = event.x;
+    pausedTouch_.startY = event.y;
+    pausedTouch_.lastX = event.x;
+    pausedTouch_.lastY = event.y;
+    pausedTouch_.startMs = nowMs;
+    pausedTouch_.lastMs = nowMs;
+    return;
+  }
+
+  if (!pausedTouch_.active) {
+    return;
+  }
+
+  pausedTouch_.lastX = event.x;
+  pausedTouch_.lastY = event.y;
+  pausedTouch_.lastMs = nowMs;
+
+  if (event.phase != TouchPhase::End) {
+    return;
+  }
+
+  pausedTouch_.active = false;
+
+  const int deltaX = static_cast<int>(pausedTouch_.lastX) - static_cast<int>(pausedTouch_.startX);
+  const int deltaY = static_cast<int>(pausedTouch_.lastY) - static_cast<int>(pausedTouch_.startY);
+  const int absDeltaX = abs(deltaX);
+  const int absDeltaY = abs(deltaY);
+  const bool tapLike = absDeltaX <= static_cast<int>(kTapSlopPx) &&
+                       absDeltaY <= static_cast<int>(kTapSlopPx);
+  const uint32_t holdMs = nowMs - pausedTouch_.startMs;
+
+  /* long-press toggles AM/FM band (checked before tap) */
+  if (tapLike && holdMs >= 600) {
+    radio_.toggleBand();
+    saveRadioPreferences();
+    renderRadioPlayer();
+    return;
+  }
+
+  if (tapLike) {
+    /* short tap toggles play/pause */
+    if (radio_.isPlaying()) {
+      radio_.pause();
+    } else {
+      OtaUpdater::Config otaCfg = preferredOtaConfig();
+      radio_.play(otaCfg.wifiSsid, otaCfg.wifiPassword);
+    }
+    renderRadioPlayer();
+    return;
+  }
+
+  const bool horizontalSwipe = absDeltaX > absDeltaY + static_cast<int>(kAxisBiasPx);
+  const bool verticalSwipe = absDeltaY > absDeltaX + static_cast<int>(kAxisBiasPx);
+
+  if (horizontalSwipe && absDeltaX >= static_cast<int>(kSwipeThresholdPx)) {
+    if (deltaX > 0) {
+      radio_.tuneNext();
+    } else {
+      radio_.tunePrevious();
+    }
+    saveRadioPreferences();
+    renderRadioPlayer();
+    return;
+  }
+
+  if (verticalSwipe && absDeltaY >= static_cast<int>(kSwipeThresholdPx)) {
+    if (deltaY < 0) {
+      radio_.adjustVolume(1);
+    } else {
+      radio_.adjustVolume(-1);
+    }
+    saveRadioPreferences();
+    renderRadioPlayer();
+    return;
+  }
+}
+
+void App::renderRadioPlayer() {
+  applyReaderUiOrientation();
+
+  const char *bandStr = (radio_.band() == InternetRadio::Band::FM) ? "FM" : "AM";
+
+  /* format frequency string */
+  char freqBuf[16];
+  float freq = radio_.frequency();
+  if (radio_.band() == InternetRadio::Band::FM) {
+    snprintf(freqBuf, sizeof(freqBuf), "%.1f", freq);
+  } else {
+    snprintf(freqBuf, sizeof(freqBuf), "%.0f", freq);
+  }
+
+  const char *stationName = radio_.stationName();
+
+  /* status line */
+  const char *statusStr = "";
+  switch (radio_.state()) {
+    case InternetRadio::State::Idle:
+      statusStr = "Tap to play";
+      break;
+    case InternetRadio::State::WifiConnecting:
+      statusStr = "Connecting to Wi-Fi...";
+      break;
+    case InternetRadio::State::Connecting:
+      statusStr = "Tuning in...";
+      break;
+    case InternetRadio::State::Playing:
+      statusStr = "< tune >   ^ vol `";
+      break;
+    case InternetRadio::State::Buffering:
+      statusStr = "Buffering...";
+      break;
+    case InternetRadio::State::NoCredentials:
+      statusStr = "Set Wi-Fi in Settings";
+      break;
+    case InternetRadio::State::WifiError:
+      statusStr = "Wi-Fi connect failed";
+      break;
+    case InternetRadio::State::StreamError:
+      statusStr = "Stream unavailable";
+      break;
+  }
+
+  uint8_t volPercent = static_cast<uint8_t>((static_cast<int>(radio_.volume()) * 100) / 10);
+
+  display_.renderRadioScreen(String(bandStr), String(freqBuf), String(stationName),
+                             String(statusStr), volPercent, radio_.isPlaying());
+}
+
+void App::saveRadioPreferences() {
+  preferences_.putUChar(kPrefRadioBand, static_cast<uint8_t>(radio_.band()));
+  preferences_.putUChar(kPrefRadioFmIdx, radio_.savedFmIndex());
+  preferences_.putUChar(kPrefRadioAmIdx, radio_.savedAmIndex());
+  preferences_.putUChar(kPrefRadioVol, radio_.volume());
+}
+
+void App::restoreRadioPreferences() {
+  const uint8_t band = preferences_.getUChar(kPrefRadioBand, 0);
+  const uint8_t fmIdx = preferences_.getUChar(kPrefRadioFmIdx, 0);
+  const uint8_t amIdx = preferences_.getUChar(kPrefRadioAmIdx, 0);
+  const uint8_t vol = preferences_.getUChar(kPrefRadioVol, 12);
+  radio_.restoreTuning(
+      (band == 1) ? InternetRadio::Band::AM : InternetRadio::Band::FM,
+      fmIdx, amIdx, vol);
 }
 
 bool App::scrollModeEnabled() const { return readerMode_ == ReaderMode::Scroll; }

--- a/src/app/App.h
+++ b/src/app/App.h
@@ -10,6 +10,7 @@
 #include "display/DisplayManager.h"
 #include "input/ButtonHandler.h"
 #include "input/TouchHandler.h"
+#include "radio/InternetRadio.h"
 #include "reader/ReadingLoop.h"
 #include "storage/StorageManager.h"
 #include "timer/FocusTimer.h"
@@ -69,6 +70,7 @@ class App {
     RestartConfirm,
     FocusTimerGenres,
     FocusTimerSession,
+    RadioPlayer,
   };
 
   enum class FooterMetricMode : uint8_t {
@@ -173,6 +175,12 @@ class App {
   void openFocusTimer();
   void updateFocusTimer(uint32_t nowMs);
   void resetFocusTimer();
+  void openRadio();
+  void updateRadio(uint32_t nowMs);
+  void applyRadioTouch(const TouchEvent &event, uint32_t nowMs);
+  void renderRadioPlayer();
+  void saveRadioPreferences();
+  void restoreRadioPreferences();
   void rebuildFocusTimerGenreMenuItems();
   void selectFocusTimerGenre(uint32_t nowMs);
   void openSettings();
@@ -293,6 +301,7 @@ class App {
   AppState state_ = AppState::Booting;
   DisplayManager display_;
   AudioManager audio_;
+  InternetRadio radio_;
   FocusTimer focusTimer_;
   ReadingLoop reader_;
   ButtonHandler button_;

--- a/src/audio/AudioManager.cpp
+++ b/src/audio/AudioManager.cpp
@@ -100,6 +100,34 @@ bool AudioManager::beep() {
 
 bool AudioManager::available() const { return available_; }
 
+void AudioManager::releaseI2s() {
+  if (!i2sInitialized_) {
+    return;
+  }
+
+  i2s_driver_uninstall(kI2sPort);
+  i2sInitialized_ = false;
+}
+
+bool AudioManager::prepareCodecForStreaming() {
+  if (!enableAudioRail()) {
+    ESP_LOGW(kTag, "Failed to enable audio rail for streaming");
+    return false;
+  }
+
+  delay(kAudioStartupDelayMs);
+
+  /* re-run full codec init so clock dividers match whatever
+     sample rate the external I2S master is using */
+  if (!initCodec() || !configureCodec()) {
+    ESP_LOGW(kTag, "Codec reconfigure for streaming failed");
+    return false;
+  }
+
+  ESP_LOGI(kTag, "Codec ready for external streaming");
+  return true;
+}
+
 bool AudioManager::enableAudioRail() {
   uint8_t direction = 0xFF;
   uint8_t output = 0xFF;
@@ -274,7 +302,12 @@ bool AudioManager::startCodec() {
 }
 
 bool AudioManager::prepareForBeep() {
-  if (!available_ || !i2sInitialized_) {
+  if (!available_) {
+    return false;
+  }
+
+  /* re-init I2S if it was released for another subsystem */
+  if (!i2sInitialized_ && !initI2s()) {
     return false;
   }
 

--- a/src/audio/AudioManager.h
+++ b/src/audio/AudioManager.h
@@ -8,6 +8,8 @@ class AudioManager {
   bool begin();
   bool beep();
   bool available() const;
+  void releaseI2s();
+  bool prepareCodecForStreaming();
 
  private:
   static constexpr uint32_t kSampleRateHz = 16000;

--- a/src/display/DisplayManager.cpp
+++ b/src/display/DisplayManager.cpp
@@ -299,8 +299,9 @@ constexpr TinyGlyph kTinyGlyphs[] = {
     {'9', {0x0E, 0x11, 0x11, 0x0F, 0x01, 0x01, 0x0E}},
     {':', {0x00, 0x0C, 0x0C, 0x00, 0x0C, 0x0C, 0x00}},
     {';', {0x00, 0x0C, 0x0C, 0x00, 0x06, 0x04, 0x08}},
-    {'?', {0x0E, 0x11, 0x01, 0x02, 0x04, 0x00, 0x04}},
+    {'<', {0x02, 0x04, 0x08, 0x10, 0x08, 0x04, 0x02}},
     {'>', {0x10, 0x08, 0x04, 0x02, 0x04, 0x08, 0x10}},
+    {'?', {0x0E, 0x11, 0x01, 0x02, 0x04, 0x00, 0x04}},
     {'A', {0x0E, 0x11, 0x11, 0x1F, 0x11, 0x11, 0x11}},
     {'B', {0x1E, 0x11, 0x11, 0x1E, 0x11, 0x11, 0x1E}},
     {'C', {0x0E, 0x11, 0x10, 0x10, 0x10, 0x11, 0x0E}},
@@ -327,7 +328,10 @@ constexpr TinyGlyph kTinyGlyphs[] = {
     {'X', {0x11, 0x0A, 0x04, 0x04, 0x04, 0x0A, 0x11}},
     {'Y', {0x11, 0x0A, 0x04, 0x04, 0x04, 0x04, 0x04}},
     {'Z', {0x1F, 0x01, 0x02, 0x04, 0x08, 0x10, 0x1F}},
+    {'^', {0x04, 0x0A, 0x11, 0x00, 0x00, 0x00, 0x00}},
+    {'`', {0x00, 0x00, 0x00, 0x00, 0x11, 0x0A, 0x04}},
     {'_', {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x1F}},
+    {'|', {0x04, 0x04, 0x04, 0x04, 0x04, 0x04, 0x04}},
 };
 
 ReaderGlyph serifGlyphForByte(uint8_t value) {
@@ -3166,5 +3170,98 @@ void DisplayManager::renderFocusTimerScreen(const String &mode, const String &ge
   }
 
   drawBatteryBadge(virtualWidth, virtualHeight);
+  flushScaledFrame(1, virtualWidth, virtualHeight);
+}
+
+void DisplayManager::renderRadioScreen(const String &bandLabel, const String &frequency,
+                                       const String &stationName, const String &statusLine,
+                                       uint8_t volumePercent, bool playing) {
+  String renderKey = "radio|";
+  renderKey += bandLabel;
+  renderKey += "|";
+  renderKey += frequency;
+  renderKey += "|";
+  renderKey += stationName;
+  renderKey += "|";
+  renderKey += statusLine;
+  renderKey += "|v:";
+  renderKey += String(volumePercent);
+  renderKey += "|p:";
+  renderKey += String(playing ? 1 : 0);
+  renderKey += "|b:";
+  renderKey += batteryLabel_;
+  renderKey += "|d:";
+  renderKey += String(darkMode_ ? 1 : 0);
+  renderKey += "|n:";
+  renderKey += String(nightMode_ ? 1 : 0);
+
+  if (!initialized_ || renderKey == lastRenderKey_) {
+    return;
+  }
+
+  lastRenderKey_ = renderKey;
+
+  const int virtualWidth = kDisplayWidth;
+  const int virtualHeight = kDisplayHeight;
+  clearVirtualBuffer(virtualWidth, virtualHeight);
+
+  const uint16_t textColor = wordColor();
+  const uint16_t accentColor = focusColor();
+  const uint16_t subtleColor = dimColor();
+
+  /* band label (FM / AM) top-left */
+  const int bandScale = 3;
+  drawTinyTextAt(bandLabel, 16, 12, accentColor, bandScale);
+
+  /* frequency display, large and centered */
+  const int freqScale = 7;
+  const int freqWidth = measureTinyTextWidth(frequency, freqScale);
+  const int freqX = (virtualWidth - freqWidth) / 2;
+  const int freqY = std::max(0, (virtualHeight / 2) - ((kTinyGlyphHeight * freqScale) / 2) - 12);
+  drawTinyTextAt(frequency, freqX, freqY, textColor, freqScale);
+
+  /* station name below frequency */
+  const int nameScale = 2;
+  const int nameWidth = measureTinyTextWidth(stationName, nameScale);
+  const int nameX = (virtualWidth - nameWidth) / 2;
+  const int nameY = freqY + (kTinyGlyphHeight * freqScale) + 8;
+  drawTinyTextAt(stationName, nameX, nameY, accentColor, nameScale);
+
+  /* volume bar on the right side, vertically centered */
+  const int barWidth = 6;
+  const int barMaxHeight = 90;
+  const int barX = virtualWidth - 28;
+  const int barCenterY = virtualHeight / 2;
+  const int barOutlineY = barCenterY - barMaxHeight / 2;
+  const int barBottomY = barOutlineY + barMaxHeight;
+  const int barOutlineHeight = barMaxHeight;
+
+  /* volume bar outline */
+  fillVirtualRect(barX - 1, barOutlineY - 1, barWidth + 2, 1, subtleColor);
+  fillVirtualRect(barX - 1, barBottomY, barWidth + 2, 1, subtleColor);
+  fillVirtualRect(barX - 1, barOutlineY - 1, 1, barOutlineHeight + 2, subtleColor);
+  fillVirtualRect(barX + barWidth, barOutlineY - 1, 1, barOutlineHeight + 2, subtleColor);
+
+  /* volume bar fill */
+  if (volumePercent > 0) {
+    int fillHeight = (barMaxHeight * static_cast<int>(volumePercent)) / 100;
+    if (fillHeight < 1) fillHeight = 1;
+    const int fillY = barBottomY - fillHeight;
+    fillVirtualRect(barX, fillY, barWidth, fillHeight, accentColor);
+  }
+
+  /* status line at bottom-left */
+  if (!statusLine.isEmpty()) {
+    const int statusScale = 2;
+    drawTinyTextAt(statusLine, 16, virtualHeight - 22, subtleColor, statusScale);
+  }
+
+  /* play/pause indicator next to band label */
+  const String playIcon = playing ? "> >" : "||";
+  const int iconScale = 2;
+  const int bandLabelWidth = measureTinyTextWidth(bandLabel, bandScale);
+  drawTinyTextAt(playIcon, 16 + bandLabelWidth + 12, 18, subtleColor, iconScale);
+
+  drawBatteryBadge();
   flushScaledFrame(1, virtualWidth, virtualHeight);
 }

--- a/src/display/DisplayManager.h
+++ b/src/display/DisplayManager.h
@@ -97,6 +97,9 @@ class DisplayManager {
   void renderFocusTimerScreen(const String &mode, const String &genre, const String &timer,
                               const String &instruction, const String &footer = "",
                               int progressPercent = -1, bool breakAccent = false);
+  void renderRadioScreen(const String &bandLabel, const String &frequency,
+                         const String &stationName, const String &statusLine,
+                         uint8_t volumePercent, bool playing);
 
  private:
   bool initPanel();

--- a/src/radio/InternetRadio.cpp
+++ b/src/radio/InternetRadio.cpp
@@ -1,0 +1,306 @@
+#include "radio/InternetRadio.h"
+
+#include <Audio.h>
+#include <WiFi.h>
+#include <esp_log.h>
+
+#include "board/BoardConfig.h"
+
+namespace {
+constexpr char kTag[] = "radio";
+constexpr uint8_t kVolumeMax = 10;
+constexpr uint8_t kVolumeDefault = 5;
+constexpr uint32_t kWifiConnectTimeoutMs = 12000;
+}  // namespace
+
+/* nyc-area stations + national streams + somafm fallbacks */
+const std::vector<InternetRadio::Station> InternetRadio::kFmStations = {
+    {88.3f, "NPR News", "https://npr-ice.streamguys1.com/live.mp3", Band::FM},
+    {93.9f, "WNYC FM", "https://fm939.wnyc.org/wnycfm", Band::FM},
+    {97.1f, "HOT 97", "http://playerservices.streamtheworld.com/api/livestream-redirect/WQHTFMAAC_SC", Band::FM},
+    {105.9f, "WQXR", "https://stream.wqxr.org/wqxr", Band::FM},
+    {107.5f, "WBLS", "http://playerservices.streamtheworld.com/api/livestream-redirect/WBLSFMAAC_SC", Band::FM},
+};
+
+const std::vector<InternetRadio::Station> InternetRadio::kAmStations = {
+    {1200.0f, "Groove Salad", "http://ice2.somafm.com/groovesalad-128-mp3", Band::AM},
+    {1340.0f, "Indie Pop", "http://ice2.somafm.com/indiepop-128-mp3", Band::AM},
+    {1450.0f, "DEF CON", "http://ice2.somafm.com/defcon-128-mp3", Band::AM},
+    {1560.0f, "Boot Liquor", "http://ice2.somafm.com/bootliquor-128-mp3", Band::AM},
+};
+
+InternetRadio::~InternetRadio() {
+  destroyAudio();
+}
+
+bool InternetRadio::ensureAudio() {
+  if (audio_) {
+    return true;
+  }
+
+  audio_ = new (std::nothrow) Audio();
+  if (!audio_) {
+    ESP_LOGE(kTag, "Failed to allocate Audio");
+    return false;
+  }
+
+  audio_->setPinout(BoardConfig::PIN_AUDIO_BCLK, BoardConfig::PIN_AUDIO_WS,
+                    BoardConfig::PIN_AUDIO_DOUT, BoardConfig::PIN_AUDIO_MCLK);
+  audio_->setVolume(volume_);
+  ESP_LOGI(kTag, "Audio engine created");
+  return true;
+}
+
+void InternetRadio::destroyAudio() {
+  if (!audio_) {
+    return;
+  }
+
+  audio_->stopSong();
+  delete audio_;
+  audio_ = nullptr;
+  ESP_LOGI(kTag, "Audio engine destroyed");
+}
+
+void InternetRadio::stop() {
+  destroyAudio();
+  disconnectWifi();
+  state_ = State::Idle;
+  ESP_LOGI(kTag, "Radio stopped");
+}
+
+void InternetRadio::update() {
+  if (state_ == State::Idle) {
+    return;
+  }
+
+  /* poll wifi connection progress */
+  if (state_ == State::WifiConnecting) {
+    if (WiFi.status() == WL_CONNECTED) {
+      ESP_LOGI(kTag, "Wi-Fi connected, starting stream");
+      connectToStation();
+      return;
+    }
+    if (millis() - wifiConnectStartMs_ >= kWifiConnectTimeoutMs) {
+      ESP_LOGW(kTag, "Wi-Fi connect timed out");
+      disconnectWifi();
+      state_ = State::WifiError;
+      return;
+    }
+    return;
+  }
+
+  if (!audio_) {
+    return;
+  }
+
+  audio_->loop();
+
+  if (state_ == State::Connecting && audio_->isRunning()) {
+    state_ = State::Playing;
+  }
+}
+
+void InternetRadio::play(const String &ssid, const String &password) {
+  if (ssid.isEmpty()) {
+    state_ = State::NoCredentials;
+    ESP_LOGW(kTag, "No Wi-Fi credentials configured");
+    return;
+  }
+
+  /* already connected from a previous play */
+  if (WiFi.status() == WL_CONNECTED) {
+    connectToStation();
+    return;
+  }
+
+  /* start async wifi connection */
+  WiFi.persistent(false);
+  WiFi.setAutoReconnect(false);
+  WiFi.mode(WIFI_STA);
+  WiFi.begin(ssid.c_str(), password.c_str());
+  wifiOwnedByRadio_ = true;
+  wifiConnectStartMs_ = millis();
+  state_ = State::WifiConnecting;
+  ESP_LOGI(kTag, "Connecting to Wi-Fi: %s", ssid.c_str());
+}
+
+void InternetRadio::pause() {
+  if (audio_) {
+    audio_->stopSong();
+  }
+  state_ = State::Idle;
+}
+
+bool InternetRadio::isPlaying() const {
+  return state_ == State::Playing || state_ == State::Connecting ||
+         state_ == State::Buffering || state_ == State::WifiConnecting;
+}
+
+bool InternetRadio::isConnectingWifi() const {
+  return state_ == State::WifiConnecting;
+}
+
+void InternetRadio::tuneNext() {
+  const auto &stations = currentStations();
+  if (stations.empty()) {
+    return;
+  }
+
+  if (band_ == Band::FM) {
+    fmStationIndex_ = (fmStationIndex_ + 1) % stations.size();
+  } else {
+    amStationIndex_ = (amStationIndex_ + 1) % stations.size();
+  }
+
+  if (isPlaying()) {
+    connectToStation();
+  }
+}
+
+void InternetRadio::tunePrevious() {
+  const auto &stations = currentStations();
+  if (stations.empty()) {
+    return;
+  }
+
+  if (band_ == Band::FM) {
+    fmStationIndex_ = (fmStationIndex_ == 0) ? stations.size() - 1 : fmStationIndex_ - 1;
+  } else {
+    amStationIndex_ = (amStationIndex_ == 0) ? stations.size() - 1 : amStationIndex_ - 1;
+  }
+
+  if (isPlaying()) {
+    connectToStation();
+  }
+}
+
+void InternetRadio::toggleBand() {
+  band_ = (band_ == Band::FM) ? Band::AM : Band::FM;
+
+  if (isPlaying()) {
+    connectToStation();
+  }
+}
+
+void InternetRadio::setVolume(uint8_t vol) {
+  volume_ = (vol > kVolumeMax) ? kVolumeMax : vol;
+  if (audio_) {
+    audio_->setVolume(volume_);
+  }
+}
+
+void InternetRadio::adjustVolume(int8_t delta) {
+  int newVol = static_cast<int>(volume_) + delta;
+  if (newVol < 0) newVol = 0;
+  if (newVol > kVolumeMax) newVol = kVolumeMax;
+  setVolume(static_cast<uint8_t>(newVol));
+}
+
+InternetRadio::Band InternetRadio::band() const { return band_; }
+
+float InternetRadio::frequency() const {
+  const auto &stations = currentStations();
+  if (stations.empty()) {
+    return 0.0f;
+  }
+  const size_t idx = (band_ == Band::FM) ? fmStationIndex_ : amStationIndex_;
+  return stations[idx].frequency;
+}
+
+const char *InternetRadio::stationName() const {
+  const auto &stations = currentStations();
+  if (stations.empty()) {
+    return "";
+  }
+  const size_t idx = (band_ == Band::FM) ? fmStationIndex_ : amStationIndex_;
+  return stations[idx].name;
+}
+
+uint8_t InternetRadio::volume() const { return volume_; }
+
+InternetRadio::State InternetRadio::state() const { return state_; }
+
+size_t InternetRadio::stationIndex() const {
+  return (band_ == Band::FM) ? fmStationIndex_ : amStationIndex_;
+}
+
+size_t InternetRadio::stationCount() const {
+  return currentStations().size();
+}
+
+void InternetRadio::setStationIndex(size_t index) {
+  const auto &stations = currentStations();
+  if (index >= stations.size()) {
+    return;
+  }
+
+  if (band_ == Band::FM) {
+    fmStationIndex_ = index;
+  } else {
+    amStationIndex_ = index;
+  }
+
+  if (isPlaying()) {
+    connectToStation();
+  }
+}
+
+void InternetRadio::setBand(Band band) {
+  band_ = band;
+}
+
+uint8_t InternetRadio::savedFmIndex() const {
+  return static_cast<uint8_t>(fmStationIndex_);
+}
+
+uint8_t InternetRadio::savedAmIndex() const {
+  return static_cast<uint8_t>(amStationIndex_);
+}
+
+void InternetRadio::restoreTuning(Band band, uint8_t fmIndex, uint8_t amIndex, uint8_t vol) {
+  band_ = band;
+  fmStationIndex_ = (fmIndex < kFmStations.size()) ? fmIndex : 0;
+  amStationIndex_ = (amIndex < kAmStations.size()) ? amIndex : 0;
+  volume_ = (vol > kVolumeMax) ? kVolumeDefault : vol;
+}
+
+void InternetRadio::connectToStation() {
+  const auto &stations = currentStations();
+  if (stations.empty()) {
+    state_ = State::StreamError;
+    return;
+  }
+
+  if (!ensureAudio()) {
+    state_ = State::StreamError;
+    return;
+  }
+
+  const size_t idx = (band_ == Band::FM) ? fmStationIndex_ : amStationIndex_;
+  const Station &station = stations[idx];
+
+  audio_->stopSong();
+  state_ = State::Connecting;
+  ESP_LOGI(kTag, "Tuning to %.1f %s: %s", station.frequency, station.name, station.url);
+
+  if (!audio_->connecttohost(station.url)) {
+    state_ = State::StreamError;
+    ESP_LOGW(kTag, "Failed to connect to stream");
+  }
+}
+
+void InternetRadio::disconnectWifi() {
+  if (!wifiOwnedByRadio_) {
+    return;
+  }
+
+  WiFi.disconnect(true, false);
+  WiFi.mode(WIFI_OFF);
+  wifiOwnedByRadio_ = false;
+  ESP_LOGI(kTag, "Wi-Fi disconnected");
+}
+
+const std::vector<InternetRadio::Station> &InternetRadio::currentStations() const {
+  return (band_ == Band::FM) ? kFmStations : kAmStations;
+}

--- a/src/radio/InternetRadio.h
+++ b/src/radio/InternetRadio.h
@@ -1,0 +1,87 @@
+#pragma once
+
+#include <Arduino.h>
+#include <vector>
+
+#include "board/BoardConfig.h"
+
+class Audio;
+
+class InternetRadio {
+ public:
+  enum class Band : uint8_t {
+    FM = 0,
+    AM = 1,
+  };
+
+  enum class State : uint8_t {
+    Idle,
+    WifiConnecting,
+    Connecting,
+    Playing,
+    Buffering,
+    WifiError,
+    NoCredentials,
+    StreamError,
+  };
+
+  struct Station {
+    float frequency;
+    const char *name;
+    const char *url;
+    Band band;
+  };
+
+  ~InternetRadio();
+
+  void stop();
+  void update();
+
+  /* call with saved credentials; kicks off wifi + stream connection */
+  void play(const String &ssid, const String &password);
+  void pause();
+  bool isPlaying() const;
+  bool isConnectingWifi() const;
+
+  void tuneNext();
+  void tunePrevious();
+  void toggleBand();
+  void setVolume(uint8_t volume);
+  void adjustVolume(int8_t delta);
+
+  Band band() const;
+  float frequency() const;
+  const char *stationName() const;
+  uint8_t volume() const;
+  State state() const;
+  size_t stationIndex() const;
+  size_t stationCount() const;
+
+  void setStationIndex(size_t index);
+  void setBand(Band band);
+
+  /* saved tuning state for preferences */
+  uint8_t savedFmIndex() const;
+  uint8_t savedAmIndex() const;
+  void restoreTuning(Band band, uint8_t fmIndex, uint8_t amIndex, uint8_t vol);
+
+ private:
+  bool ensureAudio();
+  void destroyAudio();
+  void connectToStation();
+  void disconnectWifi();
+  const std::vector<Station> &currentStations() const;
+
+  /* heap-allocated only when radio is active to avoid I2S conflict at boot */
+  Audio *audio_ = nullptr;
+  Band band_ = Band::FM;
+  size_t fmStationIndex_ = 0;
+  size_t amStationIndex_ = 0;
+  uint8_t volume_ = 12;
+  State state_ = State::Idle;
+  bool wifiOwnedByRadio_ = false;
+  uint32_t wifiConnectStartMs_ = 0;
+
+  static const std::vector<Station> kFmStations;
+  static const std::vector<Station> kAmStations;
+};


### PR DESCRIPTION
Wanted a way to listen to the radio using the existing architecture. Not necessarily
in the spirit of RSVP reading, but the hardware supports it and it felt like a fun
addition. Happy to close this if it doesn't fit the project's direction.

## What it does

Adds an internet radio player to the main menu. It streams audio over Wi-Fi using
the on-board ES8311 codec and speaker. Stations are a mix of NYC-area FM/AM stations
(WNYC, Z100, KTU, HOT 97, WQXR, WBLS, WCBS, WINS) plus NPR national and a few
SomaFM streams as fallbacks.

## Controls

- Tap: play / pause
- Swipe left/right: tune between stations
- Swipe up/down: adjust volume
- Long-press: toggle FM / AM band

Band, station, and volume are saved to Preferences automatically.

## Technical notes

- Uses the ESP32-audioI2S library (v3.0.8) for HTTP streaming and MP3/AAC decoding.
- The Audio object is allocated dynamically to avoid an I2S port conflict with
  AudioManager at boot.
- AudioManager::prepareCodecForStreaming() re-configures the ES8311 via I2C before
  handing I2S over to the streaming library.
- Wi-Fi is connected on-demand when playback starts and disconnected when the radio
  is stopped, so it doesn't interfere with normal reader use.
- Also added a "Test connection" option to Wi-Fi settings and a few missing glyphs
  (<, ^, |, `) to the tiny font.

## Testing

- Both device builds (waveshare_esp32s3, waveshare_esp32s3_usb_msc) compile cleanly.
- All 50 native_test cases pass.
- Tested on-device with multiple stations over Wi-Fi.