### PR TITLE
Add previous-sentence hint in reader top-left

### DIFF
--- a/src/app/App.cpp
+++ b/src/app/App.cpp
@@ -35,6 +35,7 @@ constexpr uint16_t kAxisBiasPx = 12;
 constexpr uint16_t kTapSlopPx = 26;
 constexpr uint16_t kReaderDoubleTapSlopPx = 92;
 constexpr uint16_t kPreviousSentenceTapWidthPx = 96;
+constexpr uint16_t kPreviousSentenceTapHeightPx = 60;
 constexpr uint16_t kFooterMetricTapWidthPx = 220;
 constexpr uint16_t kFooterMetricTapHeightPx = 32;
 constexpr uint16_t kBatteryBadgeTapWidthPx = 160;
@@ -1225,14 +1226,21 @@ bool App::isBatteryBadgeTap(uint16_t x, uint16_t y) const {
          y <= kBatteryBadgeTapHeightPx;
 }
 
-bool App::isPreviousSentenceTap(uint16_t x) const { return x < kPreviousSentenceTapWidthPx; }
+bool App::isPreviousSentenceTap(uint16_t x, uint16_t y) const {
+  return x < kPreviousSentenceTapWidthPx && y < kPreviousSentenceTapHeightPx;
+}
 
 bool App::readerFooterVisible() const {
   return scrollModeEnabled() || state_ != AppState::Playing || contextViewVisible_ ||
          wpmFeedbackVisible_;
 }
 
