### PR TITLE
Prepare v0.0.4 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,176 +1,44 @@
 # RSVP Nano
 
-RSVP Nano is an open-source ESP32-S3 reading device for showing text one word at a time with RSVP (Rapid Serial Visual Presentation). The firmware is built around stable anchor-letter rendering, readable typography, tunable pacing, SD card storage, and a browser-first book conversion workflow.
+RSVP Nano is an open-source ESP32-S3 reading device that shows text one word at a time using RSVP, Rapid Serial Visual Presentation. It is designed for small screens, SD card libraries, fast reading, and a simple browser-first workflow for converting and uploading books.
 
-The latest public release is `v0.0.3`. The hosted browser flasher installs the latest published GitHub Release, so features listed under **Coming Soon** are not in the public flasher build until the next release is published.
+This README is written for the current release, `v0.0.4`.
 
-## Works Now In v0.0.3
+## What You Need
 
-### Reader
+- An RSVP Nano device.
+- A USB-C data cable.
+- A microSD card.
+- Chrome or Edge on a desktop computer for browser flashing and the web converter.
+- Optional: an iPhone companion app installed from Xcode while TestFlight approval is pending.
 
-- One-word RSVP reader with stable anchor alignment.
-- Optional page-scroll reading mode using the same pacing and saved-position system.
-- Hold to read, double-tap locked autoplay, tap to stop locked autoplay, and sentence-boundary pausing.
-- Horizontal scrub preview with hold-to-scroll browsing, then tap to return to RSVP.
-- Sentence rewind from the visual left edge.
-- Swipe up/down WPM adjustment while paused.
-- Chapter and paragraph-aware navigation.
-- Saved reading position and reader settings.
+## Quick Start
 
-### Settings
+1. Flash the firmware from the browser.
+2. Format the SD card and create the library folders.
+3. Convert books or articles to `.rsvp`.
+4. Copy or upload files to the device.
+5. Pick a book or article from the device menu and start reading.
 
-- Adjustable reading mode, handedness, theme, brightness, and language.
-- Adjustable font size, typeface, phantom words, red focus highlight, tracking, anchor position, guide width, and guide gap.
-- Adjustable pacing delays for long words, word complexity, and punctuation.
-- Menu language selection for English, Spanish, French, German, Romanian, and Polish.
-- Wi-Fi setup on the device for OTA updates.
+## Flash The Firmware
 
-### Library And Conversion
-
-- SD card library under `/books`.
-- Supported reader files: `.rsvp`, `.txt`, and `.epub`.
-- Browser-side Library Workspace for importing and converting supported books.
-- Browser converter support for:
-  - `.epub`
-  - `.txt`
-  - `.md` / `.markdown`
-  - `.html` / `.htm` / `.xhtml`
-- On-device EPUB conversion fallback when a matching `.rsvp` file does not exist yet.
-- Browser cleanup for interrupted conversion sidecar files such as `.rsvp.tmp`, `.rsvp.converting`, and `.rsvp.failed`.
-
-### Firmware Install And Updates
-
-- Browser-based firmware install through ESP Web Tools.
-- Optional GitHub Release OTA updates over Wi-Fi.
-- USB mass-storage mode for copying books to the SD card in the default USB firmware build.
-
-## Flash v0.0.3 From The Browser
-
-Use the hosted web flasher:
+Use the hosted flasher:
 
 <https://ionutdecebal.github.io/rsvpnano/>
 
-Use Chrome or Edge on desktop, connect the device over USB, and follow the installer prompts. The browser flasher uses ESP Web Tools and Web Serial, so it must be opened over HTTPS or localhost.
+Open it in Chrome or Edge on desktop, connect the device over USB, and follow the installer prompts. The flasher uses ESP Web Tools and Web Serial, so it must run from HTTPS or localhost.
 
-The hosted flasher installs the latest published GitHub Release, not unreleased `main` commits.
+The hosted flasher installs the latest published GitHub Release. For `v0.0.4`, that means the release build includes the firmware, SD card, RSS, companion sync, web companion, and settings work described below.
 
-## Add Books In v0.0.3
+## Prepare The SD Card
 
-Create a `books` folder at the root of the SD card:
+Use a microSD card formatted as FAT32.
 
-```text
-/books
-  my-book.rsvp
-  another-book.epub
-```
+- 8 GB to 32 GB cards are the safest choice.
+- 64 GB cards can work, but they usually need to be reformatted as FAT32 with a single partition.
+- exFAT is not the recommended format for this firmware.
 
-The best workflow is to use the Library Workspace on the browser flasher page, convert books to `.rsvp`, then sync or copy the converted files into `/books`.
-
-The firmware prioritizes `.rsvp` files. If an EPUB has not been converted yet, the reader can convert it locally the first time it is opened and reuse the generated `.rsvp` file on future launches. The browser converter is still the recommended path for best compatibility.
-
-## Character Support
-
-Current text support is best for ASCII plus a curated set of accented and extended-Latin letters used in many European languages. Common book punctuation such as curly quotes, guillemets, and bracket variants is normalized into readable ASCII wrappers.
-
-The Standard serif reader font renders the wider Latin set directly. Other reader fonts and the tiny UI font fall back to the closest plain ASCII letter where possible. More complex scripts still need additional renderer and font work.
-
-## OTA Updates
-
-The firmware can check GitHub Releases over Wi-Fi and install a newer app build without erasing reader settings or saved reading progress.
-
-To enable OTA on the device:
-
-1. Open `Settings -> Wi-Fi`.
-2. Tap `Choose network`.
-3. Pick an SSID from the scanned list.
-4. Enter the password on the on-device keyboard.
-5. Optionally turn on `Auto OTA`.
-
-After that, open `Settings -> Firmware update` to manually check the latest published GitHub Release and install `rsvp-nano-ota.bin` if the release tag is newer than the firmware already on the device.
-
-[`docs/ota.conf.example`](docs/ota.conf.example) is still supported as an optional advanced override or fallback. Copy it to the SD card as `/config/ota.conf` if you want to pre-seed Wi-Fi credentials or change advanced OTA settings.
-
-## Reader Controls
-
-### Hardware Buttons
-
-- `BOOT` short press: cycle brightness.
-- `BOOT` hold: cycle theme.
-- `PWR` short press from the reader: open the menu.
-- `PWR` short press in a submenu: jump back to the main menu.
-- `PWR` short press on the main menu: return to the reader.
-- `PWR` hold: power off.
-
-### RSVP And Scroll Modes
-
-- Hold on the screen: start reading.
-- Release after a hold: pause at the end of the current sentence.
-- Double-tap while paused: lock autoplay on.
-- Tap while locked autoplay is running: stop at the end of the current sentence.
-- Tap the far-left edge: jump to the start of the current sentence, or the previous sentence if you are already at the start.
-- Swipe left: scrub backward through the text.
-- Swipe right: scrub forward through the text.
-- Swipe up while paused: increase WPM.
-- Swipe down while paused: decrease WPM.
-- Tap the bottom-right footer label: cycle between book progress percent, chapter time left, and book time left.
-
-Horizontal scrubbing in RSVP mode opens a larger preview. Tap to return to the anchored RSVP view, or hold and move vertically to browse through the surrounding text.
-
-## v0.0.3 Menu Map
-
-```text
-Main Menu
-|- Resume
-|- Chapters
-|- Library
-|- Settings
-|  |- Display
-|  |  |- Reading mode
-|  |  |- L/R Hand
-|  |  |- Theme
-|  |  |- Brightness
-|  |  `- Language
-|  |- Typography
-|  |  |- Font size
-|  |  |- Typeface
-|  |  |- Phantom words
-|  |  |- Red highlight
-|  |  |- Tracking
-|  |  |- Anchor
-|  |  |- Guide width
-|  |  |- Guide gap
-|  |  `- Reset
-|  |- Word pacing
-|  |  |- Long words
-|  |  |- Complexity
-|  |  |- Punctuation
-|  |  `- Reset pacing
-|  |- Wi-Fi
-|  `- Firmware update
-|- USB transfer
-`- Power off
-```
-
-## Coming Soon
-
-These changes are already merged after `v0.0.3` and are intended for the next release.
-
-### Device Firmware
-
-- SD card checker from the main menu.
-- Faster startup and library loading through metadata skipping and lazy loading.
-- Better support for long books and unsupported characters, with clearer error handling.
-- More reliable double-tap handling for locked autoplay.
-- Pause behavior setting: pause instantly or pause at the end of the sentence.
-- Battery display improvements, including percentage or estimated time remaining.
-- Pacing-aware time estimates for book and chapter remaining time.
-- Backlight handling improvement during standby/deep sleep.
-- Configurable OTA GitHub owner in device settings.
-- Basic Polish language fixes.
-
-### Library Changes
-
-- Separate folders for books and articles:
+Create these folders on the card:
 
 ```text
 /books/books
