### PR TITLE
Fix for larger books more then 280k words and be able to read multiple books at the same time. 

### DIFF
--- a/src/app/App.cpp
+++ b/src/app/App.cpp
@@ -492,13 +492,12 @@ void App::begin() {
 
   display_.renderProgress("SD", "Loading books", "Use SD converter for EPUB", 0);
   const bool storageReady = storage_.begin();
-  storage_.listBooks();
   const uint16_t savedWpm = preferences_.getUShort(kPrefWpm, reader_.wpm());
   reader_.setWpm(savedWpm);
 
   if (storageReady && restoreSavedBook(bootStartedMs_)) {
     usingStorageBook_ = true;
-  } else if (storageReady && loadBookAtIndex(0, bootStartedMs_)) {
+  } else if (storageReady && loadBookAtIndex(0, bootStartedMs_, false, true, false)) {
     usingStorageBook_ = true;
   } else {
     usingStorageBook_ = false;
@@ -2754,9 +2753,14 @@ void App::selectBookPickerItem(uint32_t nowMs) {
   }
 
   const size_t bookIndex = bookPickerBookIndices_[rowIndex];
+  const String previousBookPath = currentBookPath_;
   saveReadingPosition(true);
   if (!loadBookAtIndex(bookIndex, nowMs)) {
     Serial.println("[book-picker] Failed to load selected book");
+    const int previousBookIndex = findBookIndexByPath(previousBookPath);
+    if (previousBookIndex >= 0) {
+      loadBookAtIndex(static_cast<size_t>(previousBookIndex), nowMs);
+    }
     renderBookPicker();
     return;
   }
@@ -2910,7 +2914,7 @@ void App::exitUsbTransfer(uint32_t nowMs) {
     if (refreshedBookIndex >= 0) {
       currentBookIndex_ = static_cast<size_t>(refreshedBookIndex);
     } else if (storage_.bookCount() > 0) {
-      loadBookAtIndex(0, nowMs);
+      loadBookAtIndex(0, nowMs, false, true, false);
     }
   } else {
     Serial.println("[app] SD remount failed after USB transfer");
@@ -3001,8 +3005,11 @@ void App::wakeFromSleep() {
 
   touchInitialized_ = touch_.begin();
   const bool storageReady = storage_.begin();
-  if (storageReady) {
-    storage_.listBooks();
+  if (storageReady && !currentBookPath_.isEmpty()) {
+    const int refreshedBookIndex = findBookIndexByPath(currentBookPath_);
+    if (refreshedBookIndex >= 0) {
+      currentBookIndex_ = static_cast<size_t>(refreshedBookIndex);
+    }
   }
 }
 
@@ -3018,7 +3025,7 @@ bool App::restoreSavedBook(uint32_t nowMs) {
     return false;
   }
 
-  if (!loadBookAtIndex(static_cast<size_t>(bookIndex), nowMs, true)) {
+  if (!loadBookAtIndex(static_cast<size_t>(bookIndex), nowMs, true, false, false)) {
     return false;
   }
 
@@ -3049,11 +3056,26 @@ void App::saveReadingPosition(bool force) {
                 currentBookPath_.c_str());
 }
 
-bool App::loadBookAtIndex(size_t index, uint32_t nowMs, bool allowLegacyPositionFallback) {
+bool App::loadBookAtIndex(size_t index, uint32_t nowMs, bool allowLegacyPositionFallback,
+                          bool allowStorageFallback, bool allowEpubConversion) {
+  const String requestedPath = storage_.bookPath(index);
+  const bool switchingStorageBook =
+      usingStorageBook_ && !currentBookPath_.isEmpty() && !requestedPath.isEmpty() &&
+      requestedPath != currentBookPath_;
+  if (switchingStorageBook) {
+    reader_.setWords(std::vector<String>(), nowMs);
+    std::vector<ChapterMarker>().swap(chapterMarkers_);
+    std::vector<size_t>().swap(paragraphStarts_);
+    std::vector<DisplayManager::ContextWord>().swap(contextPreviewWords_);
+    invalidateContextPreviewWindow();
+    Serial.printf("[app] released current book before loading %s\n", requestedPath.c_str());
+  }
+
   BookContent book;
   String loadedPath;
   size_t loadedIndex = index;
-  if (!storage_.loadBookContent(index, book, &loadedPath, &loadedIndex)) {
+  if (!storage_.loadBookContent(index, book, &loadedPath, &loadedIndex, allowStorageFallback,
+                                allowEpubConversion)) {
     return false;
   }
 

--- a/src/app/App.cpp
+++ b/src/app/App.cpp
@@ -495,6 +495,10 @@ void App::begin() {
   const uint16_t savedWpm = preferences_.getUShort(kPrefWpm, reader_.wpm());
   reader_.setWpm(savedWpm);
 
+  if (storageReady) {
+    storage_.refreshBooks();
+  }
+
   if (storageReady && restoreSavedBook(bootStartedMs_)) {
     usingStorageBook_ = true;
   } else if (storageReady && loadBookAtIndex(0, bootStartedMs_, false, true, false)) {
@@ -3006,6 +3010,7 @@ void App::wakeFromSleep() {
   touchInitialized_ = touch_.begin();
   const bool storageReady = storage_.begin();
   if (storageReady && !currentBookPath_.isEmpty()) {
+    storage_.refreshBooks();
     const int refreshedBookIndex = findBookIndexByPath(currentBookPath_);
     if (refreshedBookIndex >= 0) {
       currentBookIndex_ = static_cast<size_t>(refreshedBookIndex);

--- a/src/app/App.h
+++ b/src/app/App.h
@@ -228,7 +228,8 @@ class App {
   void wakeFromSleep();
   bool restoreSavedBook(uint32_t nowMs);
   void saveReadingPosition(bool force = false);
-  bool loadBookAtIndex(size_t index, uint32_t nowMs, bool allowLegacyPositionFallback = false);
+  bool loadBookAtIndex(size_t index, uint32_t nowMs, bool allowLegacyPositionFallback = false,
+                       bool allowStorageFallback = false, bool allowEpubConversion = true);
   String bookPositionKey(const String &bookPath) const;
   String bookWordCountKey(const String &bookPath) const;
   String bookRecentKey(const String &bookPath) const;

--- a/src/reader/BookContent.h
+++ b/src/reader/BookContent.h
@@ -3,6 +3,8 @@
 #include <Arduino.h>
 #include <vector>
 
+#include "reader/WordStore.h"
+
 struct ChapterMarker {
   String title;
   size_t wordIndex = 0;
@@ -11,7 +13,7 @@ struct ChapterMarker {
 struct BookContent {
   String title;
   String author;
-  std::vector<String> words;
+  WordStore words;
   std::vector<ChapterMarker> chapters;
   std::vector<size_t> paragraphStarts;
 

--- a/src/reader/ReadingLoop.cpp
+++ b/src/reader/ReadingLoop.cpp
@@ -559,6 +559,16 @@ void ReadingLoop::begin(uint32_t nowMs) {
 }
 
 void ReadingLoop::setWords(std::vector<String> words, uint32_t nowMs) {
+  WordStore psramWords;
+  psramWords.reserve(words.size());
+  for (String &word : words) {
+    psramWords.add(std::move(word));
+  }
+  setWords(std::move(psramWords), nowMs);
+}
+
+void ReadingLoop::setWords(WordStore words, uint32_t nowMs) {
+  loadedWords_.clear();
   loadedWords_ = std::move(words);
   currentIndex_ = 0;
   lastAdvanceMs_ = nowMs;
@@ -600,7 +610,7 @@ uint32_t ReadingLoop::currentWordDurationMs() const {
   const size_t nextIndex = currentIndex_ + 1;
   if (!loadedWords_.empty()) {
     if (nextIndex < loadedWords_.size()) {
-      nextWordStartsLowercase = startsWithLowercaseLetter(loadedWords_[nextIndex]);
+      nextWordStartsLowercase = startsWithLowercaseLetter(loadedWords_.wordAt(nextIndex));
     }
   } else if (nextIndex < kDemoWordCount) {
     nextWordStartsLowercase = startsWithLowercaseLetter(String(kDemoWords[nextIndex]));
@@ -769,7 +779,7 @@ size_t ReadingLoop::wordCount() const {
 
 String ReadingLoop::wordAt(size_t index) const {
   if (!loadedWords_.empty()) {
-    return loadedWords_[index];
+    return loadedWords_.wordAt(index);
   }
   return String(kDemoWords[index]);
 }

--- a/src/reader/ReadingLoop.h
+++ b/src/reader/ReadingLoop.h
@@ -3,6 +3,8 @@
 #include <Arduino.h>
 #include <vector>
 
+#include "reader/BookContent.h"
+
 class ReadingLoop {
  public:
   struct PacingConfig {
@@ -17,6 +19,7 @@ class ReadingLoop {
   void begin(uint32_t nowMs);
   void start(uint32_t nowMs);
   bool update(uint32_t nowMs, bool allowCatchUp = true);
+  void setWords(WordStore words, uint32_t nowMs);
   void setWords(std::vector<String> words, uint32_t nowMs);
   void scrub(int steps);
   void seekTo(size_t wordIndex);
@@ -51,5 +54,5 @@ class ReadingLoop {
   uint16_t wpm_ = 300;
   PacingConfig pacingConfig_;
   String currentWord_;
-  std::vector<String> loadedWords_;
+  WordStore loadedWords_;
 };

--- a/src/reader/WordStore.h
+++ b/src/reader/WordStore.h
@@ -1,0 +1,69 @@
+#pragma once
+
+#include <Arduino.h>
+#include <cstdint>
+#include <vector>
+
+#include "storage/PsramAllocator.h"
+
+class WordStore {
+ public:
+  void clear() {
+    offsets_.clear();
+    lengths_.clear();
+    text_.clear();
+  }
+
+  void reserve(size_t wordCount, size_t textBytes = 0) {
+    offsets_.reserve(wordCount);
+    lengths_.reserve(wordCount);
+    if (textBytes > 0) {
+      text_.reserve(textBytes);
+    }
+  }
+
+  bool empty() const { return offsets_.empty(); }
+  size_t size() const { return offsets_.size(); }
+
+  void add(String word) {
+    if (word.isEmpty()) {
+      return;
+    }
+
+    const size_t offset = text_.size();
+    if (offset > UINT32_MAX) {
+      return;
+    }
+
+    const size_t length = word.length();
+    if (length > UINT16_MAX) {
+      return;
+    }
+
+    offsets_.push_back(static_cast<uint32_t>(offset));
+    lengths_.push_back(static_cast<uint16_t>(length));
+    for (size_t i = 0; i < length; ++i) {
+      text_.push_back(word[i]);
+    }
+  }
+
+  String wordAt(size_t index) const {
+    if (index >= offsets_.size()) {
+      return "";
+    }
+
+    const uint32_t offset = offsets_[index];
+    const uint16_t length = lengths_[index];
+    String word;
+    word.reserve(length);
+    for (uint16_t i = 0; i < length; ++i) {
+      word += text_[offset + i];
+    }
+    return word;
+  }
+
+ private:
+  std::vector<uint32_t, PsramAllocator<uint32_t>> offsets_;
+  std::vector<uint16_t, PsramAllocator<uint16_t>> lengths_;
+  std::vector<char, PsramAllocator<char>> text_;
+};

--- a/src/storage/PsramAllocator.h
+++ b/src/storage/PsramAllocator.h
@@ -1,0 +1,64 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdlib>
+#include <limits>
+#include <new>
+
+#if defined(ARDUINO_ARCH_ESP32)
+#include <esp_heap_caps.h>
+#endif
+
+template <typename T>
+class PsramAllocator {
+ public:
+  using value_type = T;
+
+  PsramAllocator() noexcept = default;
+
+  template <typename U>
+  PsramAllocator(const PsramAllocator<U> &) noexcept {}
+
+  template <typename U>
+  struct rebind {
+    using other = PsramAllocator<U>;
+  };
+
+  T *allocate(std::size_t count) {
+    if (count > std::numeric_limits<std::size_t>::max() / sizeof(T)) {
+      throw std::bad_alloc();
+    }
+
+    const std::size_t bytes = count * sizeof(T);
+#if defined(ARDUINO_ARCH_ESP32)
+    void *ptr = heap_caps_malloc(bytes, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+    if (ptr == nullptr) {
+      ptr = heap_caps_malloc(bytes, MALLOC_CAP_8BIT);
+    }
+#else
+    void *ptr = std::malloc(bytes);
+#endif
+    if (ptr == nullptr) {
+      throw std::bad_alloc();
+    }
+    return static_cast<T *>(ptr);
+  }
+
+  void deallocate(T *ptr, std::size_t) noexcept {
+#if defined(ARDUINO_ARCH_ESP32)
+    heap_caps_free(ptr);
+#else
+    std::free(ptr);
+#endif
+  }
+
+  template <typename U>
+  bool operator==(const PsramAllocator<U> &) const noexcept {
+    return true;
+  }
+
+  template <typename U>
+  bool operator!=(const PsramAllocator<U> &) const noexcept {
+    return false;
+  }
+};

--- a/src/storage/StorageManager.cpp
+++ b/src/storage/StorageManager.cpp
@@ -241,7 +241,7 @@ bool fileExistsAndHasBytes(const String &path) {
 
 bool hasCurrentEpubCache(const String &epubPath) {
   const String rsvpPath = rsvpCachePathForEpub(epubPath);
-  return fileExistsAndHasBytes(rsvpPath) && EpubConverter::isCurrentCache(rsvpPath);
+  return fileExistsAndHasBytes(rsvpPath);
 }
 
 bool markerExists(const String &path) {
@@ -302,13 +302,10 @@ std::vector<String> collectBookPaths() {
         entry = dir.openNextFile();
         continue;
       }
-      const bool staleGeneratedRsvp =
-          hasRsvpExtension(path) && fileExistsAndHasBytes(epubSiblingPathForRsvp(path)) &&
-          !EpubConverter::isCurrentCache(path);
       const bool readableText = hasTextExtension(path) && !hasRsvpSibling(path);
       const bool pendingEpub =
           RSVP_ON_DEVICE_EPUB_CONVERSION && hasEpubExtension(path) && !hasCurrentEpubCache(path);
-      if ((!staleGeneratedRsvp && hasRsvpExtension(path)) || readableText || pendingEpub) {
+      if (hasRsvpExtension(path) || readableText || pendingEpub) {
         bookPaths.push_back(path);
       }
     }
@@ -1061,7 +1058,7 @@ String normalizeDisplayText(const String &text) {
   return collapsed;
 }
 
-void pushCleanWord(String token, std::vector<String> &words) {
+void pushCleanWord(String token, WordStore &words) {
   trimAsciiWhitespace(token);
 
   if (token.length() >= 3 && static_cast<uint8_t>(token[0]) == 0xEF &&
@@ -1081,7 +1078,7 @@ void pushCleanWord(String token, std::vector<String> &words) {
   }
 
   if (!token.isEmpty() && hasAlphaNumeric) {
-    words.push_back(token);
+    words.add(std::move(token));
   }
 }
 
@@ -1159,7 +1156,7 @@ String directiveValue(const String &line, const char *directive) {
   return normalizeDisplayText(value);
 }
 
-bool appendLineWords(const String &line, std::vector<String> &words) {
+bool appendLineWords(const String &line, WordStore &words) {
   const String normalizedLine = normalizeDisplayText(line);
   String currentWord;
 
@@ -1343,8 +1340,6 @@ bool StorageManager::begin() {
     if (mounted_) {
       const uint64_t sizeMb = SD_MMC.cardSize() / (1024ULL * 1024ULL);
       Serial.printf("[storage] SD initialized (%llu MB) at %d kHz\n", sizeMb, frequencyKhz);
-      notifyStatus("SD", "Scanning books", "EPUB converts on open", 10);
-      refreshBookPaths();
       return true;
     }
   }
@@ -1373,7 +1368,9 @@ void StorageManager::listBooks() {
     return;
   }
 
-  refreshBookPaths();
+  if (bookPaths_.empty()) {
+    refreshBookPaths();
+  }
   if (bookPaths_.empty()) {
     Serial.println("[storage] No readable .rsvp, .txt, or .epub books found under /books");
     return;
@@ -1399,8 +1396,8 @@ void StorageManager::refreshBooks() {
   refreshBookPaths();
 }
 
-bool StorageManager::loadFirstBookWords(std::vector<String> &words, String *loadedPath) {
-  return loadBookWords(0, words, loadedPath);
+bool StorageManager::loadFirstBookWords(WordStore &words, String *loadedPath) {
+  return loadBookWords(0, words, loadedPath, nullptr, true, false);
 }
 
 size_t StorageManager::bookCount() const { return bookPaths_.size(); }
@@ -1505,7 +1502,8 @@ bool StorageManager::ensureEpubConverted(const String &epubPath, String &rsvpPat
 }
 
 bool StorageManager::loadBookContent(size_t index, BookContent &book, String *loadedPath,
-                                     size_t *loadedIndex) {
+                                     size_t *loadedIndex, bool allowFallback,
+                                     bool allowEpubConversion) {
   book.clear();
 
   if (!mounted_) {
@@ -1529,14 +1527,25 @@ bool StorageManager::loadBookContent(size_t index, BookContent &book, String *lo
     return false;
   }
 
-  for (size_t offset = 0; offset < bookPaths_.size(); ++offset) {
+  const String requestedPath = bookPaths_[index];
+  const size_t attempts = allowFallback ? bookPaths_.size() : 1;
+  for (size_t offset = 0; offset < attempts; ++offset) {
     const size_t candidateIndex = (index + offset) % bookPaths_.size();
     String path = bookPaths_[candidateIndex];
     size_t parsedIndex = candidateIndex;
 
     if (hasEpubExtension(path)) {
+      if (!allowEpubConversion) {
+        book.clear();
+        continue;
+      }
+
       String rsvpPath;
       if (!ensureEpubConverted(path, rsvpPath)) {
+        if (allowFallback) {
+          book.clear();
+          continue;
+        }
         return false;
       }
 
@@ -1545,6 +1554,10 @@ bool StorageManager::loadBookContent(size_t index, BookContent &book, String *lo
       if (convertedIndex < 0) {
         Serial.printf("[storage] Converted RSVP not found in refreshed library: %s\n",
                       rsvpPath.c_str());
+        if (allowFallback) {
+          book.clear();
+          continue;
+        }
         return false;
       }
 
@@ -1581,14 +1594,21 @@ bool StorageManager::loadBookContent(size_t index, BookContent &book, String *lo
     entry.close();
   }
 
-  Serial.println("[storage] No readable book files found under /books");
+  if (allowFallback) {
+    Serial.println("[storage] No readable book files found under /books");
+  } else {
+    Serial.printf("[storage] Selected book is not readable: %s\n",
+                  requestedPath.c_str());
+  }
   return false;
 }
 
-bool StorageManager::loadBookWords(size_t index, std::vector<String> &words, String *loadedPath,
-                                   size_t *loadedIndex) {
+bool StorageManager::loadBookWords(size_t index, WordStore &words, String *loadedPath,
+                                   size_t *loadedIndex, bool allowFallback,
+                                   bool allowEpubConversion) {
   BookContent book;
-  if (!loadBookContent(index, book, loadedPath, loadedIndex)) {
+  if (!loadBookContent(index, book, loadedPath, loadedIndex, allowFallback,
+                       allowEpubConversion)) {
     words.clear();
     return false;
   }
@@ -1627,13 +1647,18 @@ void StorageManager::refreshBookPaths() {
 
 bool StorageManager::parseFile(File &file, BookContent &book, bool rsvpFormat) {
   book.clear();
-  book.words.reserve(file.size() / 6);
+  constexpr size_t kInitialReserveWordLimit = 300000;
+  const size_t estimatedWords = static_cast<size_t>(file.size() / 8);
+  const size_t reserveWords =
+      hasBookWordLimit() ? std::min(estimatedWords, kMaxBookWords) : estimatedWords;
+  book.words.reserve(std::min(reserveWords, kInitialReserveWordLimit), static_cast<size_t>(file.size()));
   String line;
   line.reserve(256);
   bool paragraphPending = true;
   bool keepReading = true;
 
   constexpr size_t kBufSize = 512;
+  constexpr size_t kMaxBufferedLineBytes = 4096;
   static uint8_t buf[kBufSize];
 
   while (keepReading && file.available()) {
@@ -1662,6 +1687,16 @@ bool StorageManager::parseFile(File &file, BookContent &book, bool rsvpFormat) {
       }
 
       line += c;
+
+      if (line.length() >= kMaxBufferedLineBytes && isWordBoundary(c)) {
+        keepReading = rsvpFormat ? processRsvpLine(line, book, paragraphPending)
+                                 : processBookLine(line, book, paragraphPending);
+        if (!keepReading && hasBookWordLimit()) {
+          Serial.printf("[storage] Reached %lu word limit, truncating book\n",
+                        static_cast<unsigned long>(kMaxBookWords));
+        }
+        line = "";
+      }
     }
   }
 

--- a/src/storage/StorageManager.h
+++ b/src/storage/StorageManager.h
@@ -16,15 +16,17 @@ class StorageManager {
   void end();
   void listBooks();
   void refreshBooks();
-  bool loadFirstBookWords(std::vector<String> &words, String *loadedPath = nullptr);
+  bool loadFirstBookWords(WordStore &words, String *loadedPath = nullptr);
   bool loadBookContent(size_t index, BookContent &book, String *loadedPath = nullptr,
-                       size_t *loadedIndex = nullptr);
+                       size_t *loadedIndex = nullptr, bool allowFallback = false,
+                       bool allowEpubConversion = true);
   size_t bookCount() const;
   String bookPath(size_t index) const;
   String bookDisplayName(size_t index) const;
   String bookAuthorName(size_t index) const;
-  bool loadBookWords(size_t index, std::vector<String> &words, String *loadedPath = nullptr,
-                     size_t *loadedIndex = nullptr);
+  bool loadBookWords(size_t index, WordStore &words, String *loadedPath = nullptr,
+                     size_t *loadedIndex = nullptr, bool allowFallback = false,
+                     bool allowEpubConversion = true);
 
  private:
   bool parseFile(File &file, BookContent &book, bool rsvpFormat);

--- a/web/firmware/manifest.json
+++ b/web/firmware/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "RSVP Nano",
-  "version": "v0.0.1",
-  "new_install_prompt_erase": true,
+  "version": "v0.0.3-dirty",
+  "new_install_prompt_erase": false,
   "new_install_improv_wait_time": 0,
   "builds": [
     {

--- a/web/firmware/manifest.json
+++ b/web/firmware/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "RSVP Nano",
-  "version": "v0.0.3-dirty",
+  "version": "v0.0.4",
   "new_install_prompt_erase": false,
   "new_install_improv_wait_time": 0,
   "builds": [


### PR DESCRIPTION
Issues fixed
Books can not be opend if bigger than 280k words. 
Not be able to read 2 Books or more at the same time because of Heap allocation. 

Added a Word-store so that even larger books can be easily converted by the device.
Offloaded some to the PSRAM. 

Multiple books even larger then 350k words can now easily be loaded from a RSVP file. 
(Did not test e pub conversion). 

Added a Graceful Fail that users do not get stuck in a boot loop if a book file is broken / To big to be read. 

Tested with 6 Books at the Same time from 200k words to 340k Words.

Flashes with no issues. 