-void App::rewindReaderSentence(uint32_t nowMs) {
+bool App::handlePreviousSentenceTap(uint16_t x, uint16_t y, uint32_t nowMs) {
+  const bool previewBrowseMode = contextViewVisible_ && !scrollModeEnabled();
+  if (previewBrowseMode || !isPreviousSentenceTap(x, y)) {
+    return false;
+  }
+
   resetReaderTapTracking();
   pausedTouch_.active = false;
   pausedTouchIntent_ = TouchIntent::None;
@@ -1248,6 +1256,7 @@ void App::rewindReaderSentence(uint32_t nowMs) {
 
   Serial.printf("[app] sentence rewind index=%u word=%s\n",
                 static_cast<unsigned int>(reader_.currentIndex()), reader_.currentWord().c_str());
+  return true;
 }
 
 bool App::handleFooterMetricTap(uint16_t x, uint16_t y, uint32_t nowMs) {
@@ -1480,8 +1489,7 @@ void App::applyPausedTouchGesture(const TouchEvent &event, uint32_t nowMs) {
         if (handleFooterMetricTap(event.x, event.y, nowMs)) {
           return;
         }
-        if (isPreviousSentenceTap(event.x)) {
-          rewindReaderSentence(nowMs);
+        if (handlePreviousSentenceTap(event.x, event.y, nowMs)) {
           return;
         }
         if (playLocked_ || pauseAtSentenceEndRequested_) {
@@ -1568,8 +1576,7 @@ void App::applyPausedTouchGesture(const TouchEvent &event, uint32_t nowMs) {
     if (tapLike && handleFooterMetricTap(event.x, event.y, nowMs)) {
       return;
     }
-    if (tapLike && !previewBrowseMode && isPreviousSentenceTap(event.x)) {
-      rewindReaderSentence(nowMs);
+    if (tapLike && handlePreviousSentenceTap(event.x, event.y, nowMs)) {
       return;
     }
     if (tapLike && previewBrowseMode) {

--- a/src/app/App.h
+++ b/src/app/App.h
@@ -167,15 +167,15 @@ class App {
   void handleReaderTap(uint16_t x, uint16_t y, uint32_t nowMs);
   bool handleFooterMetricTap(uint16_t x, uint16_t y, uint32_t nowMs);
   bool handleBatteryBadgeTap(uint16_t x, uint16_t y, uint32_t nowMs);
+  bool handlePreviousSentenceTap(uint16_t x, uint16_t y, uint32_t nowMs);
   void requestReaderPauseAtSentenceEnd(uint32_t nowMs);
   void finalizeReaderPause(uint32_t nowMs);
   bool shouldFinalizeReaderPause(uint32_t nowMs) const;
   void resetReaderTapTracking();
   bool isFooterMetricTap(uint16_t x, uint16_t y) const;
   bool isBatteryBadgeTap(uint16_t x, uint16_t y) const;
-  bool isPreviousSentenceTap(uint16_t x) const;
+  bool isPreviousSentenceTap(uint16_t x, uint16_t y) const;
   bool readerFooterVisible() const;
-  void rewindReaderSentence(uint32_t nowMs);
   int scrubStepsForDrag(int deltaX) const;
   void applyScrubTarget(int targetSteps, uint32_t nowMs);
   int browseScrollRatePermille(uint16_t y) const;

--- a/src/display/DisplayManager.cpp
+++ b/src/display/DisplayManager.cpp
@@ -300,6 +300,7 @@ constexpr TinyGlyph kTinyGlyphs[] = {
     {':', {0x00, 0x0C, 0x0C, 0x00, 0x0C, 0x0C, 0x00}},
     {';', {0x00, 0x0C, 0x0C, 0x00, 0x06, 0x04, 0x08}},
     {'?', {0x0E, 0x11, 0x01, 0x02, 0x04, 0x00, 0x04}},
+    {'<', {0x01, 0x02, 0x04, 0x08, 0x04, 0x02, 0x01}},
     {'>', {0x10, 0x08, 0x04, 0x02, 0x04, 0x08, 0x10}},
     {'A', {0x0E, 0x11, 0x11, 0x1F, 0x11, 0x11, 0x11}},
     {'B', {0x1E, 0x11, 0x11, 0x1E, 0x11, 0x11, 0x1E}},
@@ -1528,6 +1529,10 @@ void DisplayManager::drawBatteryBadge(int logicalWidth, int logicalHeight) {
   drawTinyTextAt(batteryLabel_, x, y, footerColor(), kTinyScale);
 }
 
+void DisplayManager::drawPreviousSentenceHint() {
+  drawTinyTextAt("<<", kFooterMarginX, kFooterMarginBottom, footerColor(), kTinyScale);
+}
+
 void DisplayManager::drawFooter(const String &chapterLabel, const String &statusLabel) {
   const String status = statusLabel.isEmpty() ? "0%" : statusLabel;
   const int y = kDisplayHeight - kTinyGlyphHeight * kTinyScale - kFooterMarginBottom;
@@ -1888,6 +1893,7 @@ void DisplayManager::renderPhantomRsvpWord(const String &beforeText, const Strin
     if (showFooter) {
       drawFooter(chapterLabel, footerStatusLabel.isEmpty() ? String(progressPercent) + "%"
                                                            : footerStatusLabel);
+      drawPreviousSentenceHint();
     }
     drawBatteryBadge();
     flushScaledFrame(scale, virtualWidth, virtualHeight);
@@ -1927,6 +1933,7 @@ void DisplayManager::renderPhantomRsvpWord(const String &beforeText, const Strin
   if (showFooter) {
     drawFooter(chapterLabel, footerStatusLabel.isEmpty() ? String(progressPercent) + "%"
                                                          : footerStatusLabel);
+    drawPreviousSentenceHint();
   }
   drawBatteryBadge();
   flushScaledFrame(scale, virtualWidth, virtualHeight);
@@ -2288,6 +2295,7 @@ void DisplayManager::renderPhantomRsvpWordWithWpm(const String &beforeText, cons
     if (showFooter) {
       drawFooter(chapterLabel, footerStatusLabel.isEmpty() ? String(progressPercent) + "%"
                                                            : footerStatusLabel);
+      drawPreviousSentenceHint();
     }
     drawBatteryBadge();
     flushScaledFrame(scale, virtualWidth, virtualHeight);
@@ -2330,6 +2338,7 @@ void DisplayManager::renderPhantomRsvpWordWithWpm(const String &beforeText, cons
   if (showFooter) {
     drawFooter(chapterLabel, footerStatusLabel.isEmpty() ? String(progressPercent) + "%"
                                                          : footerStatusLabel);
+    drawPreviousSentenceHint();
   }
   drawBatteryBadge();
   flushScaledFrame(scale, virtualWidth, virtualHeight);

--- a/src/display/DisplayManager.h
+++ b/src/display/DisplayManager.h
@@ -147,6 +147,7 @@ class DisplayManager {
                                    int width, int xOffset);
   void drawBatteryBadge();
   void drawBatteryBadge(int logicalWidth, int logicalHeight);
+  void drawPreviousSentenceHint();
   void drawFooter(const String &chapterLabel, const String &statusLabel);
   void drawRsvpAnchorGuide(int anchorX, int textY, int textHeight);
   void drawWordAt(const String &word, int x, int y, uint16_t color);


### PR DESCRIPTION
## Summary
  - Draw a `<<` chevron in the reader's top-left so the back-one-sentence tap zone is discoverable (mirrors the battery badge in the top-right).
  - Refactor the tap into the battery/footer-metric pattern: `bool handlePreviousSentenceTap(x, y, nowMs)` with the hitbox guard +
  `previewBrowseMode` check moved inside, and both call sites in `handleTouch` collapsed to a symmetric one-liner.
  - Y-bound the hitbox (`kPreviousSentenceTapHeightPx = 60`) so taps near the chapter label / footer region no longer rewind a sentence.
  - Hide the hint during active playback (gated on the same `showFooter` flag the footer already uses) so the screen stays minimal while
  reading.