@@ -178,134 +46,344 @@ These changes are already merged after `v0.0.3` and are intended for the next re
 /config
 ```
 
-- Separate on-device `Books` and `Articles` pickers.
-- Legacy files directly inside `/books` are still read for compatibility.
+Books go in `/books/books`. Articles go in `/books/articles`. Older libraries with files directly inside `/books` are still read for compatibility, but the split folders are the recommended layout for `v0.0.4`.
 
-### iPhone Companion App
+If the device cannot see the SD card, the most common causes are:
 
-- New iPhone companion app in `ios/RSVPNanoCompanion`.
-- Companion sync over the reader's temporary `RSVP-Nano-xxxxxx` Wi-Fi network.
-- Library page with reader info, books, articles, upload controls, and progress percentages.
-- Article page with saved drafts, synced articles, RSS feed management, article editing, and preview before sync.
-- Settings page for changing device settings from the phone.
-- Help/FAQ page with connection, SD card, and RSS notes.
-- Safari and Chrome share flow for saving pages into the app, fetching article text, editing, and syncing later.
+- The card is exFAT instead of FAT32.
+- The card has multiple partitions.
+- The folders are missing or named differently.
+- The card was removed without ejecting it from the computer.
+- The card is slow, worn out, or unreliable.
 
-### Companion API And Settings
+The device includes an `SD card check` tool in the main menu to help diagnose card size, mount status, write access, and folder layout.
 
-- JSON device settings API:
-  - `GET /api/settings`
-  - `PATCH /api/settings`
-  - `PUT /api/settings`
-- RSS feed API:
-  - `GET /api/rss-feeds`
-  - `PUT /api/rss-feeds`
-- Books/articles API improvements for listing, uploading, deleting, and progress reporting.
-- Settings are moving toward a sturdier JSON-backed model so the phone app and future web app can edit the same device settings.
+## Convert Books And Articles
+
+The recommended conversion workflow is still the browser converter on the hosted flasher page:
+
+<https://ionutdecebal.github.io/rsvpnano/>
+
+Use the converter to turn supported files into `.rsvp`, then upload or copy the `.rsvp` files to the device.
+
+Supported converter inputs include:
+
+- `.epub`
+- `.txt`
+- `.md` / `.markdown`
+- `.html` / `.htm` / `.xhtml`
+
+The firmware can still open `.txt` files and has an on-device EPUB fallback, but the browser converter is the best path for large books, cleaner formatting, and fewer surprises.
+
+## Add Files To The Device
+
+### Option 1: Copy To The SD Card
+
+Power the device off, remove the SD card, copy files from your computer, then reinsert the card.
+
+Use this layout:
+
+```text
+/books/books/my-book.rsvp
+/books/articles/my-article.rsvp
+```
+
+### Option 2: USB Transfer Mode
+
+From the device:
+
+1. Open the main menu with the `PWR` button.
+2. Choose `USB transfer`.
+3. Copy `.rsvp` files from your computer.
+4. Eject the device from the computer.
+5. Hold `PWR` to leave USB transfer mode.
+
+Holding `PWR` is now the standard exit gesture for full-screen utility pages.
+
+### Option 3: Web Companion
+
+The device can host its own browser companion page.
+
+1. Open the main menu.
+2. Choose `Companion sync`.
+3. The device shows the Wi-Fi network name and the browser URL.
+4. Connect your phone, tablet, or computer to the `RSVP-Nano-xxxxxx` Wi-Fi network.
+5. Open the URL shown on the device, usually `http://192.168.4.1`.
+
+The web companion has pages for:
+
+- `Books`: upload book `.rsvp` files and view the book library.
+- `Articles`: write, paste, edit, preview, and upload articles.
+- `Settings`: edit device settings and save home Wi-Fi credentials.
+- `RSS`: manage RSS feed URLs.
+- `Help`: quick notes for connection, conversion, SD cards, and RSS.
+
+The web companion is the best option for Android, desktop, and anyone who does not have the iPhone app.
+
+### Option 4: iPhone Companion App
+
+The iPhone app supports companion sync, article editing, share-sheet saving, RSS feed management, device settings, and library progress.
+
+TestFlight and App Store distribution are waiting on Apple Developer account approval. Until that is approved, the app can be installed temporarily from a Mac with Xcode.
+
+See:
+
+[`ios/RSVPNanoCompanion/README.md`](ios/RSVPNanoCompanion/README.md)
+
+## Home Wi-Fi, RSS, And OTA
+
+The device can save home Wi-Fi credentials for features that need internet access, such as RSS feed checks and OTA firmware updates.
+
+You can set Wi-Fi credentials from:
+
+- The web companion `Settings` page.
+- The iPhone companion app settings page.
+- The on-device Wi-Fi settings page.
+- Advanced users can still use `/config/ota.conf`.
+
+RSS feeds are managed from the web companion or the iPhone app, then checked from the device menu with `RSS feeds`. New articles are saved into `/books/articles`.
+
+RSS support in `v0.0.4` includes:
+
+- RSS and Atom feed parsing.
+- Redirect handling for common `301`, `302`, `303`, `307`, and `308` responses.
+- Live on-device progress while feeds are checked.
+- Duplicate skipping.
+- Feed item author, creator, or website name used as the article source.
+- Larger feed downloads than earlier test builds.
+
+Some feeds still block embedded clients, require JavaScript, return very large pages, or publish summaries instead of full articles. Those are feed or website limitations rather than SD card problems.
+
+OTA updates use GitHub Releases. Open `Settings -> Firmware update` on the device after Wi-Fi is configured.
+
+## Device Controls
+
+### Hardware Buttons
+
+- `PWR` short press from the reader: open the main menu.
+- `PWR` short press on the main menu: return to the reader.
+- `PWR` short press in most submenus: go back to the main menu.
+- `PWR` hold in Companion Sync, USB Transfer, and Focus Timer: exit that page.
+- `PWR` hold from the normal reader or main menu: power off.
+- `BOOT` short press: cycle brightness.
+- `BOOT` hold: cycle display theme.
+
+The goal is simple: use `PWR` as menu, back, exit, and power. Use `BOOT` for quick display changes.
+
+### Reader Controls
+
+- Hold the screen: start reading.
+- Release after a hold: pause.
+- Double tap while paused: start locked continuous play.
+- Tap while locked continuous play is running: pause.
+- Tap the far-left edge: rewind to the start of the current sentence, or the previous sentence if you are already at the start.
+- Swipe left or right while paused: scrub through nearby text.
+- Tap after scrubbing: return to RSVP view.
+- Hold and move vertically in the scrub preview: browse through surrounding text.
+- Swipe up while paused: increase WPM.
+- Swipe down while paused: decrease WPM.
+- Tap the bottom-right footer label: switch between progress, chapter time remaining, book time remaining, and battery display modes.
+
+Pause behavior is configurable. In `Settings -> Word pacing`, choose whether taps pause instantly or at the end of the sentence.
+
+### Main Menu
+
+Open the main menu with `PWR`.
+
+```text
+Resume
+Chapters
+Books
+Articles
+Focus Timer
+Settings
+SD card check
+RSS feeds
+Companion sync
+USB transfer
+Power off
+```
+
+Swipe up or down to move through the menu. Tap to select. Press `PWR` to go back.
+
+### Books And Articles
+
+`Books` shows files from `/books/books`.
+
+`Articles` shows files from `/books/articles`.
+
+Both pages show readable titles, progress, and saved position where available. Select an item to load it into the reader.
+
+### Chapters
+
+The `Chapters` page lists chapter markers from the current book when available. Select a chapter to jump to it. Press `PWR` to return to the main menu.
+
+### Settings
+
+Settings are grouped by how people actually use the device.
+
+`Display` includes:
+
+- Reading mode.
+- Left/right handed layout.
+- Display theme.
+- Brightness.
+- Footer and battery label behavior.
+- Language.
+
+`Typography` includes:
+
+- Font size.
+- Typeface.
+- Phantom words.
+- Red focus highlight.
+- Tracking.
+- Anchor position.
+- Guide width.
+- Guide gap.
+- Typography preview and reset.
+
+`Word pacing` includes:
+
+- Long-word delay.
+- Complexity delay.
+- Punctuation delay.
+- RSVP or scroll reading behavior.
+- Instant pause or sentence-end pause.
+- Pacing reset.
+
+`Wi-Fi` includes network setup for RSS and OTA.
+
+`Firmware update` checks GitHub Releases and installs newer firmware when available.
+
+### Companion Sync
+
+Use this page to connect the iPhone app or the web companion.
+
+1. Open `Companion sync`.
+2. Connect to the Wi-Fi network shown on the device.
+3. Open the URL shown on the device.
+4. Use the web companion or iPhone app.
+5. Hold `PWR` to exit.
+
+When Companion Sync exits, the device reloads settings and refreshes the library.
+
+### USB Transfer
+
+Use this page to copy files over USB without removing the SD card.
+
+1. Open `USB transfer`.
+2. Copy files from your computer.
+3. Eject the device from the computer.
+4. Hold `PWR` to exit.
+
+Always eject before leaving USB transfer mode where possible.
 
 ### RSS Feeds
 
