### PR TITLE
Improved UX: the page proactively tells the user if there are updates

### DIFF
--- a/web/components/install-firmware.js
+++ b/web/components/install-firmware.js
@@ -1,7 +1,7 @@
 const FLASH_KEY = "rsvpnano_last_flash";
 
 function timeAgo(ts) {
-  const s = Math.floor((Date.now() - ts) / 1000);
+  const s = Math.max(0, Math.floor((Date.now() - ts) / 1000));
   if (s < 60) return "just now";
   const m = Math.floor(s / 60);
   if (m < 60) return m + (m === 1 ? " minute ago" : " minutes ago");
@@ -14,14 +14,17 @@ function timeAgo(ts) {
 class InstallFirmware extends HTMLElement {
   connectedCallback() {
     this.innerHTML = `
-      <section class="card install-steps" id="install-section">
-        <button class="section-header" id="install-toggle" type="button" aria-expanded="true">
-          <div style="flex:1;display:flex;align-items:center;gap:10px">
+      <section class="card step-card" id="install-section">
+        <button class="step-card-toggle" id="install-toggle" type="button" aria-expanded="true" aria-controls="install-content">
+          <span class="section-header-main">
             <span class="step-number">1</span>
-            <h2>Install Firmware</h2>
-          </div>
+            <span class="section-header-label">
+              <span class="section-kicker">Browser Flasher</span>
+              <span class="section-title">Install Firmware</span>
+            </span>
+          </span>
           <span class="flash-history" id="flash-history"></span>
-          <svg class="chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"></polyline></svg>
+          <svg class="chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"></polyline></svg>
         </button>
         <div class="section-body" id="install-content">
           <div class="section-body-inner">
@@ -41,8 +44,18 @@ class InstallFirmware extends HTMLElement {
                 <span class="latest-badge"><span class="pulse-dot"></span>Latest Release</span>
               </div>
               <ul class="feature-list"></ul>
+              <div id="uptodate-badge" class="uptodate-badge" hidden>
+                <span class="uptodate-left">
+                  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"></polyline></svg>
+                  Up to date
+                </span>
+                <span class="uptodate-right">
+                  <span id="uptodate-version"></span>
+                  <span id="uptodate-ago"></span>
+                </span>
+              </div>
               <esp-web-install-button manifest="firmware/manifest.json">
-                <button slot="activate">Install Firmware</button>
+                <button id="firmware-install-btn" slot="activate">Install Firmware</button>
                 <span slot="unsupported">Use Chrome or Edge on desktop with Web Serial support.</span>
                 <span slot="not-allowed">This page must be opened over HTTPS or localhost.</span>
               </esp-web-install-button>
@@ -55,20 +68,22 @@ class InstallFirmware extends HTMLElement {
 
     this._section = this.querySelector("#install-section");
     this._historyEl = this.querySelector("#flash-history");
+    this._installBtn = this.querySelector("#firmware-install-btn");
 
-    this.querySelector("#install-toggle").addEventListener("click", () => {
-      this._section.classList.toggle("is-collapsed");
-      this.querySelector("#install-toggle").setAttribute(
-        "aria-expanded",
-        this._section.classList.contains("is-collapsed") ? "false" : "true",
-      );
+    const toggle = this.querySelector("#install-toggle");
+    const content = this.querySelector("#install-content");
+    toggle.addEventListener("click", () => {
+      const collapsed = !this._section.classList.contains("is-collapsed");
+      this._section.classList.toggle("is-collapsed", collapsed);
+      toggle.setAttribute("aria-expanded", collapsed ? "false" : "true");
+      content.hidden = collapsed;
     });
 
     this._showFlashHistory();
     this._autoCollapse();
     this._observeInstallDialog();
 
-    fetch("firmware/manifest.json")
+    fetch("firmware/manifest.json", { cache: "no-store" })
       .then(r => r.json())
       .then(m => {
         this._fwVersion = m.version;
@@ -77,42 +92,104 @@ class InstallFirmware extends HTMLElement {
           const ul = this.querySelector(".feature-list");
           ul.innerHTML = m.features.map(f => "<li>" + f + "</li>").join("");
         }
-        this._updateButtonText();
+        this._refreshInstallButton();
+        this._showFlashHistory();
       });
   }
 
-  _showFlashHistory() {
+  _readFlashData() {
     try {
-      const data = JSON.parse(localStorage.getItem(FLASH_KEY));
-      if (data && data.timestamp) {
-        const versionLabel = data.version ? data.version + " " : "";
-        this._historyEl.textContent = versionLabel + "flashed " + timeAgo(data.timestamp);
-      } else {
-        this._historyEl.textContent = "No installations in history";
-      }
+      return JSON.parse(localStorage.getItem(FLASH_KEY));
     } catch (e) {
+      return null;
+    }
+  }
+
+  _showFlashHistory() {
+    const data = this._readFlashData();
+    if (!data || !data.timestamp) {
       this._historyEl.textContent = "No installations in history";
+      this._historyEl.classList.remove("update-available");
+      return;
+    }
+
+    const hasUpdate = data.version && this._fwVersion && data.version !== this._fwVersion;
+    if (hasUpdate) {
+      this._historyEl.textContent = "Update available";
+      this._historyEl.classList.add("update-available");
+    } else {
+      const versionLabel = data.version ? data.version + " " : "";
+      this._historyEl.textContent = versionLabel + "flashed " + timeAgo(data.timestamp);
+      this._historyEl.classList.remove("update-available");
     }
   }
 
   _autoCollapse() {
-    try {
-      const data = JSON.parse(localStorage.getItem(FLASH_KEY));
-      if (data && data.timestamp) {
-        this._section.classList.add("is-collapsed");
-        this.querySelector("#install-toggle").setAttribute("aria-expanded", "false");
-      }
-    } catch (e) {}
+    const data = this._readFlashData();
+    if (data && data.timestamp) {
+      this._section.classList.add("is-collapsed");
+      this.querySelector("#install-toggle").setAttribute("aria-expanded", "false");
+      this.querySelector("#install-content").hidden = true;
+    }
   }
 
-  _updateButtonText() {
-    try {
-      const data = JSON.parse(localStorage.getItem(FLASH_KEY));
-      if (data && data.version && this._fwVersion && data.version !== this._fwVersion) {
-        const btn = this.querySelector('button[slot="activate"]');
-        if (btn) btn.textContent = "Update Firmware";
+  _refreshInstallButton() {
+    const data = this._readFlashData();
+    const uptodateBadge = this.querySelector("#uptodate-badge");
+    const espButton = this._installBtn?.closest("esp-web-install-button");
+    if (!this._installBtn || !uptodateBadge || !espButton) return;
+
+    const isUpToDate = data?.version && this._fwVersion && data.version === this._fwVersion;
+    const hasUpdate = data?.version && this._fwVersion && data.version !== this._fwVersion;
+
+    if (isUpToDate) {
+      uptodateBadge.hidden = false;
+      espButton.hidden = true;
+      const utdVersion = this.querySelector("#uptodate-version");
+      const utdAgo = this.querySelector("#uptodate-ago");
+      if (utdVersion) utdVersion.textContent = data.version;
+      if (utdAgo) utdAgo.textContent = timeAgo(data.timestamp);
+
+      let reinstallLink = this.querySelector("#uptodate-reinstall");
+      if (!reinstallLink) {
+        reinstallLink = document.createElement("button");
+        reinstallLink.id = "uptodate-reinstall";
+        reinstallLink.className = "uptodate-reinstall";
+        reinstallLink.addEventListener("click", () => {
+          espButton.style.position = "absolute";
+          espButton.style.opacity = "0";
+          espButton.style.pointerEvents = "none";
+          espButton.hidden = false;
+          this._installBtn.click();
+          espButton.hidden = true;
+          espButton.style.position = "";
+          espButton.style.opacity = "";
+          espButton.style.pointerEvents = "";
+        });
+        uptodateBadge.insertAdjacentElement("afterend", reinstallLink);
       }
-    } catch (e) {}
+      reinstallLink.textContent = "Install Firmware · " + this._fwVersion;
+      reinstallLink.hidden = false;
+    } else {
+      uptodateBadge.hidden = true;
+      espButton.hidden = false;
+      const reinstallLink = this.querySelector("#uptodate-reinstall");
+      if (reinstallLink) reinstallLink.hidden = true;
+
+      if (hasUpdate) {
+        this._installBtn.innerHTML =
+          '<span>' +
+          '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:-2px;margin-right:4px"><path d="M12 19V5"/><path d="M5 12l7-7 7 7"/></svg>' +
+          "Update Firmware</span>" +
+          '<span class="btn-version"><span>' + this._fwVersion + "</span>" +
+          "<span>" + timeAgo(data.timestamp) + "</span></span>";
+      } else {
+        const versionTag = this._fwVersion
+          ? '<span class="btn-version">' + this._fwVersion + "</span>"
+          : "";
+        this._installBtn.innerHTML = "<span>Install Firmware</span>" + versionTag;
+      }
+    }
   }
 
   _observeInstallDialog() {
@@ -124,19 +201,19 @@ class InstallFirmware extends HTMLElement {
           let saved = false;
           const pollTimer = setInterval(() => {
             if (!document.body.contains(node)) { clearInterval(pollTimer); return; }
-            if (saved) return;
-            try {
-              const text = node.shadowRoot?.textContent || "";
-              if (text.indexOf("Installation complete") !== -1) {
-                saved = true;
-                clearInterval(pollTimer);
-                localStorage.setItem(FLASH_KEY, JSON.stringify({
-                  version: this._fwVersion,
-                  timestamp: Date.now(),
-                }));
-                this._showFlashHistory();
-              }
-            } catch (e) {}
+            if (saved || !node.shadowRoot) return;
+
+            const msg = node.shadowRoot.querySelector("ewt-page-message");
+            if (!msg || !msg.label || String(msg.label).indexOf("complete") === -1) return;
+
+            saved = true;
+            clearInterval(pollTimer);
+            localStorage.setItem(FLASH_KEY, JSON.stringify({
+              version: this._fwVersion,
+              timestamp: Date.now(),
+            }));
+            this._showFlashHistory();
+            this._refreshInstallButton();
           }, 500);
 
           setTimeout(() => clearInterval(pollTimer), 600000);

--- a/web/index.html
+++ b/web/index.html
@@ -96,6 +96,11 @@
         margin-top: 28px;
       }
 
+      install-firmware {
+        display: block;
+        margin-bottom: 28px;
+      }
+
       .step-card-toggle {
         display: flex;
         align-items: center;
@@ -215,6 +220,15 @@
         display: none;
       }
 
+      .flash-history.update-available {
+        color: #14532d;
+        background: #bbf7d0;
+        padding: 2px 10px;
+        border-radius: 999px;
+        font-size: 0.82em;
+        font-weight: 600;
+      }
+
       .install-steps.is-collapsed .section-body {
         display: none;
       }
@@ -320,12 +334,64 @@
         font-weight: 700;
       }
 
+      .uptodate-badge[hidden] {
+        display: none;
+      }
+
+      .uptodate-badge {
+        width: 100%;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        border: 0;
+        border-radius: 999px;
+        padding: 13px 18px;
+        color: #fffaf1;
+        background: #4c7a4a;
+        font: 800 0.95rem/1 ui-sans-serif, system-ui, sans-serif;
+        box-shadow: 0 12px 26px rgba(76, 122, 74, 0.24);
+        box-sizing: border-box;
+      }
+
+      .uptodate-left {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+      }
+
+      .uptodate-right {
+        display: flex;
+        flex-direction: column;
+        align-items: flex-end;
+        font-weight: 600;
+        font-size: 0.72rem;
+        line-height: 1.3;
+        opacity: 0.85;
+      }
+
+      .uptodate-reinstall {
+        display: block;
+        margin-top: 6px;
+        text-align: center;
+        color: var(--muted);
+        font: 600 0.78rem/1.3 ui-sans-serif, system-ui, sans-serif;
+        text-decoration: underline;
+        text-underline-offset: 2px;
+        cursor: pointer;
+        background: none;
+        border: none;
+        padding: 0;
+      }
+
       esp-web-install-button {
         margin-top: 4px;
       }
 
       button[slot="activate"] {
         width: 100%;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
         border: 0;
         border-radius: 999px;
         padding: 13px 18px;
@@ -334,6 +400,16 @@
         font: 800 0.95rem/1 ui-sans-serif, system-ui, sans-serif;
         cursor: pointer;
         box-shadow: 0 12px 26px rgba(211, 84, 47, 0.24);
+      }
+
+      button[slot="activate"] .btn-version {
+        display: flex;
+        flex-direction: column;
+        align-items: flex-end;
+        font-weight: 600;
+        font-size: 0.72rem;
+        line-height: 1.3;
+        opacity: 0.7;
       }
 
       button[slot="activate"]:hover {


### PR DESCRIPTION
1. Solved a small bug to intercept when it's flashed
2. UX: feedback improved, see screenshots:

---

# How it works:

### First install:
The user sees:
<img width="1100" height="860" alt="CleanShot 2026-05-13 at 17 15 10" src="https://github.com/user-attachments/assets/9fa9733c-5e7f-4a56-af26-c069debc4a04" />

### After:
The version and timestamp is saved in localstorage, the user sees:
<img width="1092" height="962" alt="CleanShot 2026-05-13 at 17 08 51" src="https://github.com/user-attachments/assets/62541cff-b057-4ea8-89ff-cd7c2abae4da" />

### When the last flash is not up to date:
<img width="1092" height="896" alt="CleanShot 2026-05-13 at 17 14 45" src="https://github.com/user-attachments/assets/e05a8ad1-d752-4bbd-984b-14a8cbf09bba" />


