### PR TITLE
Resolve PR #32: document Snap Chromium USB access

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -548,6 +548,7 @@
         <ol>
           <li>Use Chrome or Edge on macOS, Windows, Linux, or ChromeOS.</li>
           <li>Connect the device with a USB data cable.</li>
+          <li>On Linux, if you use Chromium from Snap (for example on Ubuntu), grant raw USB access once by running <code>sudo snap connect chromium:raw-usb</code> in a terminal, then restart Chromium.</li>
           <li>If the installer cannot connect, hold <code>BOOT</code>, tap reset or power-cycle, then try again.</li>
           <li>After flashing, place books on the SD card under <code>/books</code>.</li>
         </ol>


### PR DESCRIPTION
Carries PR #32's Snap Chromium raw USB note forward onto the current web flasher step-card UI.

The original PR branch conflicts with the newer web flasher layout, so this branch preserves the contributor commit as a merge parent and resolves the note into the current Install Firmware instructions.