### PR TITLE
Auto OTA now works in background

### DIFF
--- a/src/app/App.cpp
+++ b/src/app/App.cpp
@@ -20,6 +20,7 @@
 #endif
 
 static const char *kAppTag = "app";
+constexpr size_t kOtaCheckTaskStackBytes = 10240;
 constexpr uint32_t kBootSplashMs = 750;
 constexpr uint32_t kWpmFeedbackMs = 900;
 constexpr uint32_t kPowerOffHoldMs = 1600;
@@ -114,6 +115,14 @@ enum RestartConfirmItem : size_t {
 };
 
 constexpr size_t kRestartConfirmHeaderRows = 1;
+
+enum UpdateConfirmItem : size_t {
+  UpdateConfirmSkip,
+  UpdateConfirmUpdate,
+  UpdateConfirmItemCount,
+};
+
+constexpr size_t kUpdateConfirmHeaderRows = 2;
 constexpr size_t kSettingsBackIndex = 0;
 constexpr size_t kSettingsHomeDisplayIndex = 1;
 constexpr size_t kSettingsHomeTypographyIndex = 2;
@@ -548,7 +557,7 @@ void App::begin() {
     }
   }
 
-  maybeAutoCheckForUpdates(bootStartedMs_);
+  maybeAutoCheckForUpdates();
   Serial.printf("[app] WPM=%u interval=%lu ms\n", reader_.wpm(),
                 static_cast<unsigned long>(reader_.wordIntervalMs()));
 
