### PR TITLE
Add release publishing workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+  release:
+    types: [published]
   workflow_dispatch:
 
 permissions:
@@ -17,7 +19,7 @@ concurrency:
 
 jobs:
   build:
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main' || github.event_name == 'release'
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
@@ -42,7 +44,7 @@ jobs:
           path: web
 
   deploy:
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main' || github.event_name == 'release'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,74 @@
+name: Release firmware
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Release tag to build, for example v0.0.5"
+        required: true
+
+permissions:
+  contents: write
+
+jobs:
+  firmware:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set release version
+        id: version
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "value=${{ inputs.version }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "value=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Install PlatformIO
+        run: pip install platformio
+
+      - name: Export firmware assets
+        run: python3 tools/export_web_firmware.py --version "${{ steps.version.outputs.value }}"
+
+      - name: Write release notes
+        env:
+          RELEASE_TAG: ${{ steps.version.outputs.value }}
+        run: |
+          NOTES_PATH="docs/releases/${RELEASE_TAG}.md"
+          if [ -f "$NOTES_PATH" ]; then
+            cp "$NOTES_PATH" release-notes.md
+          else
+            cat > release-notes.md <<'NOTES'
+          RSVP Nano firmware release.
+
+          Assets:
+          - `rsvp-nano.bin` is the full browser-flasher image for fresh installs.
+          - `rsvp-nano-ota.bin` is the app-only binary used by OTA updates.
+          NOTES
+          fi
+
+      - name: Publish GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ steps.version.outputs.value }}
+        run: |
+          if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
+            gh release upload "$RELEASE_TAG" \
+              web/firmware/rsvp-nano.bin \
+              web/firmware/rsvp-nano-ota.bin \
+              --clobber
+          else
+            gh release create "$RELEASE_TAG" \
+              web/firmware/rsvp-nano.bin \
+              web/firmware/rsvp-nano-ota.bin \
+              --title "$RELEASE_TAG" \
+              --notes-file release-notes.md
+          fi

--- a/docs/releases/v0.0.5.md
+++ b/docs/releases/v0.0.5.md
@@ -1,0 +1,24 @@
+# RSVP Nano v0.0.5
+
+This release focuses on making everyday reading more reliable, especially for large books and real SD-card libraries.
+
+## Highlights
+
+- New indexed SD streaming reader for long books, with sidecar indexes so very large `.rsvp` files can open without loading the whole book into RAM.
+- Clearer loading screens and graceful book-opening failures, including readable status text while indexing or preparing files.
+- SD-card folder repair now asks before changing the card.
+- OTA checks can run in the background, while firmware installs still ask for confirmation.
+- RSS errors now use plainer language instead of raw HTTP-style codes.
+- Optional on-screen reading labels for battery, chapter progress, and book progress.
+- Rewind control stays visible while reading or paused.
+- Battery label can cycle between percentage, time remaining, and voltage.
+- Low-battery warning and critical battery shutdown protection.
+- Standby mode with selectable display options: Game of Life, Maze, Voronoi, or screen off.
+- Better punctuation handling for ellipses and hyphenated sentence breaks.
+- Improved Latin-script character handling for Spanish and other European languages.
+- Added slower reading speeds below 100 WPM in 10 WPM steps.
+
+## Assets
+
+- `rsvp-nano.bin` is the full browser-flasher image for fresh installs.
+- `rsvp-nano-ota.bin` is the app-only binary used by OTA updates.


### PR DESCRIPTION
## Summary
- Add a tag-triggered release workflow that builds the web flasher and OTA firmware binaries
- Publish or update the matching GitHub Release with `rsvp-nano.bin` and `rsvp-nano-ota.bin`
- Add v0.0.5 release notes and redeploy Pages when a release is published, so the hosted web flasher picks up the latest release assets

## Checks
- `git diff --check` passed

## Release follow-up
After this PR lands, move the `v0.0.5` tag to the merged commit and push it. That tag push should create the GitHub Release and then the release event should refresh GitHub Pages.