-- RSS feed list managed from the iPhone app, including offline editing and sync status.
-- Device-side RSS checking over saved Wi-Fi.
-- Live on-device progress while feeds are checked.
-- Articles saved into `/books/articles`.
-- Redirect handling for common 301, 302, 303, 307, and 308 responses.
-- RSS and Atom parsing for common feed formats.
-- Feed item author, `dc:creator`, or website used as the article author.
-- Current limits: some feeds block embedded clients, some feeds are too large, and some sites require better article extraction than the firmware can do alone.
+Use the web companion or iPhone app to manage feed URLs. Then run `RSS feeds` from the device menu.
 
-### Web And Distribution
+The device shows live progress as it checks feeds. Saved articles appear in `Articles`.
 
-- Cleaner firmware installer UI.
-- Linux Chromium/Snap USB permission note.
-- Public iPhone app distribution still needs to be worked out.
-- A device-hosted companion web app is planned for Android and desktop users.
-- Bluetooth-first, Wi-Fi-second pairing is planned to make Wi-Fi password entry less painful.
-- Larger-book architecture and wider script/font support are planned for a later release.
+### Focus Timer
+
+The Focus Timer uses the device orientation to guide work and break blocks.
+
+1. Open `Focus Timer`.
+2. Choose a timer category.
+3. Place or flip the device as prompted.
+4. Follow the on-screen timer.
+5. Hold `PWR` to exit the timer page.
+
+Touch-and-hold during an active timer cancels the current timer block.
+
+### SD Card Check
+
+Run `SD card check` if books or articles do not appear. It checks whether the card mounts, whether it can write, and whether the expected library folders exist.
+
+## Character Support
+
+`v0.0.4` improves support for long books and unsupported characters. Common punctuation is normalized, and many accented Latin characters render directly or fall back to readable plain Latin equivalents.
+
+The current renderer is best for English and European Latin-script languages. Complex scripts still need additional font and shaping work.
+
+## iPhone App Status
+
+The iPhone companion app is working, but public distribution is waiting on Apple Developer account approval.
+
+Current app features include:
+
+- Library view for books and articles.
+- Article drafts, editing, preview, and sync.
+- Safari and Chrome share flow.
+- Fetch article title and text where available.
+- Device settings editor.
+- RSS feed management.
+- Help and FAQ pages.
+
+Temporary install instructions are in:
+
+[`ios/RSVPNanoCompanion/README.md`](ios/RSVPNanoCompanion/README.md)
+
+## Android App
+
+The web companion works today from Android browsers.
+
+A future native Android app is planned. Help from Android developers would be very welcome, especially around sharing URLs/articles into the app, local draft storage, and syncing with the device companion API.
 
 ## Build From Source
 
-Install PlatformIO Core, then run:
+Firmware builds with PlatformIO:
 
-```sh
+```bash
 pio run
+```
+
+Upload to a connected device:
+
+```bash
 pio run -t upload
+```
+
+Monitor serial output:
+
+```bash
 pio device monitor
 ```
 
-The default environment is `waveshare_esp32s3_usb_msc`, which includes the reader and USB transfer mode. Serial monitor runs at `115200`.
+The iPhone app lives in:
 
-To export the browser-flasher image and OTA binary:
-
-```sh
-python3 tools/export_web_firmware.py
+```text
+ios/RSVPNanoCompanion
 ```
 
-That command writes:
+Open the Xcode project from that folder when installing the app locally.
+
+To export browser-flasher and OTA firmware assets for a release:
+
+```bash
+python3 tools/export_web_firmware.py --version v0.0.4
+```
+
+That writes:
 
 ```text
 web/firmware/rsvp-nano.bin
 web/firmware/rsvp-nano-ota.bin
+web/firmware/manifest.json
 ```
 
-For OTA releases:
+## Project Status
 
-1. Build from a clean commit or tag.
-2. Run `python3 tools/export_web_firmware.py`.
-3. Create a GitHub Release in `ionutdecebal/rsvpnano`.
-4. Upload both `web/firmware/rsvp-nano.bin` and `web/firmware/rsvp-nano-ota.bin`.
+`v0.0.4` is the first release that brings the firmware, SD card workflow, RSS feeds, iPhone companion work, and web companion work together into one release-ready experience.
 
-The hosted browser flasher and OTA updater both use the latest published GitHub Release assets.
+The next areas of work are:
 
