### PR TITLE
Deploy web flasher from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,8 @@ on:
 
 permissions:
   contents: write
+  id-token: write
+  pages: write
 
 jobs:
   firmware:
@@ -72,3 +74,15 @@ jobs:
               --title "$RELEASE_TAG" \
               --notes-file release-notes.md
           fi
+
+      - name: Configure GitHub Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload GitHub Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: web
+
+      - name: Deploy GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary
- Let the release workflow deploy GitHub Pages from the same firmware assets it just built and attached to the release
- Add Pages and OIDC permissions to the release workflow

## Why
The v0.0.5 release workflow successfully published the GitHub Release, but the release-created-by-GITHUB_TOKEN event did not start a separate Pages deployment. Rerunning the old Pages workflow produced duplicate `github-pages` artifacts in the same run. Deploying from the release workflow avoids both issues.

## Checks
- `git diff --check` passed