### PR TITLE
Implement pacing-aware time estimates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 .pio
 .codex
+.claude
+CLAUDE.md
 .DS_Store
 __pycache__/
 *.py[cod]

--- a/src/app/App.cpp
+++ b/src/app/App.cpp
@@ -3518,26 +3518,13 @@ uint32_t App::pacingAwareDurationMsBetween(size_t fromIndex, size_t endIndex) co
   if (endIndex <= fromIndex) {
     return 0;
   }
-
-  if (tailCacheValid_ && tailCacheEnd_ == endIndex && fromIndex >= tailCacheStart_) {
-    uint32_t total = tailCacheMs_;
-    for (size_t i = tailCacheStart_; i < fromIndex; ++i) {
-      const uint32_t d = reader_.wordDurationMsAt(i);
-      total = (d >= total) ? 0 : (total - d);
-    }
-    tailCacheStart_ = fromIndex;
-    tailCacheMs_ = total;
-    return total;
+  if (wordPrefixSumMs_.size() == n + 1) {
+    return wordPrefixSumMs_[endIndex] - wordPrefixSumMs_[fromIndex];
   }
-
   uint32_t total = 0;
   for (size_t i = fromIndex; i < endIndex; ++i) {
     total += reader_.wordDurationMsAt(i);
   }
-  tailCacheValid_ = true;
-  tailCacheStart_ = fromIndex;
-  tailCacheEnd_ = endIndex;
-  tailCacheMs_ = total;
   return total;
 }
 