@@ -683,8 +692,23 @@ void App::setState(AppState nextState, uint32_t nowMs) {
 }
 
 void App::updateState(uint32_t nowMs) {
+  if (state_ == AppState::Paused && pendingUpdateConfirm_ &&
+      (nowMs - bootStartedMs_ < 30000)) {
+    pendingUpdateConfirm_ = false;
+    setState(AppState::Menu, nowMs);
+    openUpdateConfirm(pendingUpdateCurrentVersion_, pendingUpdateNewVersion_);
+    return;
+  }
+
   if (state_ == AppState::Booting) {
     if (nowMs - bootStartedMs_ < kBootSplashMs) {
+      return;
+    }
+
+    if (pendingUpdateConfirm_) {
+      pendingUpdateConfirm_ = false;
+      setState(AppState::Menu, nowMs);
+      openUpdateConfirm(pendingUpdateCurrentVersion_, pendingUpdateNewVersion_);
       return;
     }
 
@@ -1800,6 +1824,9 @@ void App::moveMenuSelection(int direction) {
   } else if (menuScreen_ == MenuScreen::RestartConfirm) {
     selectedIndex = &restartConfirmSelectedIndex_;
     itemCount = RestartConfirmItemCount;
+  } else if (menuScreen_ == MenuScreen::UpdateConfirm) {
+    selectedIndex = &updateConfirmSelectedIndex_;
+    itemCount = UpdateConfirmItemCount;
   } else if (menuScreen_ == MenuScreen::FocusTimerGenres) {
     selectedIndex = &focusTimerGenreSelectedIndex_;
     itemCount = focusTimerGenreMenuItems_.size();
@@ -1845,6 +1872,9 @@ void App::moveMenuSelection(int direction) {
         break;
     }
     Serial.printf("[restart] selected=%s\n", selectedLabel.c_str());
+  } else if (menuScreen_ == MenuScreen::UpdateConfirm) {
+    Serial.printf("[ota] confirm selected=%u\n",
+                  static_cast<unsigned int>(updateConfirmSelectedIndex_));
   } else if (menuScreen_ == MenuScreen::FocusTimerGenres) {
     Serial.printf("[timer] selected genre=%s\n",
                   focusTimerGenreMenuItems_[focusTimerGenreSelectedIndex_].c_str());
@@ -1911,6 +1941,10 @@ void App::selectMenuItem(uint32_t nowMs) {
   }
   if (menuScreen_ == MenuScreen::RestartConfirm) {
     selectRestartConfirmItem(nowMs);
+    return;
+  }
+  if (menuScreen_ == MenuScreen::UpdateConfirm) {
+    selectUpdateConfirmItem(nowMs);
     return;
   }
   if (menuScreen_ == MenuScreen::FocusTimerGenres) {
@@ -2728,14 +2762,45 @@ bool App::otaAutoCheckEnabled() {
   return otaConfig.autoCheck;
 }
 
-void App::maybeAutoCheckForUpdates(uint32_t nowMs) {
+void App::maybeAutoCheckForUpdates() {
   OtaUpdater::Config otaConfig = preferredOtaConfig();
   if (!otaConfig.autoCheck || !otaUpdater_.isConfigured(otaConfig)) {
     return;
   }
 
-  Serial.println("[ota] auto-check enabled");
-  runFirmwareUpdate(otaConfig, true, nowMs);
+  Serial.println("[ota] auto-check enabled, launching background task on core 0");
+
+  OtaCheckTaskParams *params = new OtaCheckTaskParams();
+  params->config = otaConfig;
+  params->updateAvailable = &pendingUpdateConfirm_;
+  params->currentVersion = &pendingUpdateCurrentVersion_;
+  params->newVersion = &pendingUpdateNewVersion_;
+
+  xTaskCreatePinnedToCore(
+      otaCheckTask, "ota_check", kOtaCheckTaskStackBytes,
+      params, 1, nullptr, 0);
+}
+
+void App::otaCheckTask(void *params) {
+  OtaCheckTaskParams *p = static_cast<OtaCheckTaskParams *>(params);
+
+  Serial.println("[ota] background check started");
+  const OtaUpdater::Result result =
+      OtaUpdater().checkOnly(p->config, nullptr, nullptr);
+
+  Serial.printf("[ota] background result: code=%u current=%s latest=%s\n",
+                static_cast<unsigned int>(result.code),
+                result.currentVersion.c_str(),
+                result.latestVersion.c_str());
+
+  if (result.code == OtaUpdater::ResultCode::UpdateAvailable) {
+    *(p->currentVersion) = result.currentVersion;
+    *(p->newVersion) = result.latestVersion;
+    *(p->updateAvailable) = true;
+  }
+
+  delete p;
+  vTaskDelete(NULL);
 }
 
 void App::runFirmwareUpdate(const OtaUpdater::Config &config, bool automatic, uint32_t nowMs) {
@@ -3074,6 +3139,37 @@ void App::selectRestartConfirmItem(uint32_t nowMs) {
   setState(AppState::Paused, nowMs);
   saveReadingPosition(true);
   Serial.println("[restart] book restarted from beginning");
+}
+
+void App::openUpdateConfirm(const String &currentVersion, const String &newVersion) {
+  pendingUpdateCurrentVersion_ = currentVersion;
+  pendingUpdateNewVersion_ = newVersion;
+  updateConfirmSelectedIndex_ = UpdateConfirmSkip;
+  menuScreen_ = MenuScreen::UpdateConfirm;
+  renderUpdateConfirm();
+}
+
+void App::selectUpdateConfirmItem(uint32_t nowMs) {
+  if (updateConfirmSelectedIndex_ != UpdateConfirmUpdate) {
+    menuScreen_ = MenuScreen::Main;
+    setState(AppState::Paused, nowMs);
+    Serial.println("[ota] update skipped by user");
+    return;
+  }
+
+  Serial.println("[ota] update confirmed by user");
+  runFirmwareUpdate(preferredOtaConfig(), false, nowMs);
+}
+
+void App::renderUpdateConfirm() {
+  std::vector<String> items;
+  items.reserve(kUpdateConfirmHeaderRows + UpdateConfirmItemCount);
+  items.push_back("Update available");
+  items.push_back(pendingUpdateCurrentVersion_ + " -> " + pendingUpdateNewVersion_);
+  items.push_back("Skip for now");
+  items.push_back("Update");
+
+  display_.renderMenu(items, updateConfirmSelectedIndex_ + kUpdateConfirmHeaderRows);
 }
 
 void App::enterCompanionSync(uint32_t nowMs) {
@@ -3546,6 +3642,8 @@ void App::renderMenu() {
     renderChapterPicker();
   } else if (menuScreen_ == MenuScreen::RestartConfirm) {
     renderRestartConfirm();
+  } else if (menuScreen_ == MenuScreen::UpdateConfirm) {
+    renderUpdateConfirm();
   } else if (menuScreen_ == MenuScreen::FocusTimerGenres) {
     renderFocusTimerGenres();
   } else if (menuScreen_ == MenuScreen::FocusTimerSession) {

--- a/src/app/App.h
+++ b/src/app/App.h
@@ -35,6 +35,13 @@ class App {
   void update(uint32_t nowMs);
 
  private:
+  struct OtaCheckTaskParams {
+    OtaUpdater::Config config;
+    volatile bool *updateAvailable;
+    String *currentVersion;
+    String *newVersion;
+  };
+
   struct PausedTouchSession {
     bool active = false;
     uint16_t startX = 0;
@@ -68,6 +75,7 @@ class App {
     BookPicker,
     ChapterPicker,
     RestartConfirm,
+    UpdateConfirm,
     FocusTimerGenres,
     FocusTimerSession,
   };
@@ -198,7 +206,8 @@ class App {
   void cycleTypographyPreviewSample(int direction);
   void rebuildSettingsMenuItems();
   void applyPacingSettings();
-  void maybeAutoCheckForUpdates(uint32_t nowMs);
+  void maybeAutoCheckForUpdates();
+  static void otaCheckTask(void *params);
   void runFirmwareUpdate(const OtaUpdater::Config &config, bool automatic, uint32_t nowMs);
   OtaUpdater::Config preferredOtaConfig();
   void scanWifiNetworks();
@@ -236,6 +245,9 @@ class App {
   void selectChapterPickerItem(uint32_t nowMs);
   void openRestartConfirm();
   void selectRestartConfirmItem(uint32_t nowMs);
+  void openUpdateConfirm(const String &currentVersion, const String &newVersion);
+  void selectUpdateConfirmItem(uint32_t nowMs);
+  void renderUpdateConfirm();
   void runSdCardCheck(uint32_t nowMs);
   void enterCompanionSync(uint32_t nowMs);
   void updateCompanionSync(uint32_t nowMs);
@@ -355,6 +367,7 @@ class App {
   size_t bookPickerSelectedIndex_ = 0;
   size_t chapterPickerSelectedIndex_ = 0;
   size_t restartConfirmSelectedIndex_ = 0;
+  size_t updateConfirmSelectedIndex_ = 0;
   size_t focusTimerGenreSelectedIndex_ = 0;
   uint8_t brightnessLevelIndex_ = 4;
   uint8_t readerFontSizeIndex_ = 0;
@@ -365,6 +378,9 @@ class App {
   size_t typographyPreviewSampleIndex_ = 0;
   MenuScreen menuScreen_ = MenuScreen::Main;
   MenuScreen restartConfirmReturnScreen_ = MenuScreen::Main;
+  String pendingUpdateCurrentVersion_;
+  String pendingUpdateNewVersion_;
+  volatile bool pendingUpdateConfirm_ = false;
   std::vector<String> settingsMenuItems_;
   std::vector<String> focusTimerGenreMenuItems_;
   std::vector<DisplayManager::LibraryItem> wifiNetworkMenuItems_;

--- a/src/update/OtaUpdater.cpp
+++ b/src/update/OtaUpdater.cpp
@@ -425,6 +425,52 @@ void OtaUpdater::reportStatus(StatusCallback callback, void *context, const char
   callback(context, title, line1.c_str(), line2.c_str(), progressPercent);
 }
 
+OtaUpdater::Result OtaUpdater::checkOnly(const Config &config, StatusCallback callback,
+                                         void *context) const {
+  Result result;
+  result.currentVersion = currentVersion();
+
+  if (!isConfigured(config)) {
+    result.code = ResultCode::NotConfigured;
+    result.summary = "Wi-Fi not set";
+    result.detail = "Settings -> Wi-Fi";
+    return result;
+  }
+
+  if (!connectWiFi(config, callback, context)) {
+    disconnectWiFi();
+    result.code = ResultCode::ConnectFailed;
+    result.summary = "Wi-Fi failed";
+    result.detail = "Check credentials";
+    return result;
+  }
+
+  LatestRelease release;
+  String metadataError;
+  if (!fetchLatestRelease(config, release, metadataError, callback, context)) {
+    disconnectWiFi();
+    result.code = ResultCode::MetadataFailed;
+    result.summary = "GitHub failed";
+    result.detail = metadataError;
+    return result;
+  }
+
+  disconnectWiFi();
+  result.latestVersion = release.tagName;
+
+  if (release.tagName == result.currentVersion) {
+    result.code = ResultCode::NoUpdate;
+    result.summary = "Already current";
+    result.detail = release.tagName;
+    return result;
+  }
+
+  result.code = ResultCode::UpdateAvailable;
+  result.summary = "Update available";
+  result.detail = release.tagName;
+  return result;
+}
+
 OtaUpdater::Result OtaUpdater::checkAndInstall(const Config &config, StatusCallback callback,
                                                void *context) const {
   Result result;

--- a/src/update/OtaUpdater.h
+++ b/src/update/OtaUpdater.h
@@ -19,6 +19,7 @@ class OtaUpdater {
   enum class ResultCode : uint8_t {
     Success,
     NoUpdate,
+    UpdateAvailable,
     NotConfigured,
     ConnectFailed,
     MetadataFailed,
@@ -38,6 +39,8 @@ class OtaUpdater {
   bool loadConfig(Config &config) const;
   bool isConfigured(const Config &config) const;
   String currentVersion() const;
+  Result checkOnly(const Config &config, StatusCallback callback = nullptr,
+                   void *context = nullptr) const;
   Result checkAndInstall(const Config &config, StatusCallback callback = nullptr,
                          void *context = nullptr) const;
 

--- a/web/firmware/manifest.json
+++ b/web/firmware/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "RSVP Nano",
-  "version": "v0.0.3",
+  "version": "v0.0.4",
   "new_install_prompt_erase": true,
   "new_install_improv_wait_time": 0,
   "features": [


### PR DESCRIPTION
Problem: if you have the feature on, it will block the user experience at every boot. 
Solution: the check runs in the background at every boot and asks the user if they want to update or to skip. 

How it works:

https://github.com/user-attachments/assets/57deab39-4e2a-4b23-8e1c-97171780756b

