### PR TITLE
Add Time Estimate section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ Main Menu
 |  |  |- Long words
 |  |  |- Complexity
 |  |  |- Punctuation
+|  |  |- Time Estimate
 |  |  `- Reset pacing
 |  |- Wi-Fi
 |  `- Firmware update


### PR DESCRIPTION
The Option "Time Estimate" was missing in the README.