@@ -3545,7 +3532,7 @@ void App::invalidateTimeEstimateCache() {
   timeEstimateCacheValid_ = false;
   chapterDurationsMs_.clear();
   bookDurationMs_ = 0;
-  tailCacheValid_ = false;
+  std::vector<uint32_t>().swap(wordPrefixSumMs_);
 }
 
 void App::rebuildTimeEstimateCache() {
@@ -3561,10 +3548,12 @@ void App::rebuildTimeEstimateCache() {
 
   const size_t chapterCount = std::max<size_t>(1, chapterMarkers_.size());
   chapterDurationsMs_.assign(chapterCount, 0);
+  wordPrefixSumMs_.assign(n + 1, 0);
 
   size_t chapterIdx = 0;
   size_t chapterEnd = (chapterMarkers_.size() > 1) ? chapterMarkers_[1].wordIndex : n;
   uint32_t acc = 0;
+  uint32_t running = 0;
   const uint32_t startMs = millis();
   for (size_t i = 0; i < n; ++i) {
     while (i >= chapterEnd && chapterIdx + 1 < chapterDurationsMs_.size()) {
@@ -3575,8 +3564,12 @@ void App::rebuildTimeEstimateCache() {
                        ? chapterMarkers_[chapterIdx + 1].wordIndex
                        : n;
     }
-    acc += reader_.wordDurationMsAt(i);
+    wordPrefixSumMs_[i] = running;
+    const uint32_t d = reader_.wordDurationMsAt(i);
+    acc += d;
+    running += d;
   }
+  wordPrefixSumMs_[n] = running;
   chapterDurationsMs_[chapterIdx] = acc;
 
   for (uint32_t d : chapterDurationsMs_) {

--- a/src/app/App.cpp
+++ b/src/app/App.cpp
@@ -540,6 +540,11 @@ void App::update(uint32_t nowMs) {
   updateWpmFeedback(nowMs);
   maybeSaveReadingPosition(nowMs);
 
+  if (pacingCacheDirty_ && state_ != AppState::Menu &&
+      nowMs - pacingCacheDirtyAtMs_ >= 500) {
+    flushPendingTimeEstimateRebuild();
+  }
+
   if (batteryChanged && (state_ == AppState::Paused || state_ == AppState::Playing)) {
     renderActiveReader(nowMs);
   } else if (batteryChanged && state_ == AppState::Menu) {
@@ -590,9 +595,7 @@ void App::setState(AppState nextState, uint32_t nowMs) {
   }
 
   const AppState previousState = state_;
-  if (previousState == AppState::Menu && nextState != AppState::Menu) {
-    flushPendingTimeEstimateRebuild();
-  }
+  flushPendingTimeEstimateRebuild();
 
   if (nextState != AppState::Paused) {
     pausedTouch_.active = false;
@@ -1311,7 +1314,8 @@ void App::applyPausedTouchGesture(const TouchEvent &event, uint32_t nowMs) {
     const int wpmDelta = (deltaY < 0) ? 1 : -1;
     reader_.adjustWpm(wpmDelta);
     preferences_.putUShort(kPrefWpm, reader_.wpm());
-    rebuildTimeEstimateCache();
+    pacingCacheDirty_ = true;
+    pacingCacheDirtyAtMs_ = nowMs;
     renderWpmFeedback(nowMs);
     Serial.printf("[app] WPM=%u interval=%lu ms\n", reader_.wpm(),
                   static_cast<unsigned long>(reader_.wordIntervalMs()));

--- a/src/app/App.cpp
+++ b/src/app/App.cpp
@@ -590,6 +590,9 @@ void App::setState(AppState nextState, uint32_t nowMs) {
   }
 
   const AppState previousState = state_;
+  if (previousState == AppState::Menu && nextState != AppState::Menu) {
+    flushPendingTimeEstimateRebuild();
+  }
 
   if (nextState != AppState::Paused) {
     pausedTouch_.active = false;
@@ -1899,6 +1902,7 @@ void App::selectSettingsItem(uint32_t nowMs) {
 
   switch (settingsSelectedIndex_) {
     case kSettingsBackIndex:
+      flushPendingTimeEstimateRebuild();
       settingsSelectedIndex_ = kSettingsHomePacingIndex;
       menuScreen_ = MenuScreen::SettingsHome;
       rebuildSettingsMenuItems();
@@ -2487,6 +2491,18 @@ void App::applyPacingSettings() {
                 static_cast<unsigned int>(pacingLongWordDelayMs_),
                 static_cast<unsigned int>(pacingComplexWordDelayMs_),
                 static_cast<unsigned int>(pacingPunctuationDelayMs_));
+  if (state_ == AppState::Menu && menuScreen_ == MenuScreen::SettingsPacing) {
+    pacingCacheDirty_ = true;
+  } else {
+    rebuildTimeEstimateCache();
+  }
+}
+
+void App::flushPendingTimeEstimateRebuild() {
+  if (!pacingCacheDirty_) {
+    return;
+  }
+  pacingCacheDirty_ = false;
   rebuildTimeEstimateCache();
 }
 

--- a/src/app/App.cpp
+++ b/src/app/App.cpp
@@ -540,11 +540,6 @@ void App::update(uint32_t nowMs) {
   updateWpmFeedback(nowMs);
   maybeSaveReadingPosition(nowMs);
 
-  if (pacingCacheDirty_ && state_ != AppState::Menu &&
-      nowMs - pacingCacheDirtyAtMs_ >= 500) {
-    flushPendingTimeEstimateRebuild();
-  }
-
   if (batteryChanged && (state_ == AppState::Paused || state_ == AppState::Playing)) {
     renderActiveReader(nowMs);
   } else if (batteryChanged && state_ == AppState::Menu) {
@@ -595,7 +590,9 @@ void App::setState(AppState nextState, uint32_t nowMs) {
   }
 
   const AppState previousState = state_;
-  flushPendingTimeEstimateRebuild();
+  if (previousState == AppState::Menu && nextState != AppState::Menu) {
+    flushPendingTimeEstimateRebuild();
+  }
 
   if (nextState != AppState::Paused) {
     pausedTouch_.active = false;
@@ -1314,8 +1311,6 @@ void App::applyPausedTouchGesture(const TouchEvent &event, uint32_t nowMs) {
     const int wpmDelta = (deltaY < 0) ? 1 : -1;
     reader_.adjustWpm(wpmDelta);
     preferences_.putUShort(kPrefWpm, reader_.wpm());
-    pacingCacheDirty_ = true;
-    pacingCacheDirtyAtMs_ = nowMs;
     renderWpmFeedback(nowMs);
     Serial.printf("[app] WPM=%u interval=%lu ms\n", reader_.wpm(),
                   static_cast<unsigned long>(reader_.wordIntervalMs()));
@@ -3494,18 +3489,20 @@ uint32_t App::estimatedReadingTimeRemainingMs(size_t startIndex, size_t endIndex
     return 0;
   }
 
+  const uint32_t baseMs = static_cast<uint32_t>(
+      (static_cast<uint64_t>(endIndex - startIndex) * 60000ULL) /
+      static_cast<uint64_t>(reader_.wpm()));
+
   if (!accurateTimeEstimateEnabled_ || !timeEstimateCacheValid_) {
-    const size_t remainingWords = endIndex - startIndex;
-    return static_cast<uint32_t>((static_cast<uint64_t>(remainingWords) * 60000ULL) /
-                                 static_cast<uint64_t>(reader_.wpm()));
+    return baseMs;
   }
 
-  return wordPrefixSumMs_[endIndex] - wordPrefixSumMs_[startIndex];
+  return baseMs + wordBonusPrefixSumMs_[endIndex] - wordBonusPrefixSumMs_[startIndex];
 }
 
 void App::invalidateTimeEstimateCache() {
   timeEstimateCacheValid_ = false;
-  std::vector<uint32_t>().swap(wordPrefixSumMs_);
+  std::vector<uint32_t>().swap(wordBonusPrefixSumMs_);
 }
 
 void App::rebuildTimeEstimateCache() {
@@ -3519,17 +3516,17 @@ void App::rebuildTimeEstimateCache() {
     return;
   }
 
-  wordPrefixSumMs_.assign(n + 1, 0);
+  wordBonusPrefixSumMs_.assign(n + 1, 0);
   uint32_t running = 0;
   const uint32_t startMs = millis();
   for (size_t i = 0; i < n; ++i) {
-    wordPrefixSumMs_[i] = running;
-    running += reader_.wordDurationMsAt(i);
+    wordBonusPrefixSumMs_[i] = running;
+    running += reader_.wordPacingBonusMsAt(i);
   }
-  wordPrefixSumMs_[n] = running;
+  wordBonusPrefixSumMs_[n] = running;
   timeEstimateCacheValid_ = true;
 
-  Serial.printf("[time-est] cached %u words total=%lums took=%lums\n",
+  Serial.printf("[time-est] cached %u words bonus=%lums took=%lums\n",
                 static_cast<unsigned int>(n), static_cast<unsigned long>(running),
                 static_cast<unsigned long>(millis() - startMs));
 }

--- a/src/app/App.cpp
+++ b/src/app/App.cpp
@@ -2501,7 +2501,6 @@ void App::flushPendingTimeEstimateRebuild() {
   if (!pacingCacheDirty_) {
     return;
   }
-  pacingCacheDirty_ = false;
   rebuildTimeEstimateCache();
 }
 
@@ -3507,6 +3506,7 @@ void App::invalidateTimeEstimateCache() {
 
 void App::rebuildTimeEstimateCache() {
   invalidateTimeEstimateCache();
+  pacingCacheDirty_ = false;
   if (!accurateTimeEstimateEnabled_) {
     return;
   }

--- a/src/app/App.cpp
+++ b/src/app/App.cpp
@@ -3496,58 +3496,11 @@ uint32_t App::estimatedReadingTimeRemainingMs(size_t startIndex, size_t endIndex
                                  static_cast<uint64_t>(reader_.wpm()));
   }
 
-  const size_t curChapter = currentChapterIndex();
-  const size_t curChapterEnd = (curChapter + 1 < chapterMarkers_.size())
-                                   ? chapterMarkers_[curChapter + 1].wordIndex
-                                   : wordCount;
-
-  if (endIndex <= curChapterEnd) {
-    return pacingAwareDurationMsBetween(startIndex, endIndex);
-  }
-
-  uint32_t total = pacingAwareDurationMsBetween(startIndex, curChapterEnd);
-  for (size_t c = curChapter + 1; c < chapterDurationsMs_.size(); ++c) {
-    const size_t chapterStart = chapterMarkers_[c].wordIndex;
-    const size_t chapterEndIdx = (c + 1 < chapterMarkers_.size())
-                                     ? chapterMarkers_[c + 1].wordIndex
-                                     : wordCount;
-    if (chapterStart >= endIndex) {
-      break;
-    }
-    if (chapterEndIdx <= endIndex) {
-      total += chapterDurationsMs_[c];
-    } else {
-      total += pacingAwareDurationMsBetween(chapterStart, endIndex);
-      break;
-    }
-  }
-  return total;
-}
-
-uint32_t App::pacingAwareDurationMsBetween(size_t fromIndex, size_t endIndex) const {
-  const size_t n = reader_.wordCount();
-  if (n == 0) {
-    return 0;
-  }
-  fromIndex = std::min(fromIndex, n);
-  endIndex = std::min(endIndex, n);
-  if (endIndex <= fromIndex) {
-    return 0;
-  }
-  if (wordPrefixSumMs_.size() == n + 1) {
-    return wordPrefixSumMs_[endIndex] - wordPrefixSumMs_[fromIndex];
-  }
-  uint32_t total = 0;
-  for (size_t i = fromIndex; i < endIndex; ++i) {
-    total += reader_.wordDurationMsAt(i);
-  }
-  return total;
+  return wordPrefixSumMs_[endIndex] - wordPrefixSumMs_[startIndex];
 }
 
 void App::invalidateTimeEstimateCache() {
   timeEstimateCacheValid_ = false;
-  chapterDurationsMs_.clear();
-  bookDurationMs_ = 0;
   std::vector<uint32_t>().swap(wordPrefixSumMs_);
 }
 
@@ -3562,40 +3515,18 @@ void App::rebuildTimeEstimateCache() {
     return;
   }
 
-  const size_t chapterCount = std::max<size_t>(1, chapterMarkers_.size());
-  chapterDurationsMs_.assign(chapterCount, 0);
   wordPrefixSumMs_.assign(n + 1, 0);
-
-  size_t chapterIdx = 0;
-  size_t chapterEnd = (chapterMarkers_.size() > 1) ? chapterMarkers_[1].wordIndex : n;
-  uint32_t acc = 0;
   uint32_t running = 0;
   const uint32_t startMs = millis();
   for (size_t i = 0; i < n; ++i) {
-    while (i >= chapterEnd && chapterIdx + 1 < chapterDurationsMs_.size()) {
-      chapterDurationsMs_[chapterIdx] = acc;
-      ++chapterIdx;
-      acc = 0;
-      chapterEnd = (chapterIdx + 1 < chapterMarkers_.size())
-                       ? chapterMarkers_[chapterIdx + 1].wordIndex
-                       : n;
-    }
     wordPrefixSumMs_[i] = running;
-    const uint32_t d = reader_.wordDurationMsAt(i);
-    acc += d;
-    running += d;
+    running += reader_.wordDurationMsAt(i);
   }
   wordPrefixSumMs_[n] = running;
-  chapterDurationsMs_[chapterIdx] = acc;
-
-  for (uint32_t d : chapterDurationsMs_) {
-    bookDurationMs_ += d;
-  }
   timeEstimateCacheValid_ = true;
 
-  Serial.printf("[time-est] cached %u chapters total=%lums took=%lums\n",
-                static_cast<unsigned int>(chapterDurationsMs_.size()),
-                static_cast<unsigned long>(bookDurationMs_),
+  Serial.printf("[time-est] cached %u words total=%lums took=%lums\n",
+                static_cast<unsigned int>(n), static_cast<unsigned long>(running),
                 static_cast<unsigned long>(millis() - startMs));
 }
 

--- a/src/app/App.cpp
+++ b/src/app/App.cpp
@@ -120,7 +120,8 @@ constexpr size_t kSettingsDisplayLanguageIndex = 5;
 constexpr size_t kSettingsPacingLongWordsIndex = 1;
 constexpr size_t kSettingsPacingComplexityIndex = 2;
 constexpr size_t kSettingsPacingPunctuationIndex = 3;
-constexpr size_t kSettingsPacingResetIndex = 4;
+constexpr size_t kSettingsPacingTimeEstimateIndex = 4;
+constexpr size_t kSettingsPacingResetIndex = 5;
 constexpr size_t kWifiSettingsNetworkIndex = 1;
 constexpr size_t kWifiSettingsChooseIndex = 2;
 constexpr size_t kWifiSettingsAutoUpdateIndex = 3;
@@ -154,6 +155,7 @@ constexpr const char *kPrefLegacyPacingPunctuation = "pace_pnc";
 constexpr const char *kPrefPacingLongMs = "pace_lms";
 constexpr const char *kPrefPacingComplexMs = "pace_cms";
 constexpr const char *kPrefPacingPunctuationMs = "pace_pms";
+constexpr const char *kPrefAccurateTime = "time_est_a";
 constexpr const char *kPrefTypographyTracking = "type_trk";
 constexpr const char *kPrefTypographyAnchor = "type_anc";
 constexpr const char *kPrefTypographyGuideWidth = "type_wid";
@@ -439,6 +441,7 @@ void App::begin() {
       loadPacingDelayMs(preferences_, kPrefPacingComplexMs, kPrefLegacyPacingComplex);
   pacingPunctuationDelayMs_ =
       loadPacingDelayMs(preferences_, kPrefPacingPunctuationMs, kPrefLegacyPacingPunctuation);
+  accurateTimeEstimateEnabled_ = preferences_.getBool(kPrefAccurateTime, true);
   typographyConfig_ = defaultTypographyConfig();
   typographyConfig_.typeface = readerTypefaceFromSetting(
       preferences_.getUChar(kPrefReaderTypeface, static_cast<uint8_t>(typographyConfig_.typeface)));
@@ -508,6 +511,7 @@ void App::begin() {
     currentBookTitle_ = "Demo";
     reader_.begin(bootStartedMs_);
     invalidateContextPreviewWindow();
+    rebuildTimeEstimateCache();
     Serial.println("[app] using built-in demo text");
   }
 
@@ -1304,6 +1308,7 @@ void App::applyPausedTouchGesture(const TouchEvent &event, uint32_t nowMs) {
     const int wpmDelta = (deltaY < 0) ? 1 : -1;
     reader_.adjustWpm(wpmDelta);
     preferences_.putUShort(kPrefWpm, reader_.wpm());
+    rebuildTimeEstimateCache();
     renderWpmFeedback(nowMs);
     Serial.printf("[app] WPM=%u interval=%lu ms\n", reader_.wpm(),
                   static_cast<unsigned long>(reader_.wordIntervalMs()));
@@ -1914,6 +1919,17 @@ void App::selectSettingsItem(uint32_t nowMs) {
           pacingPunctuationDelayMs_, kPacingDelayMinMs, kPacingDelayMaxMs, kPacingDelayStepMs));
       preferences_.putUShort(kPrefPacingPunctuationMs, pacingPunctuationDelayMs_);
       break;
+    case kSettingsPacingTimeEstimateIndex:
+      accurateTimeEstimateEnabled_ = !accurateTimeEstimateEnabled_;
+      preferences_.putBool(kPrefAccurateTime, accurateTimeEstimateEnabled_);
+      if (accurateTimeEstimateEnabled_) {
+        rebuildTimeEstimateCache();
+      } else {
+        invalidateTimeEstimateCache();
+      }
+      rebuildSettingsMenuItems();
+      renderSettings();
+      return;
     case kSettingsPacingResetIndex:
       pacingLongWordDelayMs_ = kDefaultPacingDelayMs;
       pacingComplexWordDelayMs_ = kDefaultPacingDelayMs;
@@ -2445,6 +2461,7 @@ void App::rebuildSettingsMenuItems() {
                                  pacingDelayLabel(pacingComplexWordDelayMs_));
     settingsMenuItems_.push_back(uiText(UiText::Punctuation) + ": " +
                                  pacingDelayLabel(pacingPunctuationDelayMs_));
+    settingsMenuItems_.push_back(uiText(UiText::TimeEstimate) + ": " + timeEstimateModeLabel());
     settingsMenuItems_.push_back(uiText(UiText::ResetPacing));
   } else if (menuScreen_ == MenuScreen::WifiSettings) {
     settingsMenuItems_.push_back(uiText(UiText::Back));
@@ -2470,6 +2487,7 @@ void App::applyPacingSettings() {
                 static_cast<unsigned int>(pacingLongWordDelayMs_),
                 static_cast<unsigned int>(pacingComplexWordDelayMs_),
                 static_cast<unsigned int>(pacingPunctuationDelayMs_));
+  rebuildTimeEstimateCache();
 }
 
 OtaUpdater::Config App::preferredOtaConfig() {
@@ -3061,6 +3079,7 @@ bool App::loadBookAtIndex(size_t index, uint32_t nowMs, bool allowLegacyPosition
   paragraphStarts_ = std::move(book.paragraphStarts);
   reader_.setWords(std::move(book.words), nowMs);
   invalidateContextPreviewWindow();
+  rebuildTimeEstimateCache();
   currentBookIndex_ = loadedIndex;
   currentBookPath_ = loadedPath;
   currentBookTitle_ = book.title.isEmpty() ? displayNameForPath(loadedPath) : book.title;
@@ -3445,19 +3464,118 @@ String App::currentFooterMetricLabel() const {
 
 uint32_t App::estimatedReadingTimeRemainingMs(size_t startIndex, size_t endIndex) const {
   const size_t wordCount = reader_.wordCount();
-  if (wordCount == 0) {
+  if (wordCount == 0 || reader_.wpm() == 0) {
     return 0;
   }
 
-  startIndex = std::min(startIndex, wordCount - 1);
+  startIndex = std::min(startIndex, wordCount);
   endIndex = std::min(endIndex, wordCount);
   if (endIndex <= startIndex) {
     return 0;
   }
 
-  const size_t remainingWords = endIndex - startIndex;
-  return static_cast<uint32_t>((static_cast<uint64_t>(remainingWords) * 60000ULL) /
-                               static_cast<uint64_t>(reader_.wpm()));
+  if (!accurateTimeEstimateEnabled_ || !timeEstimateCacheValid_) {
+    const size_t remainingWords = endIndex - startIndex;
+    return static_cast<uint32_t>((static_cast<uint64_t>(remainingWords) * 60000ULL) /
+                                 static_cast<uint64_t>(reader_.wpm()));
+  }
+
+  const size_t curChapter = currentChapterIndex();
+  const size_t curChapterEnd = (curChapter + 1 < chapterMarkers_.size())
+                                   ? chapterMarkers_[curChapter + 1].wordIndex
+                                   : wordCount;
+
+  if (endIndex <= curChapterEnd) {
+    return pacingAwareDurationMsBetween(startIndex, endIndex);
+  }
+
+  uint32_t total = pacingAwareDurationMsBetween(startIndex, curChapterEnd);
+  for (size_t c = curChapter + 1; c < chapterDurationsMs_.size(); ++c) {
+    const size_t chapterStart = chapterMarkers_[c].wordIndex;
+    const size_t chapterEndIdx = (c + 1 < chapterMarkers_.size())
+                                     ? chapterMarkers_[c + 1].wordIndex
+                                     : wordCount;
+    if (chapterStart >= endIndex) {
+      break;
+    }
+    if (chapterEndIdx <= endIndex) {
+      total += chapterDurationsMs_[c];
+    } else {
+      total += pacingAwareDurationMsBetween(chapterStart, endIndex);
+      break;
+    }
+  }
+  return total;
+}
+
+uint32_t App::pacingAwareDurationMsBetween(size_t fromIndex, size_t endIndex) const {
+  const size_t n = reader_.wordCount();
+  if (n == 0) {
+    return 0;
+  }
+  fromIndex = std::min(fromIndex, n);
+  endIndex = std::min(endIndex, n);
+  if (endIndex <= fromIndex) {
+    return 0;
+  }
+  uint32_t total = 0;
+  for (size_t i = fromIndex; i < endIndex; ++i) {
+    total += reader_.wordDurationMsAt(i);
+  }
+  return total;
+}
+
+void App::invalidateTimeEstimateCache() {
+  timeEstimateCacheValid_ = false;
+  chapterDurationsMs_.clear();
+  bookDurationMs_ = 0;
+}
+
+void App::rebuildTimeEstimateCache() {
+  invalidateTimeEstimateCache();
+  if (!accurateTimeEstimateEnabled_) {
+    return;
+  }
+
+  const size_t n = reader_.wordCount();
+  if (n == 0) {
+    return;
+  }
+
+  const size_t chapterCount = std::max<size_t>(1, chapterMarkers_.size());
+  chapterDurationsMs_.assign(chapterCount, 0);
+
+  size_t chapterIdx = 0;
+  size_t chapterEnd = (chapterMarkers_.size() > 1) ? chapterMarkers_[1].wordIndex : n;
+  uint32_t acc = 0;
+  const uint32_t startMs = millis();
+  for (size_t i = 0; i < n; ++i) {
+    while (i >= chapterEnd && chapterIdx + 1 < chapterDurationsMs_.size()) {
+      chapterDurationsMs_[chapterIdx] = acc;
+      ++chapterIdx;
+      acc = 0;
+      chapterEnd = (chapterIdx + 1 < chapterMarkers_.size())
+                       ? chapterMarkers_[chapterIdx + 1].wordIndex
+                       : n;
+    }
+    acc += reader_.wordDurationMsAt(i);
+  }
+  chapterDurationsMs_[chapterIdx] = acc;
+
+  for (uint32_t d : chapterDurationsMs_) {
+    bookDurationMs_ += d;
+  }
+  timeEstimateCacheValid_ = true;
+
+  Serial.printf("[time-est] cached %u chapters total=%lums took=%lums\n",
+                static_cast<unsigned int>(chapterDurationsMs_.size()),
+                static_cast<unsigned long>(bookDurationMs_),
+                static_cast<unsigned long>(millis() - startMs));
+}
+
+String App::timeEstimateModeLabel() const {
+  return uiText(accurateTimeEstimateEnabled_ ? UiText::TimeEstimateAccurate
+                                             : UiText::TimeEstimateFast);
 }
 
 String App::formatReadingTimeRemaining(uint32_t remainingMs) const {

--- a/src/app/App.cpp
+++ b/src/app/App.cpp
@@ -3518,10 +3518,26 @@ uint32_t App::pacingAwareDurationMsBetween(size_t fromIndex, size_t endIndex) co
   if (endIndex <= fromIndex) {
     return 0;
   }
+
+  if (tailCacheValid_ && tailCacheEnd_ == endIndex && fromIndex >= tailCacheStart_) {
+    uint32_t total = tailCacheMs_;
+    for (size_t i = tailCacheStart_; i < fromIndex; ++i) {
+      const uint32_t d = reader_.wordDurationMsAt(i);
+      total = (d >= total) ? 0 : (total - d);
+    }
+    tailCacheStart_ = fromIndex;
+    tailCacheMs_ = total;
+    return total;
+  }
+
   uint32_t total = 0;
   for (size_t i = fromIndex; i < endIndex; ++i) {
     total += reader_.wordDurationMsAt(i);
   }
+  tailCacheValid_ = true;
+  tailCacheStart_ = fromIndex;
+  tailCacheEnd_ = endIndex;
+  tailCacheMs_ = total;
   return total;
 }
 
@@ -3529,6 +3545,7 @@ void App::invalidateTimeEstimateCache() {
   timeEstimateCacheValid_ = false;
   chapterDurationsMs_.clear();
   bookDurationMs_ = 0;
+  tailCacheValid_ = false;
 }
 
 void App::rebuildTimeEstimateCache() {

--- a/src/app/App.h
+++ b/src/app/App.h
@@ -348,6 +348,7 @@ class App {
   bool timeEstimateCacheValid_ = false;
   bool accurateTimeEstimateEnabled_ = true;
   bool pacingCacheDirty_ = false;
+  uint32_t pacingCacheDirtyAtMs_ = 0;
   std::vector<DisplayManager::ContextWord> contextPreviewWords_;
   std::vector<WifiNetworkInfo> wifiNetworks_;
   std::vector<TextEntryButton> textEntryButtons_;

--- a/src/app/App.h
+++ b/src/app/App.h
@@ -344,11 +344,10 @@ class App {
   std::vector<String> chapterMenuItems_;
   std::vector<ChapterMarker> chapterMarkers_;
   std::vector<size_t> paragraphStarts_;
-  std::vector<uint32_t> wordPrefixSumMs_;
+  std::vector<uint32_t> wordBonusPrefixSumMs_;
   bool timeEstimateCacheValid_ = false;
   bool accurateTimeEstimateEnabled_ = true;
   bool pacingCacheDirty_ = false;
-  uint32_t pacingCacheDirtyAtMs_ = 0;
   std::vector<DisplayManager::ContextWord> contextPreviewWords_;
   std::vector<WifiNetworkInfo> wifiNetworks_;
   std::vector<TextEntryButton> textEntryButtons_;

--- a/src/app/App.h
+++ b/src/app/App.h
@@ -348,6 +348,10 @@ class App {
   uint32_t bookDurationMs_ = 0;
   bool timeEstimateCacheValid_ = false;
   bool accurateTimeEstimateEnabled_ = true;
+  mutable bool tailCacheValid_ = false;
+  mutable size_t tailCacheStart_ = 0;
+  mutable size_t tailCacheEnd_ = 0;
+  mutable uint32_t tailCacheMs_ = 0;
   std::vector<DisplayManager::ContextWord> contextPreviewWords_;
   std::vector<WifiNetworkInfo> wifiNetworks_;
   std::vector<TextEntryButton> textEntryButtons_;

--- a/src/app/App.h
+++ b/src/app/App.h
@@ -255,7 +255,11 @@ class App {
   String currentChapterLabel() const;
   String currentFooterMetricLabel() const;
   uint32_t estimatedReadingTimeRemainingMs(size_t startIndex, size_t endIndex) const;
+  uint32_t pacingAwareDurationMsBetween(size_t fromIndex, size_t endIndex) const;
+  void rebuildTimeEstimateCache();
+  void invalidateTimeEstimateCache();
   String formatReadingTimeRemaining(uint32_t remainingMs) const;
+  String timeEstimateModeLabel() const;
   uint8_t readingProgressPercent() const;
   void renderReaderWord();
   void renderContextPreview();
@@ -340,6 +344,10 @@ class App {
   std::vector<String> chapterMenuItems_;
   std::vector<ChapterMarker> chapterMarkers_;
   std::vector<size_t> paragraphStarts_;
+  std::vector<uint32_t> chapterDurationsMs_;
+  uint32_t bookDurationMs_ = 0;
+  bool timeEstimateCacheValid_ = false;
+  bool accurateTimeEstimateEnabled_ = true;
   std::vector<DisplayManager::ContextWord> contextPreviewWords_;
   std::vector<WifiNetworkInfo> wifiNetworks_;
   std::vector<TextEntryButton> textEntryButtons_;

--- a/src/app/App.h
+++ b/src/app/App.h
@@ -258,6 +258,7 @@ class App {
   uint32_t pacingAwareDurationMsBetween(size_t fromIndex, size_t endIndex) const;
   void rebuildTimeEstimateCache();
   void invalidateTimeEstimateCache();
+  void flushPendingTimeEstimateRebuild();
   String formatReadingTimeRemaining(uint32_t remainingMs) const;
   String timeEstimateModeLabel() const;
   uint8_t readingProgressPercent() const;
@@ -349,6 +350,7 @@ class App {
   uint32_t bookDurationMs_ = 0;
   bool timeEstimateCacheValid_ = false;
   bool accurateTimeEstimateEnabled_ = true;
+  bool pacingCacheDirty_ = false;
   std::vector<DisplayManager::ContextWord> contextPreviewWords_;
   std::vector<WifiNetworkInfo> wifiNetworks_;
   std::vector<TextEntryButton> textEntryButtons_;

--- a/src/app/App.h
+++ b/src/app/App.h
@@ -345,13 +345,10 @@ class App {
   std::vector<ChapterMarker> chapterMarkers_;
   std::vector<size_t> paragraphStarts_;
   std::vector<uint32_t> chapterDurationsMs_;
+  std::vector<uint32_t> wordPrefixSumMs_;
   uint32_t bookDurationMs_ = 0;
   bool timeEstimateCacheValid_ = false;
   bool accurateTimeEstimateEnabled_ = true;
-  mutable bool tailCacheValid_ = false;
-  mutable size_t tailCacheStart_ = 0;
-  mutable size_t tailCacheEnd_ = 0;
-  mutable uint32_t tailCacheMs_ = 0;
   std::vector<DisplayManager::ContextWord> contextPreviewWords_;
   std::vector<WifiNetworkInfo> wifiNetworks_;
   std::vector<TextEntryButton> textEntryButtons_;

--- a/src/app/App.h
+++ b/src/app/App.h
@@ -255,7 +255,6 @@ class App {
   String currentChapterLabel() const;
   String currentFooterMetricLabel() const;
   uint32_t estimatedReadingTimeRemainingMs(size_t startIndex, size_t endIndex) const;
-  uint32_t pacingAwareDurationMsBetween(size_t fromIndex, size_t endIndex) const;
   void rebuildTimeEstimateCache();
   void invalidateTimeEstimateCache();
   void flushPendingTimeEstimateRebuild();
@@ -345,9 +344,7 @@ class App {
   std::vector<String> chapterMenuItems_;
   std::vector<ChapterMarker> chapterMarkers_;
   std::vector<size_t> paragraphStarts_;
-  std::vector<uint32_t> chapterDurationsMs_;
   std::vector<uint32_t> wordPrefixSumMs_;
-  uint32_t bookDurationMs_ = 0;
   bool timeEstimateCacheValid_ = false;
   bool accurateTimeEstimateEnabled_ = true;
   bool pacingCacheDirty_ = false;

--- a/src/app/Localization.h
+++ b/src/app/Localization.h
@@ -66,6 +66,9 @@ enum class UiText : uint8_t {
   Standard,
   RsvpMode,
   ScrollMode,
+  TimeEstimate,
+  TimeEstimateAccurate,
+  TimeEstimateFast,
 };
 
 namespace Localization {
@@ -211,6 +214,12 @@ inline const char *text(UiLanguage language, UiText key) {
           return "RSVP";
         case UiText::ScrollMode:
           return "Scroll pagina";
+        case UiText::TimeEstimate:
+          return "Tiempo restante";
+        case UiText::TimeEstimateAccurate:
+          return "Preciso";
+        case UiText::TimeEstimateFast:
+          return "Rapido";
       }
       break;
     case UiLanguage::French:
@@ -321,6 +330,12 @@ inline const char *text(UiLanguage language, UiText key) {
           return "RSVP";
         case UiText::ScrollMode:
           return "Defilement page";
+        case UiText::TimeEstimate:
+          return "Temps restant";
+        case UiText::TimeEstimateAccurate:
+          return "Precis";
+        case UiText::TimeEstimateFast:
+          return "Rapide";
       }
       break;
     case UiLanguage::German:
@@ -431,6 +446,12 @@ inline const char *text(UiLanguage language, UiText key) {
           return "RSVP";
         case UiText::ScrollMode:
           return "Seiten-Scroll";
+        case UiText::TimeEstimate:
+          return "Restzeit";
+        case UiText::TimeEstimateAccurate:
+          return "Genau";
+        case UiText::TimeEstimateFast:
+          return "Schnell";
       }
       break;
     case UiLanguage::Romanian:
@@ -541,6 +562,12 @@ inline const char *text(UiLanguage language, UiText key) {
           return "RSVP";
         case UiText::ScrollMode:
           return "Derulare pagina";
+        case UiText::TimeEstimate:
+          return "Timp ramas";
+        case UiText::TimeEstimateAccurate:
+          return "Exact";
+        case UiText::TimeEstimateFast:
+          return "Rapid";
       }
       break;
     case UiLanguage::Polish:
@@ -651,6 +678,12 @@ inline const char *text(UiLanguage language, UiText key) {
           return "RSVP";
         case UiText::ScrollMode:
           return "Scroll strony";
+        case UiText::TimeEstimate:
+          return "Pozostaly czas";
+        case UiText::TimeEstimateAccurate:
+          return "Dokladny";
+        case UiText::TimeEstimateFast:
+          return "Szybki";
       }
       break;
     case UiLanguage::English:
@@ -762,6 +795,12 @@ inline const char *text(UiLanguage language, UiText key) {
           return "RSVP";
         case UiText::ScrollMode:
           return "Page scroll";
+        case UiText::TimeEstimate:
+          return "Time estimate";
+        case UiText::TimeEstimateAccurate:
+          return "Accurate";
+        case UiText::TimeEstimateFast:
+          return "Fast";
       }
       break;
   }

--- a/src/reader/ReadingLoop.cpp
+++ b/src/reader/ReadingLoop.cpp
@@ -529,10 +529,10 @@ uint16_t punctuationPausePercentForWord(const String &word, bool nextWordStartsL
   }
 }
 
-uint32_t durationForWord(const String &word, bool nextWordStartsLowercase, uint32_t baseIntervalMs,
-                         const ReadingLoop::PacingConfig &config) {
-  if (word.isEmpty() || baseIntervalMs == 0) {
-    return baseIntervalMs;
+uint32_t pacingBonusMsForWord(const String &word, bool nextWordStartsLowercase,
+                              const ReadingLoop::PacingConfig &config) {
+  if (word.isEmpty()) {
+    return 0;
   }
 
   uint32_t totalBonusMs = 0;
@@ -546,8 +546,15 @@ uint32_t durationForWord(const String &word, bool nextWordStartsLowercase, uint3
       scaledDelayMs(scaledPercent(punctuationPausePercentForWord(word, nextWordStartsLowercase),
                                   config.punctuationScalePercent),
                     config.punctuationDelayMs);
+  return totalBonusMs;
+}
 
-  return baseIntervalMs + totalBonusMs;
+uint32_t durationForWord(const String &word, bool nextWordStartsLowercase, uint32_t baseIntervalMs,
+                         const ReadingLoop::PacingConfig &config) {
+  if (baseIntervalMs == 0) {
+    return 0;
+  }
+  return baseIntervalMs + pacingBonusMsForWord(word, nextWordStartsLowercase, config);
 }
 
 }  // namespace
@@ -618,6 +625,17 @@ uint32_t ReadingLoop::wordDurationMsAt(size_t index) const {
   const String word = wordAt(index);
   const bool nextLowercase = nextWordStartsLowercaseAt(index);
   return durationForWord(word, nextLowercase, wordIntervalMs(), pacingConfig_);
+}
+
+uint32_t ReadingLoop::wordPacingBonusMsAt(size_t index) const {
+  const size_t count = wordCount();
+  if (count == 0 || index >= count) {
+    return 0;
+  }
+
+  const String word = wordAt(index);
+  const bool nextLowercase = nextWordStartsLowercaseAt(index);
+  return pacingBonusMsForWord(word, nextLowercase, pacingConfig_);
 }
 
 uint32_t ReadingLoop::elapsedInCurrentWordMs(uint32_t nowMs) const {

--- a/src/reader/ReadingLoop.cpp
+++ b/src/reader/ReadingLoop.cpp
@@ -616,17 +616,6 @@ uint32_t ReadingLoop::currentWordDurationMs() const {
   return durationForWord(currentWord_, nextWordStartsLowercase, wordIntervalMs(), pacingConfig_);
 }
 
-uint32_t ReadingLoop::wordDurationMsAt(size_t index) const {
-  const size_t count = wordCount();
-  if (count == 0 || index >= count) {
-    return 0;
-  }
-
-  const String word = wordAt(index);
-  const bool nextLowercase = nextWordStartsLowercaseAt(index);
-  return durationForWord(word, nextLowercase, wordIntervalMs(), pacingConfig_);
-}
-
 uint32_t ReadingLoop::wordPacingBonusMsAt(size_t index) const {
   const size_t count = wordCount();
   if (count == 0 || index >= count) {

--- a/src/reader/ReadingLoop.cpp
+++ b/src/reader/ReadingLoop.cpp
@@ -609,6 +609,17 @@ uint32_t ReadingLoop::currentWordDurationMs() const {
   return durationForWord(currentWord_, nextWordStartsLowercase, wordIntervalMs(), pacingConfig_);
 }
 
+uint32_t ReadingLoop::wordDurationMsAt(size_t index) const {
+  const size_t count = wordCount();
+  if (count == 0 || index >= count) {
+    return 0;
+  }
+
+  const String word = wordAt(index);
+  const bool nextLowercase = nextWordStartsLowercaseAt(index);
+  return durationForWord(word, nextLowercase, wordIntervalMs(), pacingConfig_);
+}
+
 uint32_t ReadingLoop::elapsedInCurrentWordMs(uint32_t nowMs) const {
   if (nowMs <= lastAdvanceMs_) {
     return 0;

--- a/src/reader/ReadingLoop.h
+++ b/src/reader/ReadingLoop.h
@@ -34,6 +34,7 @@ class ReadingLoop {
   uint16_t wpm() const;
   uint32_t wordIntervalMs() const;
   uint32_t currentWordDurationMs() const;
+  uint32_t wordDurationMsAt(size_t index) const;
   uint32_t elapsedInCurrentWordMs(uint32_t nowMs) const;
   bool currentWordEndsSentence() const;
   bool atEnd() const;

--- a/src/reader/ReadingLoop.h
+++ b/src/reader/ReadingLoop.h
@@ -34,7 +34,6 @@ class ReadingLoop {
   uint16_t wpm() const;
   uint32_t wordIntervalMs() const;
   uint32_t currentWordDurationMs() const;
-  uint32_t wordDurationMsAt(size_t index) const;
   uint32_t wordPacingBonusMsAt(size_t index) const;
   uint32_t elapsedInCurrentWordMs(uint32_t nowMs) const;
   bool currentWordEndsSentence() const;

--- a/src/reader/ReadingLoop.h
+++ b/src/reader/ReadingLoop.h
@@ -35,6 +35,7 @@ class ReadingLoop {
   uint32_t wordIntervalMs() const;
   uint32_t currentWordDurationMs() const;
   uint32_t wordDurationMsAt(size_t index) const;
+  uint32_t wordPacingBonusMsAt(size_t index) const;
   uint32_t elapsedInCurrentWordMs(uint32_t nowMs) const;
   bool currentWordEndsSentence() const;
   bool atEnd() const;

--- a/test/test_pacing/test_main.cpp
+++ b/test/test_pacing/test_main.cpp
@@ -446,6 +446,33 @@ void test_word_duration_at_scales_with_wpm(void) {
   TEST_ASSERT_TRUE(r.wordDurationMsAt(0) < base);
 }
 
+void test_word_pacing_bonus_at_is_invariant_to_wpm(void) {
+  // The pacing bonus is the WPM-independent part of the per-word duration. Changing WPM must not
+  // change the bonus, which lets us cache it once per book.
+  ReadingLoop r = makeReader(300, {"This", "is,", "honestly,", "information.", "Then"});
+  uint32_t baselineBonuses[5];
+  for (size_t i = 0; i < 5; ++i) {
+    baselineBonuses[i] = r.wordPacingBonusMsAt(i);
+    TEST_ASSERT_EQUAL_UINT32(r.wordDurationMsAt(i) - r.wordIntervalMs(), baselineBonuses[i]);
+  }
+
+  r.setWpm(600);
+  for (size_t i = 0; i < 5; ++i) {
+    TEST_ASSERT_EQUAL_UINT32(baselineBonuses[i], r.wordPacingBonusMsAt(i));
+  }
+
+  r.setWpm(150);
+  for (size_t i = 0; i < 5; ++i) {
+    TEST_ASSERT_EQUAL_UINT32(baselineBonuses[i], r.wordPacingBonusMsAt(i));
+  }
+}
+
+void test_word_pacing_bonus_at_out_of_range_returns_zero(void) {
+  ReadingLoop r = makeReader(300, {"a", "b"});
+  TEST_ASSERT_EQUAL_UINT32(0u, r.wordPacingBonusMsAt(2));
+  TEST_ASSERT_EQUAL_UINT32(0u, r.wordPacingBonusMsAt(99));
+}
+
 // ---------------------------------------------------------------------------
 // Main
 // ---------------------------------------------------------------------------
@@ -515,6 +542,8 @@ int main(void) {
   RUN_TEST(test_word_duration_at_out_of_range_returns_zero);
   RUN_TEST(test_word_duration_at_sum_uses_pacing_bonuses);
   RUN_TEST(test_word_duration_at_scales_with_wpm);
+  RUN_TEST(test_word_pacing_bonus_at_is_invariant_to_wpm);
+  RUN_TEST(test_word_pacing_bonus_at_out_of_range_returns_zero);
 
   return UNITY_END();
 }

--- a/test/test_pacing/test_main.cpp
+++ b/test/test_pacing/test_main.cpp
@@ -391,59 +391,27 @@ void test_word_at_returns_correct_word(void) {
 }
 
 // ---------------------------------------------------------------------------
-// wordDurationMsAt: pacing-aware per-word duration for time estimates
+// wordPacingBonusMsAt: WPM-independent per-word bonus used by the time-estimate cache
 // ---------------------------------------------------------------------------
 
-void test_word_duration_at_matches_current_after_seek(void) {
-  ReadingLoop r = makeReader(300, {"This", "is", "fine.", "Then", "done."});
-  for (size_t i = 0; i < 5; ++i) {
-    r.seekTo(i);
-    TEST_ASSERT_EQUAL_UINT32(r.currentWordDurationMs(), r.wordDurationMsAt(i));
-  }
-}
-
-void test_word_duration_at_out_of_range_returns_zero(void) {
-  ReadingLoop r = makeReader(300, {"a", "b"});
-  TEST_ASSERT_EQUAL_UINT32(0u, r.wordDurationMsAt(2));
-  TEST_ASSERT_EQUAL_UINT32(0u, r.wordDurationMsAt(99));
-}
-
-void test_word_duration_at_sum_uses_pacing_bonuses(void) {
-  // Phrase mixes a comma pause, a sentence pause, and a long word so the pacing-aware sum is
-  // strictly larger than the naive uniform-pacing estimate.
+void test_word_pacing_bonus_at_sum_matches_expected(void) {
+  // Phrase mixes a comma pause, a sentence pause, and a long word so the bonus sum is non-zero.
   ReadingLoop r = makeReader(300, {"This", "is,", "honestly,", "information.", "Then"});
 
-  uint32_t pacingAwareSum = 0;
+  uint32_t bonusSum = 0;
   for (size_t i = 0; i < 5; ++i) {
-    pacingAwareSum += r.wordDurationMsAt(i);
+    bonusSum += r.wordPacingBonusMsAt(i);
   }
-  const uint32_t naiveSum = 5u * r.wordIntervalMs();
-  TEST_ASSERT_TRUE(pacingAwareSum > naiveSum);
 
-  // Recompute manually:
-  //   "This"          → 200 (base)
-  //   "is,"           → 200 + comma(45% of 200) = 290
-  //   "honestly,"     → readable=8, tier1 extra=2→12%; syllables h,o(1),n,e(2),s,t,l,y(3 if y vowel?
-  //                       y is treated as vowel by LatinText::isVowel → groups=3, but lettersOnly="honestly"
-  //                       ends 'y' (not 'e'), no decrement → groups=3 → syll bonus=(3-2)*10=10%.
-  //                       length 12% + complexity 10% + comma 45% = 67% → 200 + 134 = 334.
-  //   "information."  → next "Then" (uppercase) → sentence pause +135%.
-  //                       length: readable=11. tier1 extra=5→30, tier2 extra=1→9 = 39%.
-  //                       complexity: syllables=4, (4-2)*10=20% → length 39 + complexity 20 = 59%.
-  //                       total = 59% + 135% = 194% → 200 + 388 = 588.
-  //   "Then"          → 200 (base).
-  // Expected = 200 + 290 + 334 + 588 + 200 = 1612.
-  TEST_ASSERT_EQUAL_UINT32(1612u, pacingAwareSum);
-}
-
-void test_word_duration_at_scales_with_wpm(void) {
-  ReadingLoop r = makeReader(300, {"This", "is,", "fine."});
-  const uint32_t base = r.wordDurationMsAt(0);
-
-  // wordIntervalMs at 600 is half of 300; punctuation bonuses are absolute (ms), so faster WPM
-  // produces a strictly smaller per-word duration.
-  r.setWpm(600);
-  TEST_ASSERT_TRUE(r.wordDurationMsAt(0) < base);
+  // Per-word bonuses (base interval is 200 ms at 300 WPM):
+  //   "This"          → 0
+  //   "is,"           → comma(45% of 200) = 90
+  //   "honestly,"     → length 12% + complexity 10% + comma 45% = 67% of 200 = 134.
+  //   "information."  → length 39% + complexity 20% + sentence 135% (next "Then" uppercase) = 194%
+  //                     of 200 = 388.
+  //   "Then"          → 0.
+  // Expected = 0 + 90 + 134 + 388 + 0 = 612.
+  TEST_ASSERT_EQUAL_UINT32(612u, bonusSum);
 }
 
 void test_word_pacing_bonus_at_is_invariant_to_wpm(void) {
@@ -453,7 +421,6 @@ void test_word_pacing_bonus_at_is_invariant_to_wpm(void) {
   uint32_t baselineBonuses[5];
   for (size_t i = 0; i < 5; ++i) {
     baselineBonuses[i] = r.wordPacingBonusMsAt(i);
-    TEST_ASSERT_EQUAL_UINT32(r.wordDurationMsAt(i) - r.wordIntervalMs(), baselineBonuses[i]);
   }
 
   r.setWpm(600);
@@ -464,6 +431,16 @@ void test_word_pacing_bonus_at_is_invariant_to_wpm(void) {
   r.setWpm(150);
   for (size_t i = 0; i < 5; ++i) {
     TEST_ASSERT_EQUAL_UINT32(baselineBonuses[i], r.wordPacingBonusMsAt(i));
+  }
+}
+
+void test_word_pacing_bonus_plus_interval_equals_current_duration(void) {
+  // Sanity check that base + bonus reconstructs the runtime per-word duration.
+  ReadingLoop r = makeReader(300, {"This", "is,", "fine.", "Then"});
+  for (size_t i = 0; i < 4; ++i) {
+    r.seekTo(i);
+    TEST_ASSERT_EQUAL_UINT32(r.wordIntervalMs() + r.wordPacingBonusMsAt(i),
+                             r.currentWordDurationMs());
   }
 }
 
@@ -538,11 +515,9 @@ int main(void) {
 
   RUN_TEST(test_word_at_returns_correct_word);
 
-  RUN_TEST(test_word_duration_at_matches_current_after_seek);
-  RUN_TEST(test_word_duration_at_out_of_range_returns_zero);
-  RUN_TEST(test_word_duration_at_sum_uses_pacing_bonuses);
-  RUN_TEST(test_word_duration_at_scales_with_wpm);
+  RUN_TEST(test_word_pacing_bonus_at_sum_matches_expected);
   RUN_TEST(test_word_pacing_bonus_at_is_invariant_to_wpm);
+  RUN_TEST(test_word_pacing_bonus_plus_interval_equals_current_duration);
   RUN_TEST(test_word_pacing_bonus_at_out_of_range_returns_zero);
 
   return UNITY_END();

--- a/test/test_pacing/test_main.cpp
+++ b/test/test_pacing/test_main.cpp
@@ -391,6 +391,62 @@ void test_word_at_returns_correct_word(void) {
 }
 
 // ---------------------------------------------------------------------------
+// wordDurationMsAt: pacing-aware per-word duration for time estimates
+// ---------------------------------------------------------------------------
+
+void test_word_duration_at_matches_current_after_seek(void) {
+  ReadingLoop r = makeReader(300, {"This", "is", "fine.", "Then", "done."});
+  for (size_t i = 0; i < 5; ++i) {
+    r.seekTo(i);
+    TEST_ASSERT_EQUAL_UINT32(r.currentWordDurationMs(), r.wordDurationMsAt(i));
+  }
+}
+
+void test_word_duration_at_out_of_range_returns_zero(void) {
+  ReadingLoop r = makeReader(300, {"a", "b"});
+  TEST_ASSERT_EQUAL_UINT32(0u, r.wordDurationMsAt(2));
+  TEST_ASSERT_EQUAL_UINT32(0u, r.wordDurationMsAt(99));
+}
+
+void test_word_duration_at_sum_uses_pacing_bonuses(void) {
+  // Phrase mixes a comma pause, a sentence pause, and a long word so the pacing-aware sum is
+  // strictly larger than the naive uniform-pacing estimate.
+  ReadingLoop r = makeReader(300, {"This", "is,", "honestly,", "information.", "Then"});
+
+  uint32_t pacingAwareSum = 0;
+  for (size_t i = 0; i < 5; ++i) {
+    pacingAwareSum += r.wordDurationMsAt(i);
+  }
+  const uint32_t naiveSum = 5u * r.wordIntervalMs();
+  TEST_ASSERT_TRUE(pacingAwareSum > naiveSum);
+
+  // Recompute manually:
+  //   "This"          → 200 (base)
+  //   "is,"           → 200 + comma(45% of 200) = 290
+  //   "honestly,"     → readable=8, tier1 extra=2→12%; syllables h,o(1),n,e(2),s,t,l,y(3 if y vowel?
+  //                       y is treated as vowel by LatinText::isVowel → groups=3, but lettersOnly="honestly"
+  //                       ends 'y' (not 'e'), no decrement → groups=3 → syll bonus=(3-2)*10=10%.
+  //                       length 12% + complexity 10% + comma 45% = 67% → 200 + 134 = 334.
+  //   "information."  → next "Then" (uppercase) → sentence pause +135%.
+  //                       length: readable=11. tier1 extra=5→30, tier2 extra=1→9 = 39%.
+  //                       complexity: syllables=4, (4-2)*10=20% → length 39 + complexity 20 = 59%.
+  //                       total = 59% + 135% = 194% → 200 + 388 = 588.
+  //   "Then"          → 200 (base).
+  // Expected = 200 + 290 + 334 + 588 + 200 = 1612.
+  TEST_ASSERT_EQUAL_UINT32(1612u, pacingAwareSum);
+}
+
+void test_word_duration_at_scales_with_wpm(void) {
+  ReadingLoop r = makeReader(300, {"This", "is,", "fine."});
+  const uint32_t base = r.wordDurationMsAt(0);
+
+  // wordIntervalMs at 600 is half of 300; punctuation bonuses are absolute (ms), so faster WPM
+  // produces a strictly smaller per-word duration.
+  r.setWpm(600);
+  TEST_ASSERT_TRUE(r.wordDurationMsAt(0) < base);
+}
+
+// ---------------------------------------------------------------------------
 // Main
 // ---------------------------------------------------------------------------
 
@@ -454,6 +510,11 @@ int main(void) {
   RUN_TEST(test_rewind_sentence_ignores_abbreviation_periods);
 
   RUN_TEST(test_word_at_returns_correct_word);
+
+  RUN_TEST(test_word_duration_at_matches_current_after_seek);
+  RUN_TEST(test_word_duration_at_out_of_range_returns_zero);
+  RUN_TEST(test_word_duration_at_sum_uses_pacing_bonuses);
+  RUN_TEST(test_word_duration_at_scales_with_wpm);
 
   return UNITY_END();
 }


### PR DESCRIPTION
## Summary

The footer's predicted time-remaining (for the current chapter and the whole book) currently divides remaining word count by WPM, which underestimates how long is actually left because it ignores the per-word punctuation pauses, long-word delays, and complexity bonuses added by `ReadingLoop` pacing. On punctuation-dense or chapter-rich text the discrepancy compounds — a chapter that will really take ~30 minutes predicts ~22 left at the start.

This branch makes the *prediction* match what the reader will actually do: it sums the per-word durations (`baseIntervalMs(wpm) + pacingBonusMs(word, config)`) over the words ahead of the cursor rather than just the base intervals.

## What changed

- **`ReadingLoop::wordPacingBonusMsAt(index)`** — exposes the WPM-independent pacing bonus for an arbitrary word. The existing `durationForWord` is split into a `pacingBonusMsForWord` helper + base interval so the bonus can be computed without recomputing the base.
- **`App` prefix-sum cache** — `wordBonusPrefixSumMs_` is a per-word prefix sum of bonuses built once per book load. `estimatedReadingTimeRemainingMs(start, end)` becomes `(end-start)*60000/wpm + prefix[end] - prefix[start]`, i.e. O(1) regardless of how often the footer redraws.
- **Settings → Pacing → Time estimate: Accurate / Fast** — toggle to fall back to the old uniform-pacing math (e.g. for users who prefer the optimistic estimate, or to skip the rebuild cost on very large books). Stored in NVS (`time_est_a`). Defaults to Accurate. Six languages added in `Localization.h`.
- **Cache lifecycle**
  - Built on book load and on demo-text bootstrap.
  - Pacing-delay changes inside Settings → Pacing mark the cache dirty and flush on menu exit, so dragging through three sliders rebuilds once, not three times.
  - WPM scrub touches no cache at all — the cache stores only the WPM-invariant bonus, so the base interval is recomputed on the fly. This keeps the WPM gesture smooth even on books with tens of thousands of words.

## Footprint

```
 src/app/App.cpp                | ~85 lines (cache + settings plumbing)
 src/app/App.h                  | ~8 lines
 src/app/Localization.h         | 3 new UiText keys × 6 languages
 src/reader/ReadingLoop.{h,cpp} | wordPacingBonusMsAt + helper split
 test/test_pacing/test_main.cpp | 4 new tests (sum, WPM invariance,
                                  base+bonus identity, out-of-range)
```

Flash: +0.3% (34.0% of 6.25 MB). RAM: +N×4 bytes for the prefix sum, where N is the loaded book's word count.

## Test plan

- [x] `pio test -e native_test -f test_pacing` — 54/54 pass (includes 4 new pacing-bonus tests).
- [x] Firmware builds clean for `waveshare_esp32s3_usb_msc`.
- [x] Flashed to device. Verified on a real book:
  - The predicted time remaining for chapter and book is higher than the old (uniform-pacing) prediction, and the gap matches the pacing bonuses on the words ahead of the cursor.
  - The prediction decreases roughly in line with how long passages of dense punctuation or long words actually take, instead of running ahead of the cursor like the old estimate did.
  - WPM scrub gesture is smooth at any WPM, no cache rebuild lag.
  - Settings → Pacing slider drag is smooth; rebuild happens once on Back.
  - Toggling Accurate/Fast in Settings → Pacing flips the prediction immediately.
- [x] OTA-friendly: no SD writes, settings live in `Preferences`.

## Notes for review

- `.gitignore` adds `.claude` and `CLAUDE.md` (personal AI assistant artifacts, matching the existing `.codex` entry). Happy to drop these from the PR if upstream prefers a clean ignore list.
- The cache is destroyed via `std::vector::swap` on invalidate to actually release the heap pages — important on ESP32-S3 where fragmentation matters.