### PR TITLE
fix: Implement backlight control during deep sleep mode

### DIFF
--- a/src/app/App.cpp
+++ b/src/app/App.cpp
@@ -2938,12 +2938,14 @@ void App::enterPowerOff(uint32_t nowMs) {
 
   display_.renderStatus("OFF", "Release PWR", "Hold PWR to start");
   delay(300);
+  display_.prepareForSleep();
 
   storage_.end();
   touch_.end();
   touchInitialized_ = false;
   Serial.flush();
 
+  BoardConfig::holdBacklightOffForDeepSleep();
   BoardConfig::releaseBatteryPowerHold();
 
   const uint32_t waitStartMs = millis();
@@ -2952,7 +2954,6 @@ void App::enterPowerOff(uint32_t nowMs) {
     delay(10);
   }
 
-  display_.prepareForSleep();
   esp_sleep_enable_ext0_wakeup(static_cast<gpio_num_t>(BoardConfig::PIN_PWR_BUTTON), 0);
   esp_deep_sleep_start();
 }

--- a/src/board/BoardConfig.cpp
+++ b/src/board/BoardConfig.cpp
@@ -143,6 +143,8 @@ uint8_t batteryPercentForVoltage(float voltage) {
 void begin() {
   pinMode(PIN_BOOT_BUTTON, INPUT_PULLUP);
   pinMode(PIN_PWR_BUTTON, INPUT_PULLUP);
+  gpio_deep_sleep_hold_dis();
+  gpio_hold_dis(static_cast<gpio_num_t>(PIN_LCD_BACKLIGHT));
   pinMode(PIN_LCD_BACKLIGHT, OUTPUT);
   digitalWrite(PIN_LCD_BACKLIGHT, LOW);
 
@@ -169,6 +171,20 @@ void lightSleepUntilBootButton() {
   esp_light_sleep_start();
   gpio_wakeup_disable(static_cast<gpio_num_t>(PIN_BOOT_BUTTON));
   esp_sleep_disable_wakeup_source(ESP_SLEEP_WAKEUP_GPIO);
+}
+
+void holdBacklightOffForDeepSleep() {
+  const gpio_num_t backlightPin = static_cast<gpio_num_t>(PIN_LCD_BACKLIGHT);
+
+  // The LCD backlight is active-low. Hold the inactive level while the ESP32 is in deep sleep,
+  // because PWM output stops there and can otherwise leave the backlight pin floating.
+  analogWrite(PIN_LCD_BACKLIGHT, 255);
+  pinMode(PIN_LCD_BACKLIGHT, OUTPUT);
+  digitalWrite(PIN_LCD_BACKLIGHT, HIGH);
+  gpio_set_direction(backlightPin, GPIO_MODE_OUTPUT);
+  gpio_set_level(backlightPin, 1);
+  gpio_hold_en(backlightPin);
+  gpio_deep_sleep_hold_en();
 }
 
 bool readBatteryStatus(BatteryStatus &status) {

--- a/src/board/BoardConfig.h
+++ b/src/board/BoardConfig.h
@@ -58,6 +58,7 @@ struct BatteryStatus {
 
 void begin();
 void lightSleepUntilBootButton();
+void holdBacklightOffForDeepSleep();
 bool readBatteryStatus(BatteryStatus &status);
 bool releaseBatteryPowerHold();
 


### PR DESCRIPTION
Great project! Just got the device a few days ago and have been playing around with it for a while. The work is solid and excited to know how it will grow.

I got the case B version and I am still waiting for an MX1.25 connector to arrive so I can adapt a battery I have laying around, in the meantime I am hooked to a power bank or my phone to use it. However, I noticed that in the power-off mode, the backlight for the screen is turned on and would consume more battery once I install it. This PR fixes this and I'm running my fork locally to test it.