-## Hardware
-
-The current firmware targets the [Waveshare ESP32-S3-Touch-LCD-3.49](https://www.waveshare.com/esp32-s3-touch-lcd-3.49.htm?&aff_id=153227):
-
-- ESP32-S3 with 16 MB flash and OPI PSRAM.
-- AXS15231B-based 172 x 640 LCD panel used in landscape as 640 x 172.
-- SD card connected through `SD_MMC`.
-- Touch, battery, and board power control pins defined in `src/board/BoardConfig.h`.
-
-If you are adapting the project to different hardware, start with `src/board/BoardConfig.h`, then review the display, touch, power, and SD wiring code.
-
-## Running Tests
-
-The pacing algorithm has a host-side unit test suite that runs without hardware using PlatformIO's native environment.
-
-```sh
-pio test -e native_test
-```
-
-Tests live in `test/test_pacing/` and cover word duration calculation, WPM clamping, and seek/scrub behavior.
-
-## Desktop Converter Fallback
-
-The browser converter is the normal path. The desktop helper is still available for offline or batch conversion:
-
-- Windows: `Convert books.bat`
-- macOS: `Convert books.command`
-- Linux: `convert_books_linux.sh` or `python3 convert_books.py`
-
-Copy the helper files from `tools/sd_card_converter` to the SD card root and run the launcher for your platform. The desktop converter scans `/books` and creates `.rsvp` files beside supported sources.
-
-## RSVP File Format
-
-`.rsvp` files are plain text. The reader understands a small set of directives:
-
-```text
-@rsvp 1
-@title The Book Title
-@author Author Name
-@source /books/source.epub
-@chapter Chapter 1
-@para
-```
-
-Normal text lines after the directives are split into words by the firmware.
-
-## Contributing
-
-Issues, experiments, forks, and pull requests are welcome. If you change hardware mappings, build environments, the companion API, or the flashing flow, please update the relevant docs alongside the code.
+- TestFlight and unlisted App Store distribution after Apple Developer approval.
+- Better Android support, ideally with a native app.
+- More capable article extraction for sites that do not expose full RSS content.
+- A fuller browser-hosted companion experience for desktop and Android users.
+- More font and script support.
 
 ## License
 

--- a/ios/RSVPNanoCompanion/README.md
+++ b/ios/RSVPNanoCompanion/README.md
@@ -1,21 +1,82 @@
 # RSVP Nano Companion
 
-Native SwiftUI iPhone app for the RSVP Nano companion sync spike.
+Native SwiftUI iPhone app for RSVP Nano companion sync.
 
-## Run
+The app is not required for the public firmware release. Android, desktop, and iPhone users can use
+the device-hosted web companion from Companion sync. The native app adds the iOS share sheet flow,
+local article drafts, and a more polished iPhone experience.
 
-1. Open `RSVPNanoCompanion.xcodeproj` in Xcode.
-2. Select the `RSVPNanoCompanion` scheme.
-3. Select your iPhone as the run destination.
-4. In target signing settings, choose your Apple developer team if Xcode asks.
-5. Put the reader into `Companion sync`.
-6. Run the app. It shows connection instructions and checks for the reader automatically.
-7. Join the `RSVP-Nano-xxxxxx` Wi-Fi network shown on the reader in iPhone Settings, then return to
-   the app. The library appears once the HTTP API is reachable.
+TestFlight/App Store distribution is planned. Until that is approved, installing from Xcode is the
+temporary tester path.
 
-The app can read `/api/info`, list `/api/books`, delete books, upload `.rsvp`/`.epub` files, and
-convert EPUB, plain text, Markdown, or HTML/XHTML files into `.rsvp` before upload. The library
-shows saved reading percentage when the reader reports `progressPercent` for a book.
+## Install From Your Mac
+
+This is a temporary no-TestFlight install path for owners, contributors, and testers who are
+comfortable using Xcode.
+
+1. Install Xcode from the Mac App Store.
+2. Open Xcode and sign in:
+   - `Xcode -> Settings -> Accounts`
+   - Add your Apple ID.
+3. Connect your iPhone to the Mac with USB.
+4. Unlock the iPhone and tap `Trust This Computer` if prompted.
+5. If iOS asks for Developer Mode, enable it:
+   - `Settings -> Privacy & Security -> Developer Mode`
+   - Restart the iPhone when prompted.
+6. Open:
+
+```text
+ios/RSVPNanoCompanion/RSVPNanoCompanion.xcodeproj
+```
+
+7. Select the `RSVPNanoCompanion` scheme.
+8. Select your connected iPhone as the run destination.
+9. Select the project in Xcode, then check signing for both targets:
+   - `RSVPNanoCompanion`
+   - `RSVPNanoShareExtension`
+10. In `Signing & Capabilities`, enable `Automatically manage signing` and choose your team.
+11. If Xcode says the bundle identifier is unavailable, change both bundle IDs to something unique,
+    for example:
+
+```text
+com.yourname.rsvpnano
+com.yourname.rsvpnano.share
+```
+
+12. The app and share extension must use the same App Group. If you change it, update all three
+    places:
+
+```text
+ios/RSVPNanoCompanion/RSVPNanoCompanion/RSVPNanoCompanion.entitlements
+ios/RSVPNanoCompanion/RSVPNanoShareExtension/RSVPNanoShareExtension.entitlements
+ios/RSVPNanoCompanion/RSVPNanoCompanion/PendingUploadStore.swift
+```
+
+For example:
+
+```text
+group.com.yourname.rsvpnano
+```
+
+13. Press `Run` in Xcode. Xcode builds, installs, and launches the app on the iPhone.
+14. If iOS says the developer is not trusted, open:
+    - `Settings -> General -> VPN & Device Management`
+    - Trust your developer profile.
+
+Free Apple IDs can run apps on personal devices, but they may have short-lived provisioning and may
+not support every capability needed by the share extension. A paid Apple Developer Program account
+is still required for TestFlight, App Store, and unlisted App Store distribution.
+
+## Connect To The Reader
+
+1. Put the reader into `Companion sync`.
+2. Join the `RSVP-Nano-xxxxxx` Wi-Fi network shown on the reader in iPhone Settings.
+3. Return to the app.
+4. The library appears once the HTTP API at `192.168.4.1` is reachable.
+
+The app can read `/api/info`, list `/api/books`, delete books, upload files, change device
+settings, save Wi-Fi credentials for RSS/OTA, and manage RSS feeds. The library shows saved reading
+percentage when the reader reports `progressPercent` for a book.
 
 ## Add Reading Material
 

--- a/ios/RSVPNanoCompanion/RSVPNanoCompanion.xcodeproj/project.pbxproj
+++ b/ios/RSVPNanoCompanion/RSVPNanoCompanion.xcodeproj/project.pbxproj
@@ -402,6 +402,8 @@
 				DEVELOPMENT_ASSET_PATHS = "";
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = RSVPNanoCompanion/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = "RSVP NANO";
+				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.education";
 				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -429,6 +431,8 @@
 				DEVELOPMENT_ASSET_PATHS = "";
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = RSVPNanoCompanion/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = "RSVP NANO";
+				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.education";
 				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/ios/RSVPNanoCompanion/RSVPNanoCompanion.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/ios/RSVPNanoCompanion/RSVPNanoCompanion.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,4 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Workspace
    version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
 </Workspace>

--- a/ios/RSVPNanoCompanion/RSVPNanoCompanion/ContentView.swift
+++ b/ios/RSVPNanoCompanion/RSVPNanoCompanion/ContentView.swift
@@ -9,6 +9,9 @@ final class NanoViewModel: ObservableObject {
     @Published var info: NanoInfo?
     @Published var books: [NanoBook] = []
     @Published var deviceSettings: NanoSettings?
+    @Published var wifiSettings: NanoWifiSettings?
+    @Published var wifiSsidDraft = ""
+    @Published var wifiPasswordDraft = ""
     @Published var rssFeeds: [String] = []
     @Published var syncedRssFeeds: [String] = []
     @Published var rssFeedDraft = ""
@@ -72,6 +75,9 @@ final class NanoViewModel: ObservableObject {
                     return
                 }
                 self.deviceSettings = try? await client.fetchSettings()
+                if let wifi = try? await client.fetchWifiSettings() {
+                    self.applyWifiSettings(wifi)
+                }
                 if let deviceFeeds = try? await client.fetchRssFeeds().feeds {
                     self.mergeRssFeedsFromDevice(deviceFeeds)
                 }
@@ -84,7 +90,11 @@ final class NanoViewModel: ObservableObject {
     func refreshSettings() {
         Task {
             await run("Reading settings") { [self] in
-                self.deviceSettings = try await NanoClient(baseURLString: self.address).fetchSettings()
+                let client = NanoClient(baseURLString: self.address)
+                self.deviceSettings = try await client.fetchSettings()
+                if let wifi = try? await client.fetchWifiSettings() {
+                    self.applyWifiSettings(wifi)
+                }
                 self.status = "Device settings refreshed."
             }
         }
@@ -97,6 +107,41 @@ final class NanoViewModel: ObservableObject {
                 next.reading.accurateTimeEstimate = true
                 self.deviceSettings = try await NanoClient(baseURLString: self.address).updateSettings(next)
                 self.status = "Device settings saved. Exit sync on the reader to apply all changes."
+            }
+        }
+    }
+
+    func refreshWifiSettings() {
+        Task {
+            await run("Reading Wi-Fi settings") { [self] in
+                self.applyWifiSettings(try await NanoClient(baseURLString: self.address).fetchWifiSettings())
+                self.status = "Wi-Fi settings refreshed."
+            }
+        }
+    }
+
+    func saveWifiSettings() {
+        let ssid = wifiSsidDraft.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !ssid.isEmpty else {
+            lastConnectionError = "Enter a Wi-Fi network name first."
+            status = "Wi-Fi was not saved."
+            return
+        }
+        Task {
+            await run("Saving Wi-Fi") { [self] in
+                let wifi = try await NanoClient(baseURLString: self.address)
+                    .updateWifi(ssid: ssid, password: self.wifiPasswordDraft)
+                self.applyWifiSettings(wifi)
+                self.status = "Wi-Fi saved for RSS and OTA."
+            }
+        }
+    }
+
+    func forgetWifiSettings() {
+        Task {
+            await run("Clearing Wi-Fi") { [self] in
+                self.applyWifiSettings(try await NanoClient(baseURLString: self.address).forgetWifi())
+                self.status = "Wi-Fi credentials cleared."
             }
         }
     }
@@ -296,12 +341,18 @@ final class NanoViewModel: ObservableObject {
                 self.books = []
                 self.lastConnectionError = "Library read failed: \(error.localizedDescription)"
                 self.deviceSettings = try? await client.fetchSettings()
+                if let wifi = try? await client.fetchWifiSettings() {
+                    self.applyWifiSettings(wifi)
+                }
                 self.mergeRssFeedsFromDevice((try? await client.fetchRssFeeds().feeds) ?? [])
                 self.refreshPendingUploads()
                 self.status = "Connected to \(self.info?.name ?? "RSVP Nano"), but the library could not be read."
                 return
             }
             self.deviceSettings = try? await client.fetchSettings()
+            if let wifi = try? await client.fetchWifiSettings() {
+                self.applyWifiSettings(wifi)
+            }
             self.mergeRssFeedsFromDevice((try? await client.fetchRssFeeds().feeds) ?? [])
             self.refreshPendingUploads()
             self.lastConnectionError = nil
@@ -353,6 +404,12 @@ final class NanoViewModel: ObservableObject {
         syncedRssFeeds = normalizedRssFeeds(deviceFeeds)
         rssFeeds = normalizedRssFeeds(rssFeedStore.load() + syncedRssFeeds)
         rssFeedStore.save(rssFeeds)
+    }
+
+    private func applyWifiSettings(_ wifi: NanoWifiSettings) {
+        wifiSettings = wifi
+        wifiSsidDraft = wifi.ssid
+        wifiPasswordDraft = ""
     }
 
     private func normalizedRssFeeds(_ feeds: [String]) -> [String] {
@@ -1006,6 +1063,7 @@ struct ContentView: View {
             } else {
                 wordPacingSettingsSection
                 displaySettingsSection
+                wifiSettingsSection
                 typographySettingsSection
 
                 Section {
@@ -1021,6 +1079,58 @@ struct ContentView: View {
                         .foregroundStyle(.secondary)
                 }
             }
+        }
+    }
+
+    private var wifiSettingsSection: some View {
+        Section {
+            if let wifi = viewModel.wifiSettings {
+                LabeledContent("Saved Network", value: wifi.configured ? wifi.ssid : "Not set")
+                if wifi.passwordSet {
+                    Text("A password is saved on the reader. The app cannot read it back.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            TextField("Network name", text: $viewModel.wifiSsidDraft)
+                .textInputAutocapitalization(.never)
+                .autocorrectionDisabled()
+
+            SecureField("Password", text: $viewModel.wifiPasswordDraft)
+                .textInputAutocapitalization(.never)
+                .autocorrectionDisabled()
+
+            HStack(spacing: 10) {
+                Button {
+                    viewModel.saveWifiSettings()
+                } label: {
+                    Label("Save Wi-Fi", systemImage: "wifi")
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.borderedProminent)
+                .disabled(viewModel.isBusy || viewModel.wifiSsidDraft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+
+                Button(role: .destructive) {
+                    viewModel.forgetWifiSettings()
+                } label: {
+                    Label("Forget", systemImage: "trash")
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.bordered)
+                .disabled(viewModel.isBusy || viewModel.wifiSettings?.configured != true)
+            }
+
+            Button {
+                viewModel.refreshWifiSettings()
+            } label: {
+                Label("Refresh Wi-Fi", systemImage: "arrow.clockwise")
+            }
+            .disabled(viewModel.isBusy)
+        } header: {
+            Text("Wi-Fi")
+        } footer: {
+            Text("Used for RSS and OTA. You can still configure Wi-Fi directly on the reader if you want the standalone path.")
         }
     }
 

--- a/ios/RSVPNanoCompanion/RSVPNanoCompanion/Models.swift
+++ b/ios/RSVPNanoCompanion/RSVPNanoCompanion/Models.swift
@@ -59,6 +59,18 @@ struct NanoRssFeeds: Codable {
     var feeds: [String]
 }
 
+struct NanoWifiSettings: Codable {
+    var ok: Bool
+    var configured: Bool
+    var ssid: String
+    var passwordSet: Bool
+}
+
+struct NanoWifiUpdate: Encodable {
+    var ssid: String
+    var password: String
+}
+
 struct NanoSettings: Codable {
     var ok: Bool
     var version: Int

--- a/ios/RSVPNanoCompanion/RSVPNanoCompanion/NanoClient.swift
+++ b/ios/RSVPNanoCompanion/RSVPNanoCompanion/NanoClient.swift
@@ -69,6 +69,51 @@ struct NanoClient {
         return try JSONDecoder().decode(NanoSettings.self, from: data)
     }
 
+    func fetchWifiSettings() async throws -> NanoWifiSettings {
+        let url = try endpoint("/api/wifi")
+        let (data, response) = try await URLSession.shared.data(from: url)
+        try validate(response)
+        return try JSONDecoder().decode(NanoWifiSettings.self, from: data)
+    }
+
+    func updateWifi(ssid: String, password: String) async throws -> NanoWifiSettings {
+        var request = URLRequest(url: try endpoint("/api/wifi"))
+        request.httpMethod = "PUT"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try JSONEncoder().encode(NanoWifiUpdate(ssid: ssid, password: password))
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+        guard let http = response as? HTTPURLResponse else {
+            throw NanoClientError.invalidResponse
+        }
+        if !(200..<300).contains(http.statusCode) {
+            if let decoded = try? JSONDecoder().decode(NanoUploadResponse.self, from: data),
+               let error = decoded.error {
+                throw NanoClientError.deviceRejected(error)
+            }
+            throw NanoClientError.invalidResponse
+        }
+        return try JSONDecoder().decode(NanoWifiSettings.self, from: data)
+    }
+
+    func forgetWifi() async throws -> NanoWifiSettings {
+        var request = URLRequest(url: try endpoint("/api/wifi"))
+        request.httpMethod = "DELETE"
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+        guard let http = response as? HTTPURLResponse else {
+            throw NanoClientError.invalidResponse
+        }
+        if !(200..<300).contains(http.statusCode) {
+            if let decoded = try? JSONDecoder().decode(NanoUploadResponse.self, from: data),
+               let error = decoded.error {
+                throw NanoClientError.deviceRejected(error)
+            }
+            throw NanoClientError.invalidResponse
+        }
+        return try JSONDecoder().decode(NanoWifiSettings.self, from: data)
+    }
+
     func fetchRssFeeds() async throws -> NanoRssFeeds {
         let url = try endpoint("/api/rss-feeds")
         let (data, response) = try await URLSession.shared.data(from: url)

--- a/src/app/App.cpp
+++ b/src/app/App.cpp
@@ -807,6 +807,19 @@ void App::handlePowerButton(uint32_t nowMs) {
     return;
   }
 
+  if (powerButtonLongPressHandled_ && powerButton_.isHeld()) {
+    return;
+  }
+
+  if (state_ == AppState::Menu && isFocusTimerMenuScreen(menuScreen_) &&
+      powerButton_.isHeld() && nowMs - powerButton_.lastEdgeMs() >= kUsbTransferExitHoldMs) {
+    powerButtonLongPressHandled_ = true;
+    resetFocusTimer();
+    menuScreen_ = MenuScreen::Main;
+    renderMainMenu();
+    return;
+  }
+
   if (powerButton_.isHeld() && nowMs - powerButton_.lastEdgeMs() >= kPowerOffHoldMs) {
     powerButtonLongPressHandled_ = true;
     enterPowerOff(nowMs);
@@ -3264,7 +3277,8 @@ void App::enterCompanionSync(uint32_t nowMs) {
 void App::updateCompanionSync(uint32_t nowMs) {
   companionSync_.update();
 
-  if (button_.isHeld() && nowMs - button_.lastEdgeMs() >= kUsbTransferExitHoldMs) {
+  if (powerButton_.isHeld() && nowMs - powerButton_.lastEdgeMs() >= kUsbTransferExitHoldMs) {
+    powerButtonLongPressHandled_ = true;
     exitCompanionSync(nowMs);
     return;
   }
@@ -3324,7 +3338,7 @@ void App::enterUsbTransfer(uint32_t nowMs) {
   const uint64_t sizeMb = usbTransfer_.cardSizeBytes() / (1024ULL * 1024ULL);
   Serial.printf("[app] USB transfer active (%llu MB). Eject from computer when finished.\n",
                 sizeMb);
-  display_.renderStatus("USB", "Copy books now", "Eject then hold BOOT");
+  display_.renderStatus("USB", "Copy books now", "Eject then hold PWR");
 }
 
 void App::updateUsbTransfer(uint32_t nowMs) {
@@ -3332,14 +3346,18 @@ void App::updateUsbTransfer(uint32_t nowMs) {
     return;
   }
 
-  const bool bootExitRequested =
-      button_.isHeld() && nowMs - button_.lastEdgeMs() >= kUsbTransferExitHoldMs;
-  if (!usbTransfer_.ejected() && !bootExitRequested) {
+  const bool powerExitRequested =
+      powerButton_.isHeld() && nowMs - powerButton_.lastEdgeMs() >= kUsbTransferExitHoldMs;
+  if (!usbTransfer_.ejected() && !powerExitRequested) {
     return;
   }
 
-  if (bootExitRequested && !usbTransfer_.ejected()) {
-    Serial.println("[app] leaving USB transfer by BOOT hold; make sure host was ejected first");
+  if (powerExitRequested && !usbTransfer_.ejected()) {
+    Serial.println("[app] leaving USB transfer by PWR hold; make sure host was ejected first");
+  }
+
+  if (powerExitRequested) {
+    powerButtonLongPressHandled_ = true;
   }
 
   exitUsbTransfer(nowMs);

--- a/src/sync/CompanionSyncManager.cpp
+++ b/src/sync/CompanionSyncManager.cpp
@@ -42,6 +42,8 @@ constexpr const char *kPrefTypographyTracking = "type_trk";
 constexpr const char *kPrefTypographyAnchor = "type_anc";
 constexpr const char *kPrefTypographyGuideWidth = "type_wid";
 constexpr const char *kPrefTypographyGuideGap = "type_gap";
+constexpr const char *kPrefWifiSsid = "wifi_ssid";
+constexpr const char *kPrefWifiPass = "wifi_pass";
 constexpr uint16_t kDefaultWpm = 300;
 constexpr uint16_t kMinWpm = 100;
 constexpr uint16_t kMaxWpm = 1000;
@@ -68,6 +70,165 @@ constexpr uint8_t kDefaultTypographyGuideWidth = 30;
 constexpr uint8_t kMinTypographyGuideGap = 2;
 constexpr uint8_t kMaxTypographyGuideGap = 8;
 constexpr uint8_t kDefaultTypographyGuideGap = 5;
+
+const char kWebCompanionHtml[] PROGMEM = R"HTML(<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>RSVP Nano Companion</title>
+<style>
+:root{color-scheme:dark;--bg:#0c1110;--fg:#f5f1e8;--muted:#a7aaa0;--line:#2d3430;--card:#151b18;--accent:#78d5b1;--accentInk:#07110e;--accent2:#ff9b73;--soft:#1d2924}
+*{box-sizing:border-box}body{margin:0;background:radial-gradient(circle at top left,#18241f 0,#0c1110 38%);color:var(--fg);font:15px/1.45 system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif}
+header{position:sticky;top:0;z-index:2;background:rgba(12,17,16,.92);backdrop-filter:blur(14px);border-bottom:1px solid var(--line);padding:14px 16px 10px}
+h1{font-size:1.15rem;margin:0 0 10px}.tabs{display:grid;grid-template-columns:repeat(5,minmax(0,1fr));gap:6px}
+button,.button{border:1px solid var(--line);border-radius:8px;background:#111714;color:var(--fg);padding:9px 11px;font:inherit}
+button.primary,.button.primary{background:var(--accent);border-color:var(--accent);color:var(--accentInk);font-weight:700}button.danger{color:var(--accent2)}
+.tabs button{white-space:nowrap;padding:8px 6px}.tabs button.active{background:var(--fg);color:var(--bg)}
+main{max-width:980px;margin:0 auto;padding:16px}.page{display:none}.page.active{display:block}
+.grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:12px}.card{background:var(--card);border:1px solid var(--line);border-radius:8px;padding:14px;margin-bottom:12px}
+h2{font-size:1.05rem;margin:0 0 10px}h3{font-size:.95rem;margin:0 0 8px}.muted{color:var(--muted)}.status{padding:10px 12px;border-radius:8px;background:var(--soft);margin-bottom:12px}
+label{display:block;font-weight:650;margin:10px 0 5px}input,textarea,select{width:100%;border:1px solid var(--line);border-radius:8px;background:var(--bg);color:var(--fg);font:inherit;padding:9px}
+textarea{min-height:180px;resize:vertical}.row{display:flex;gap:8px;align-items:center;flex-wrap:wrap}.row>*{flex:1}.row button{flex:0 0 auto}
+.item{border-top:1px solid var(--line);padding:10px 0}.item:first-child{border-top:0}.item-title{font-weight:700}.item-meta{color:var(--muted);font-size:.9rem}
+ul{padding-left:20px}code{background:var(--soft);border-radius:4px;padding:1px 4px}
+</style>
+</head>
+<body>
+<header>
+<h1>RSVP Nano Companion</h1>
+<nav class="tabs">
+<button data-tab="books" class="active">Books</button>
+<button data-tab="articles">Articles</button>
+<button data-tab="settings">Settings</button>
+<button data-tab="rss">RSS</button>
+<button data-tab="help">Help</button>
+</nav>
+</header>
+<main>
+<div id="status" class="status">Connecting to reader...</div>
+
+<section id="books" class="page active">
+<div class="grid">
+<div class="card"><h2>Upload Book</h2>
+<p class="muted">For best EPUB/HTML/Markdown conversion, use the hosted web converter first, then upload the finished <code>.rsvp</code> file here wirelessly.</p>
+<label>Book file</label><input id="bookFileInput" type="file" accept=".rsvp,.txt,.epub">
+<p><button class="primary" id="uploadBookButton">Upload book</button></p>
+</div>
+<div class="card"><h2>Reader</h2><div id="infoBox" class="muted">No reader info yet.</div><p><button id="refreshBooksButton">Refresh books</button></p></div>
+</div>
+<div class="card"><h2>Books</h2><div id="booksList" class="muted">Loading...</div></div>
+</section>
+
+<section id="articles" class="page">
+<div class="grid">
+<div class="card"><h2>New Article</h2>
+<label>Title</label><input id="articleTitle" placeholder="Article title">
+<label>Author or source</label><input id="articleAuthor" placeholder="Website or author">
+<label>Body</label><textarea id="articleBody" placeholder="Paste article text here"></textarea>
+<div class="row"><button id="saveDraftButton">Save draft</button><button class="primary" id="syncArticleButton">Sync article</button></div>
+</div>
+<div class="card"><h2>Upload Article File</h2>
+<p class="muted">Use this for prepared article <code>.rsvp</code> files or short text files.</p>
+<label>Article file</label><input id="articleFileInput" type="file" accept=".rsvp,.txt,.epub">
+<p><button class="primary" id="uploadArticleButton">Upload article</button></p>
+</div>
+</div>
+<div class="card"><h2>Articles</h2><div id="articlesList" class="muted">Loading...</div><p><button id="refreshArticlesButton">Refresh articles</button></p></div>
+</section>
+
+<section id="settings" class="page">
+<div class="grid">
+<div class="card"><h2>Word Pacing</h2>
+<label>Reading mode</label><select id="readerMode"><option value="rsvp">RSVP</option><option value="scroll">Scroll</option></select>
+<label>Pause behaviour</label><select id="pauseMode"><option value="sentence_end">End of sentence</option><option value="instant">Instant</option></select>
+<label>Base speed <span id="wpmValue"></span></label><input id="wpm" type="range" min="100" max="1000" step="25">
+<label>Long words <span id="longWordMsValue"></span></label><input id="longWordMs" type="range" min="0" max="600" step="50">
+<label>Complexity <span id="complexWordMsValue"></span></label><input id="complexWordMs" type="range" min="0" max="600" step="50">
+<label>Punctuation <span id="punctuationMsValue"></span></label><input id="punctuationMs" type="range" min="0" max="600" step="50">
+</div>
+<div class="card"><h2>Display</h2>
+<label>Display mode</label><select id="displayMode"><option value="dark">Dark</option><option value="light">Light</option><option value="night">Night</option></select>
+<label>Brightness <span id="brightnessValue"></span></label><input id="brightnessIndex" type="range" min="0" max="4">
+<label>Reader hand</label><select id="handedness"><option value="right">Right</option><option value="left">Left</option></select>
+<label>Footer label</label><select id="footerMetric"><option value="percentage">Percentage</option><option value="chapter_time">Chapter time</option><option value="book_time">Book time</option></select>
+<label>Battery label</label><select id="batteryLabel"><option value="percent">Percentage</option><option value="time_remaining">Time remaining</option></select>
+</div>
+<div class="card"><h2>Typography</h2>
+<label>Typeface</label><select id="typeface"><option value="standard">Standard</option><option value="open_dyslexic">OpenDyslexic</option><option value="atkinson">Atkinson</option></select>
+<label>Font size <span id="fontSizeValue"></span></label><input id="fontSizeIndex" type="range" min="0" max="2">
+<label>Tracking <span id="trackingValue"></span></label><input id="tracking" type="range" min="-2" max="3">
+<label>Anchor <span id="anchorValue"></span></label><input id="anchorPercent" type="range" min="30" max="40">
+<label>Guide width <span id="guideWidthValue"></span></label><input id="guideWidth" type="range" min="12" max="30" step="2">
+<label>Guide gap <span id="guideGapValue"></span></label><input id="guideGap" type="range" min="2" max="8">
+<label><input id="focusHighlight" type="checkbox" style="width:auto"> Focus highlight</label>
+<label><input id="phantomWords" type="checkbox" style="width:auto"> Phantom words</label>
+</div>
+<div class="card"><h2>Home Wi-Fi</h2>
+<p class="muted">Save Wi-Fi here for RSS and OTA. The reader does not send the saved password back to this page.</p>
+<label>SSID</label><input id="wifiSsid" autocomplete="off" placeholder="Network name">
+<label>Password</label><input id="wifiPassword" type="password" autocomplete="new-password" placeholder="Leave blank for open networks">
+<div class="row"><button class="primary" id="saveWifiButton">Save Wi-Fi</button><button class="danger" id="forgetWifiButton">Forget</button></div>
+<p id="wifiCurrent" class="muted">No saved Wi-Fi loaded yet.</p>
+</div>
+</div>
+<p><button class="primary" id="saveSettingsButton">Save settings</button></p>
+</section>
+
+<section id="rss" class="page">
+<div class="card"><h2>RSS Feeds</h2><p class="muted">Add one feed URL per line. Feeds are saved to <code>/config/rss.conf</code>; run RSS feeds from the reader menu to download articles.</p>
+<textarea id="rssFeeds" placeholder="https://example.com/feed/"></textarea>
+<p><button class="primary" id="saveRssButton">Save feeds</button> <button id="reloadRssButton">Reload</button></p>
+</div>
+</section>
+
+<section id="help" class="page">
+<div class="card"><h2>How to use this web companion</h2>
+<ul>
+<li>Open Companion sync on the reader, join the <code>RSVP-Nano</code> Wi-Fi network, then open this page.</li>
+<li>Use Books for prepared book files and Articles for article drafts, article uploads, and synced articles.</li>
+<li>For best book conversion, use the hosted web converter/flasher first. This page is the wireless upload and settings companion, not the full conversion engine.</li>
+<li><code>.txt</code> and <code>.epub</code> uploads are accepted, but EPUB conversion is handled on the device when opened.</li>
+<li>Use Wi-Fi to save your home network for RSS and OTA. You can still use the on-device Wi-Fi keyboard if you prefer the standalone path.</li>
+<li>Use <code>/books/books</code> for books and <code>/books/articles</code> for articles. Legacy files in <code>/books</code> still show up.</li>
+</ul>
+</div>
+</section>
+</main>
+<script>
+const $=id=>document.getElementById(id);let settings=null;
+function status(msg){$('status').textContent=msg}
+async function api(path,opts){const r=await fetch(path,opts);const t=await r.text();let j={};try{j=t?JSON.parse(t):{}}catch(e){throw new Error(t||'Bad response')}if(!r.ok||j.ok===false)throw new Error(j.error||r.statusText);return j}
+function bytes(n){return n<1024?n+' B':n<1048576?(n/1024).toFixed(1)+' KB':(n/1048576).toFixed(1)+' MB'}
+function safeName(s){return (s||'article').replace(/[^a-z0-9._ -]+/gi,'-').replace(/\s+/g,' ').trim().slice(0,72)||'article'}
+function escRsvp(s){return (s||'').replace(/\r\n/g,'\n').replace(/\r/g,'\n').trim()}
+function articleFile(){const title=$('articleTitle').value.trim()||'Untitled Article';const author=$('articleAuthor').value.trim();const body=escRsvp($('articleBody').value);let out='@rsvp 1\n@title '+title+'\n';if(author)out+='@author '+author+'\n';out+='@para\n'+body+'\n';return {name:safeName(title)+'.rsvp',blob:new Blob([out],{type:'text/plain'})}}
+function html(s){return String(s==null?'':s).replace(/[&<>"']/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]))}
+function renderList(id,items){$(id).innerHTML=items.length?items.map(b=>`<div class="item"><div class="item-title">${html(b.title||b.name)}</div><div class="item-meta">${html([b.author,b.name,bytes(b.bytes),b.progressPercent!=null?b.progressPercent+'% read':null].filter(Boolean).join(' - '))}</div><p><button class="danger" data-delete="${html(encodeURIComponent(b.name))}">Delete</button></p></div>`).join(''):'<span class="muted">Nothing here yet.</span>';document.querySelectorAll('[data-delete]').forEach(b=>b.onclick=()=>delBook(decodeURIComponent(b.dataset.delete)))}
+async function refresh(){try{const info=await api('/api/info');$('infoBox').innerHTML=`${info.name}<br><span class="muted">${info.mode} - ${info.networkSsid||''}</span><br>Pairing code: <strong>${info.pairingCode}</strong>`;const data=await api('/api/books');renderList('booksList',data.books.filter(b=>b.category!=='article'&&!String(b.name).startsWith('articles/')));renderList('articlesList',data.books.filter(b=>b.category==='article'||String(b.name).startsWith('articles/')));status('Connected to RSVP Nano.')}catch(e){status('Connection problem: '+e.message)}}
+async function delBook(name){if(!confirm('Delete '+name+'?'))return;try{await api('/api/books?name='+encodeURIComponent(name),{method:'DELETE'});await refresh();status('Deleted '+name)}catch(e){status('Delete failed: '+e.message)}}
+async function uploadBlob(blob,name,category){const fd=new FormData();fd.append('file',blob,name);await api('/api/books?name='+encodeURIComponent(name)+'&category='+encodeURIComponent(category),{method:'POST',body:fd})}
+async function uploadPicked(inputId,category){const f=$(inputId).files[0];if(!f){status('Choose a file first.');return}try{await uploadBlob(f,f.name,category);$(inputId).value='';await refresh();status('Uploaded '+f.name)}catch(e){status('Upload failed: '+e.message)}}
+async function syncArticle(){const f=articleFile();if(!$('articleBody').value.trim()){status('Paste article text first.');return}try{await uploadBlob(f.blob,f.name,'article');localStorage.removeItem('rsvpArticleDraft');await refresh();status('Synced '+f.name)}catch(e){status('Article sync failed: '+e.message)}}
+function saveDraft(){localStorage.setItem('rsvpArticleDraft',JSON.stringify({title:$('articleTitle').value,author:$('articleAuthor').value,body:$('articleBody').value}));status('Draft saved in this browser.')}
+function loadDraft(){try{const d=JSON.parse(localStorage.getItem('rsvpArticleDraft')||'{}');$('articleTitle').value=d.title||'';$('articleAuthor').value=d.author||'';$('articleBody').value=d.body||''}catch(e){}}
+function val(id){const e=$(id);return e.type==='checkbox'?e.checked:e.value}
+function setVal(id,v){const e=$(id);if(e.type==='checkbox')e.checked=!!v;else e.value=v}
+function updateLabels(){['wpm','longWordMs','complexWordMs','punctuationMs','brightnessIndex','fontSizeIndex','tracking','anchorPercent','guideWidth','guideGap'].forEach(id=>{const l=$(id+'Value')||$(id.replace('Index','')+'Value');if(l)l.textContent=$(id).value+(id==='wpm'?' WPM':id.includes('Ms')?' ms':'')})}
+async function loadSettings(){try{settings=await api('/api/settings');setVal('readerMode',settings.reading.readerMode);setVal('pauseMode',settings.reading.pauseMode);setVal('wpm',settings.reading.wpm);setVal('longWordMs',settings.reading.pacing.longWordMs);setVal('complexWordMs',settings.reading.pacing.complexWordMs);setVal('punctuationMs',settings.reading.pacing.punctuationMs);setVal('displayMode',settings.display.nightMode?'night':settings.display.darkMode?'dark':'light');setVal('brightnessIndex',settings.display.brightnessIndex);setVal('handedness',settings.display.handedness);setVal('footerMetric',settings.display.footerMetric);setVal('batteryLabel',settings.display.batteryLabel);setVal('typeface',settings.typography.typeface);setVal('fontSizeIndex',settings.display.fontSizeIndex);setVal('tracking',settings.typography.tracking);setVal('anchorPercent',settings.typography.anchorPercent);setVal('guideWidth',settings.typography.guideWidth);setVal('guideGap',settings.typography.guideGap);setVal('focusHighlight',settings.typography.focusHighlight);setVal('phantomWords',settings.display.phantomWords);updateLabels()}catch(e){status('Settings load failed: '+e.message)}}
+async function saveSettings(){const mode=val('displayMode');const payload={reading:{wpm:+val('wpm'),readerMode:val('readerMode'),pauseMode:val('pauseMode'),pacing:{longWordMs:+val('longWordMs'),complexWordMs:+val('complexWordMs'),punctuationMs:+val('punctuationMs')}},display:{darkMode:mode==='dark',nightMode:mode==='night',brightnessIndex:+val('brightnessIndex'),handedness:val('handedness'),footerMetric:val('footerMetric'),batteryLabel:val('batteryLabel'),phantomWords:val('phantomWords'),fontSizeIndex:+val('fontSizeIndex')},typography:{typeface:val('typeface'),focusHighlight:val('focusHighlight'),tracking:+val('tracking'),anchorPercent:+val('anchorPercent'),guideWidth:+val('guideWidth'),guideGap:+val('guideGap')}};try{settings=await api('/api/settings',{method:'PATCH',headers:{'Content-Type':'application/json'},body:JSON.stringify(payload)});status('Settings saved. Exit sync mode to apply all reader changes.')}catch(e){status('Settings save failed: '+e.message)}}
+async function loadWifi(){try{const w=await api('/api/wifi');$('wifiSsid').value=w.ssid||'';$('wifiPassword').value='';$('wifiCurrent').textContent=w.configured?'Saved network: '+w.ssid:'No home Wi-Fi saved.'}catch(e){status('Wi-Fi load failed: '+e.message)}}
+async function saveWifi(){const ssid=$('wifiSsid').value.trim();if(!ssid){status('Enter a Wi-Fi SSID first.');return}try{const w=await api('/api/wifi',{method:'PUT',headers:{'Content-Type':'application/json'},body:JSON.stringify({ssid,password:$('wifiPassword').value})});$('wifiPassword').value='';$('wifiCurrent').textContent='Saved network: '+w.ssid;status('Wi-Fi saved for RSS and OTA.')}catch(e){status('Wi-Fi save failed: '+e.message)}}
+async function forgetWifi(){if(!confirm('Forget saved Wi-Fi?'))return;try{await api('/api/wifi',{method:'DELETE'});$('wifiSsid').value='';$('wifiPassword').value='';$('wifiCurrent').textContent='No home Wi-Fi saved.';status('Wi-Fi credentials cleared.')}catch(e){status('Forget Wi-Fi failed: '+e.message)}}
+async function loadRss(){try{const r=await api('/api/rss-feeds');$('rssFeeds').value=(r.feeds||[]).join('\n');status('RSS feeds loaded.')}catch(e){status('RSS load failed: '+e.message)}}
+async function saveRss(){const feeds=$('rssFeeds').value.split(/\n+/).map(s=>s.trim()).filter(Boolean);try{await api('/api/rss-feeds',{method:'PUT',headers:{'Content-Type':'application/json'},body:JSON.stringify({feeds})});status('RSS feeds saved.')}catch(e){status('RSS save failed: '+e.message)}}
+document.querySelectorAll('.tabs button').forEach(b=>b.onclick=()=>{document.querySelectorAll('.tabs button,.page').forEach(x=>x.classList.remove('active'));b.classList.add('active');$(b.dataset.tab).classList.add('active');if(b.dataset.tab==='settings'){loadSettings();loadWifi()}if(b.dataset.tab==='rss')loadRss()});
+['wpm','longWordMs','complexWordMs','punctuationMs','brightnessIndex','fontSizeIndex','tracking','anchorPercent','guideWidth','guideGap'].forEach(id=>$(id).oninput=updateLabels);
+$('refreshBooksButton').onclick=refresh;$('refreshArticlesButton').onclick=refresh;$('uploadBookButton').onclick=()=>uploadPicked('bookFileInput','book');$('uploadArticleButton').onclick=()=>uploadPicked('articleFileInput','article');$('syncArticleButton').onclick=syncArticle;$('saveDraftButton').onclick=saveDraft;$('saveSettingsButton').onclick=saveSettings;$('saveWifiButton').onclick=saveWifi;$('forgetWifiButton').onclick=forgetWifi;$('saveRssButton').onclick=saveRss;$('reloadRssButton').onclick=loadRss;
+loadDraft();refresh();
+</script>
+</body>
+</html>)HTML";
 
 bool isSafeFilenameChar(char c) {
   return (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') ||
@@ -380,8 +541,8 @@ bool CompanionSyncManager::begin(const Config &config) {
   }
 
   active_ = true;
-  statusLine1_ = "Sync ready";
-  statusLine2_ = networkSsid_;
+  statusLine1_ = networkSsid_;
+  statusLine2_ = baseUrl();
   Serial.printf("[sync] ready ssid=%s url=%s pairing=%s\n", networkSsid_.c_str(), baseUrl().c_str(),
                 pairingCode_.c_str());
   return true;
@@ -452,6 +613,12 @@ void CompanionSyncManager::handleSettingsStatic() {
   }
 }
 
+void CompanionSyncManager::handleWifiStatic() {
+  if (instance_ != nullptr) {
+    instance_->handleWifi();
+  }
+}
+
 void CompanionSyncManager::handleRssFeedsStatic() {
   if (instance_ != nullptr) {
     instance_->handleRssFeeds();
@@ -507,6 +674,9 @@ bool CompanionSyncManager::startServer() {
   server_.on("/api/settings", HTTP_GET, handleSettingsStatic);
   server_.on("/api/settings", HTTP_PATCH, handleSettingsStatic);
   server_.on("/api/settings", HTTP_PUT, handleSettingsStatic);
+  server_.on("/api/wifi", HTTP_GET, handleWifiStatic);
+  server_.on("/api/wifi", HTTP_PUT, handleWifiStatic);
+  server_.on("/api/wifi", HTTP_DELETE, handleWifiStatic);
   server_.on("/api/rss-feeds", HTTP_GET, handleRssFeedsStatic);
   server_.on("/api/rss-feeds", HTTP_PUT, handleRssFeedsStatic);
   server_.onNotFound(handleNotFoundStatic);
@@ -540,26 +710,8 @@ void CompanionSyncManager::handleInfo() {
 }
 
 void CompanionSyncManager::handleRoot() {
-  String body;
-  body.reserve(980);
-  body += "<!doctype html><html><head><meta name=\"viewport\" content=\"width=device-width,initial-scale=1\">";
-  body += "<title>RSVP Nano Sync</title>";
-  body += "<style>body{font-family:-apple-system,BlinkMacSystemFont,sans-serif;margin:32px;line-height:1.45}";
-  body += "code{background:#f2f2f2;padding:2px 5px;border-radius:4px}</style></head><body>";
-  body += "<h1>RSVP Nano Sync</h1>";
-  body += "<p>Status: <strong>" + statusLine1_ + "</strong></p>";
-  if (!statusLine2_.isEmpty()) {
-    body += "<p><code>" + statusLine2_ + "</code></p>";
-  }
-  body += "<p>API endpoints:</p><ul>";
-  body += "<li><a href=\"/api/info\">/api/info</a></li>";
-  body += "<li><a href=\"/api/books\">/api/books</a></li>";
-  body += "<li><a href=\"/api/settings\">/api/settings</a></li>";
-  body += "<li><a href=\"/api/rss-feeds\">/api/rss-feeds</a></li>";
-  body += "</ul>";
-  body += "<p>Pairing code: <strong>" + pairingCode_ + "</strong></p>";
-  body += "</body></html>";
-  server_.send(200, "text/html", body);
+  server_.sendHeader("Cache-Control", "no-store, max-age=0");
+  server_.send_P(200, "text/html", kWebCompanionHtml);
 }
 
 void CompanionSyncManager::handleBooksList() {
@@ -636,6 +788,33 @@ void CompanionSyncManager::handleSettings() {
   }
 
   server_.send(200, "application/json", settingsJson());
+}
+
+void CompanionSyncManager::handleWifi() {
+  if (server_.method() == HTTP_GET) {
+    server_.send(200, "application/json", wifiJson());
+    return;
+  }
+
+  if (server_.method() == HTTP_DELETE) {
+    preferences_.remove(kPrefWifiSsid);
+    preferences_.remove(kPrefWifiPass);
+    statusLine1_ = "Wi-Fi cleared";
+    statusLine2_ = "";
+    server_.send(200, "application/json", wifiJson());
+    return;
+  }
+
+  String error;
+  if (!applyWifiJson(server_.arg("plain"), error)) {
+    server_.send(400, "application/json",
+                 String("{\"ok\":false,\"error\":\"") + jsonEscape(error) + "\"}");
+    return;
+  }
+
+  statusLine1_ = "Wi-Fi saved";
+  statusLine2_ = preferences_.getString(kPrefWifiSsid, "");
+  server_.send(200, "application/json", wifiJson());
 }
 
 void CompanionSyncManager::handleRssFeeds() {
@@ -1074,6 +1253,46 @@ bool CompanionSyncManager::applySettingsJson(const String &body, String &error) 
     preferences_.putUChar(kPrefTypographyGuideGap, static_cast<uint8_t>(intValue));
   }
 
+  return true;
+}
+
+String CompanionSyncManager::wifiJson() {
+  const String ssid = preferences_.getString(kPrefWifiSsid, "");
+  return String("{\"ok\":true,\"configured\":") + (ssid.isEmpty() ? "false" : "true") +
+         ",\"ssid\":\"" + jsonEscape(ssid) + "\",\"passwordSet\":" +
+         (preferences_.getString(kPrefWifiPass, "").isEmpty() ? "false" : "true") + "}";
+}
+
+bool CompanionSyncManager::applyWifiJson(const String &body, String &error) {
+  if (body.length() > 512) {
+    error = "Wi-Fi payload too large";
+    return false;
+  }
+
+  String ssid;
+  if (!readJsonString(body, "ssid", ssid)) {
+    error = "Missing Wi-Fi SSID";
+    return false;
+  }
+  ssid.trim();
+  if (ssid.isEmpty()) {
+    error = "Wi-Fi SSID is required";
+    return false;
+  }
+  if (ssid.length() > 32) {
+    error = "Wi-Fi SSID is too long";
+    return false;
+  }
+
+  String password;
+  readJsonString(body, "password", password);
+  if (password.length() > 64) {
+    error = "Wi-Fi password is too long";
+    return false;
+  }
+
+  preferences_.putString(kPrefWifiSsid, ssid);
+  preferences_.putString(kPrefWifiPass, password);
   return true;
 }
 

--- a/src/sync/CompanionSyncManager.h
+++ b/src/sync/CompanionSyncManager.h
@@ -36,6 +36,7 @@ class CompanionSyncManager {
   static void handleRootStatic();
   static void handleBooksListStatic();
   static void handleSettingsStatic();
+  static void handleWifiStatic();
   static void handleRssFeedsStatic();
   static void handleBookDeleteStatic();
   static void handleBooksStatic();
@@ -49,6 +50,7 @@ class CompanionSyncManager {
   void handleRoot();
   void handleBooksList();
   void handleSettings();
+  void handleWifi();
   void handleRssFeeds();
   void handleBookDelete();
   void handleBooks();
@@ -56,6 +58,8 @@ class CompanionSyncManager {
   void handleNotFound();
   String settingsJson();
   bool applySettingsJson(const String &body, String &error);
+  String wifiJson();
+  bool applyWifiJson(const String &body, String &error);
   String rssFeedsJson();
   bool writeRssFeedsJson(const String &body, String &error);
   String deviceSuffix() const;

--- a/tools/export_web_firmware.py
+++ b/tools/export_web_firmware.py
@@ -24,10 +24,12 @@ EXPORTS = {
 }
 
 
-def run(command: list[str]) -> None:
+def run(command: list[str], version: str | None = None) -> None:
     print("+", " ".join(command))
     env = os.environ.copy()
     env.setdefault("PLATFORMIO_SETTING_ENABLE_TELEMETRY", "No")
+    if version:
+        env["RSVP_FIRMWARE_VERSION"] = version
     subprocess.run(command, cwd=ROOT, check=True, env=env)
 
 
@@ -133,7 +135,7 @@ def main() -> int:
 
     for env, export in EXPORTS.items():
         if not args.skip_build:
-            run([pio, "run", "-e", env])
+            run([pio, "run", "-e", env], args.version)
 
         output = WEB_FIRMWARE_DIR / export["binary"]
         print(f"Exporting {export['label']} -> {output}")

--- a/web/firmware/manifest.json
+++ b/web/firmware/manifest.json
@@ -1,12 +1,13 @@
 {
   "name": "RSVP Nano",
-  "version": "v0.0.3",
+  "version": "v0.0.4",
   "new_install_prompt_erase": true,
   "new_install_improv_wait_time": 0,
   "features": [
-    "On-device EPUB conversion",
-    "USB SD-card transfer mode",
-    "Extended-Latin character support"
+    "Books and articles library",
+    "Device-hosted web companion",
+    "RSS feed downloads",
+    "USB SD-card transfer mode"
   ],
   "builds": [
     {


### PR DESCRIPTION
## Summary
- Update the README for the v0.0.4 user-facing release flow: flashing, SD card setup, conversion, upload options, device controls, iPhone app status, and Android help wanted.
- Add the device-hosted web companion/Wi-Fi settings/iOS companion work to the release branch.
- Standardize full-screen utility exit behavior around holding the PWR/menu button.
- Update the web firmware manifest to v0.0.4 and fix the firmware exporter so the compiled version string matches the manifest.

## Verification
- `pio run`
- `xcodebuild -project ios/RSVPNanoCompanion/RSVPNanoCompanion.xcodeproj -scheme RSVPNanoCompanion -configuration Debug -destination generic/platform=iOS -derivedDataPath /private/tmp/rsvp-nano-companion-derived CODE_SIGNING_ALLOWED=NO build`
- `python3 tools/export_web_firmware.py --version v0.0.4`
- `git diff --check`
- Confirmed firmware binary contains `v0.0.4`