### PR TITLE
Brightness level toast

### DIFF
--- a/src/app/App.cpp
+++ b/src/app/App.cpp
@@ -24,6 +24,7 @@ static const char *kAppTag = "app";
 constexpr uint32_t kOtaCheckTaskStackBytes = 10240;
 constexpr uint32_t kBootSplashMs = 750;
 constexpr uint32_t kWpmFeedbackMs = 900;
+constexpr uint32_t kBrightnessToastMs = 1500;
 constexpr uint32_t kPowerOffHoldMs = 1600;
 constexpr uint32_t kPowerOffReleaseWaitMs = 4000;
 constexpr uint32_t kBatterySampleIntervalMs = 180000;
@@ -825,6 +826,7 @@ void App::update(uint32_t nowMs) {
   updateReader(nowMs);
   handleTouch(nowMs);
   updateWpmFeedback(nowMs);
+  updateBrightnessToast(nowMs);
   maybeSaveReadingPosition(nowMs);
   updateTimeEstimateBuild(nowMs);
 
@@ -1131,7 +1133,7 @@ void App::handleBootButton(uint32_t nowMs) {
   }
 
   if (button_.lastHoldDurationMs() < kThemeToggleHoldMs) {
-    cycleBrightness();
+    cycleBrightness(nowMs);
   }
 }
 
@@ -1420,7 +1422,7 @@ void App::applyTypographySettings(uint32_t nowMs, bool rerender) {
   }
 }
 
-void App::cycleBrightness() {
+void App::cycleBrightness(uint32_t nowMs) {
   brightnessLevelIndex_ = static_cast<uint8_t>((brightnessLevelIndex_ + 1) % kBrightnessLevelCount);
   preferences_.putUChar(kPrefBrightness, brightnessLevelIndex_);
   const uint8_t percent = currentBrightnessPercent();
@@ -1428,7 +1430,9 @@ void App::cycleBrightness() {
                 static_cast<unsigned int>(brightnessLevelIndex_ + 1),
                 static_cast<unsigned int>(kBrightnessLevelCount),
                 static_cast<unsigned int>(percent));
-  applyDisplayPreferences(millis());
+  brightnessToastVisible_ = true;
+  brightnessToastUntilMs_ = nowMs + kBrightnessToastMs;
+  applyDisplayPreferences(nowMs);
 }
 
 void App::cycleThemeMode(uint32_t nowMs) {
@@ -1666,6 +1670,21 @@ void App::updateBatteryWarningOverlay(uint32_t nowMs) {
     renderMenu();
   } else if (state_ == AppState::Standby) {
     updateStandbyScreensaver(nowMs, true);
+  }
+}
+
+void App::updateBrightnessToast(uint32_t nowMs) {
+  if (!brightnessToastVisible_) {
+    return;
+  }
+
+  if (nowMs < brightnessToastUntilMs_) {
+    return;
+  }
+
+  brightnessToastVisible_ = false;
+  if (state_ == AppState::Playing || state_ == AppState::Paused) {
+    renderActiveReader(nowMs);
   }
 }
 
@@ -2683,7 +2702,7 @@ void App::selectSettingsItem(uint32_t nowMs) {
         cycleThemeMode(nowMs);
         return;
       case kSettingsDisplayBrightnessIndex:
-        cycleBrightness();
+        cycleBrightness(nowMs);
         return;
       case kSettingsDisplayHandednessIndex:
         cycleHandednessMode(nowMs);
@@ -5904,7 +5923,9 @@ void App::renderActiveReader(uint32_t nowMs) {
 
   applyReaderUiOrientation();
   if (scrollModeEnabled()) {
-    if (wpmFeedbackVisible_) {
+    if (brightnessToastVisible_) {
+      renderBrightnessToast(nowMs);
+    } else if (wpmFeedbackVisible_) {
       renderScrollReader(nowMs, String(reader_.wpm()) + " WPM");
     } else {
       renderScrollReader(nowMs);
@@ -5914,6 +5935,8 @@ void App::renderActiveReader(uint32_t nowMs) {
 
   if (contextViewVisible_) {
     renderContextPreview();
+  } else if (brightnessToastVisible_) {
+    renderBrightnessToast(nowMs);
   } else if (wpmFeedbackVisible_) {
     renderWpmFeedback(nowMs);
   } else {
@@ -6134,6 +6157,29 @@ void App::renderWpmFeedback(uint32_t nowMs) {
                                         readerFontSizeIndex_, reader_.wpm(),
                                         currentChapterLabel(), readingProgressPercent(),
                                         readerFooterVisible(), footerMetricLabel, chrome);
+}
+
+void App::renderBrightnessToast(uint32_t nowMs) {
+  if (!ensureCurrentBookWordAvailable(nowMs)) {
+    return;
+  }
+
+  applyReaderUiOrientation();
+  const String overlayText = String(currentBrightnessPercent()) + "%";
+  if (scrollModeEnabled()) {
+    renderScrollReader(nowMs, overlayText);
+    return;
+  }
+
+  contextViewVisible_ = false;
+  const String beforeText = phantomWordsEnabled_ ? phantomBeforeText() : "";
+  const String afterText = phantomWordsEnabled_ ? phantomAfterText() : "";
+  const DisplayManager::ReaderChrome chrome = readerChrome();
+  const String footerMetricLabel = readerFooterStatusLabel();
+  display_.renderPhantomRsvpWord(beforeText, reader_.currentWord(), afterText,
+                                 readerFontSizeIndex_, currentChapterLabel(),
+                                 readingProgressPercent(), readerFooterVisible(),
+                                 footerMetricLabel, chrome, overlayText);
 }
 
 void App::renderStorageStatus(const char *title, const char *line1, const char *line2,

--- a/src/app/App.cpp
+++ b/src/app/App.cpp
@@ -1432,6 +1432,7 @@ void App::cycleBrightness(uint32_t nowMs) {
                 static_cast<unsigned int>(percent));
   brightnessToastVisible_ = true;
   brightnessToastUntilMs_ = nowMs + kBrightnessToastMs;
+  display_.setBrightnessOverlay(String(percent) + "%");
   applyDisplayPreferences(nowMs);
 }
 
@@ -1683,9 +1684,8 @@ void App::updateBrightnessToast(uint32_t nowMs) {
   }
 
   brightnessToastVisible_ = false;
-  if (state_ == AppState::Playing || state_ == AppState::Paused) {
-    renderActiveReader(nowMs);
-  }
+  display_.setBrightnessOverlay("");
+  applyDisplayPreferences(nowMs);
 }
 
 void App::updateWpmFeedback(uint32_t nowMs) {
@@ -5923,9 +5923,7 @@ void App::renderActiveReader(uint32_t nowMs) {
 
   applyReaderUiOrientation();
   if (scrollModeEnabled()) {
-    if (brightnessToastVisible_) {
-      renderBrightnessToast(nowMs);
-    } else if (wpmFeedbackVisible_) {
+    if (wpmFeedbackVisible_) {
       renderScrollReader(nowMs, String(reader_.wpm()) + " WPM");
     } else {
       renderScrollReader(nowMs);
@@ -5935,8 +5933,6 @@ void App::renderActiveReader(uint32_t nowMs) {
 
   if (contextViewVisible_) {
     renderContextPreview();
-  } else if (brightnessToastVisible_) {
-    renderBrightnessToast(nowMs);
   } else if (wpmFeedbackVisible_) {
     renderWpmFeedback(nowMs);
   } else {
@@ -6157,29 +6153,6 @@ void App::renderWpmFeedback(uint32_t nowMs) {
                                         readerFontSizeIndex_, reader_.wpm(),
                                         currentChapterLabel(), readingProgressPercent(),
                                         readerFooterVisible(), footerMetricLabel, chrome);
-}
-
-void App::renderBrightnessToast(uint32_t nowMs) {
-  if (!ensureCurrentBookWordAvailable(nowMs)) {
-    return;
-  }
-
-  applyReaderUiOrientation();
-  const String overlayText = String(currentBrightnessPercent()) + "%";
-  if (scrollModeEnabled()) {
-    renderScrollReader(nowMs, overlayText);
-    return;
-  }
-
-  contextViewVisible_ = false;
-  const String beforeText = phantomWordsEnabled_ ? phantomBeforeText() : "";
-  const String afterText = phantomWordsEnabled_ ? phantomAfterText() : "";
-  const DisplayManager::ReaderChrome chrome = readerChrome();
-  const String footerMetricLabel = readerFooterStatusLabel();
-  display_.renderPhantomRsvpWord(beforeText, reader_.currentWord(), afterText,
-                                 readerFontSizeIndex_, currentChapterLabel(),
-                                 readingProgressPercent(), readerFooterVisible(),
-                                 footerMetricLabel, chrome, overlayText);
 }
 
 void App::renderStorageStatus(const char *title, const char *line1, const char *line2,

--- a/src/app/App.h
+++ b/src/app/App.h
@@ -175,13 +175,14 @@ class App {
   void updateState(uint32_t nowMs);
   void updateReader(uint32_t nowMs);
   void updateWpmFeedback(uint32_t nowMs);
+  void updateBrightnessToast(uint32_t nowMs);
   void maybeSaveReadingPosition(uint32_t nowMs);
   void handleBootButton(uint32_t nowMs);
   void handlePowerButton(uint32_t nowMs);
   bool handleStandbyCombo(uint32_t nowMs);
   void toggleMenuFromPowerButton(uint32_t nowMs);
   void openMainMenu(uint32_t nowMs);
-  void cycleBrightness();
+  void cycleBrightness(uint32_t nowMs);
   void cycleThemeMode(uint32_t nowMs);
   void cycleUiLanguage(uint32_t nowMs);
   void cycleReaderMode(uint32_t nowMs);
@@ -371,6 +372,7 @@ class App {
   void renderReaderWord();
   void renderContextPreview();
   void renderWpmFeedback(uint32_t nowMs);
+  void renderBrightnessToast(uint32_t nowMs);
   size_t phantomBeforeCharTarget() const;
   size_t phantomAfterCharTarget() const;
   String collectPhantomBeforeText(size_t currentIndex, size_t charTarget) const;
@@ -424,6 +426,7 @@ class App {
   uint32_t bootStartedMs_ = 0;
   uint32_t lastStateLogMs_ = 0;
   uint32_t wpmFeedbackUntilMs_ = 0;
+  uint32_t brightnessToastUntilMs_ = 0;
   uint32_t lastProgressSaveMs_ = 0;
   uint32_t lastBatterySampleMs_ = 0;
   uint32_t batteryRuntimeAnchorMs_ = 0;
@@ -530,6 +533,7 @@ class App {
   bool contextViewVisible_ = false;
   bool contextPreviewWindowValid_ = false;
   bool wpmFeedbackVisible_ = false;
+  bool brightnessToastVisible_ = false;
   bool usingStorageBook_ = false;
   bool storageReady_ = false;
   bool pendingBootBookLoad_ = false;

--- a/src/app/App.h
+++ b/src/app/App.h
@@ -372,7 +372,6 @@ class App {
   void renderReaderWord();
   void renderContextPreview();
   void renderWpmFeedback(uint32_t nowMs);
-  void renderBrightnessToast(uint32_t nowMs);
   size_t phantomBeforeCharTarget() const;
   size_t phantomAfterCharTarget() const;
   String collectPhantomBeforeText(size_t currentIndex, size_t charTarget) const;

--- a/src/display/DisplayManager.cpp
+++ b/src/display/DisplayManager.cpp
@@ -882,6 +882,11 @@ void DisplayManager::setBrightnessPercent(uint8_t percent) {
   }
 }
 
+void DisplayManager::setBrightnessOverlay(const String &text) {
+  brightnessOverlayText_ = text;
+  lastRenderKey_ = "";
+}
+
 void DisplayManager::setDarkMode(bool darkMode) {
   if (darkMode_ == darkMode) {
     return;
@@ -1769,6 +1774,9 @@ void DisplayManager::applyBrightness() {
 
 void DisplayManager::flushScaledFrame(int scale, int virtualWidth, int virtualHeight) {
   tickerPlaybackFrameActive_ = false;
+  if (!brightnessOverlayText_.isEmpty()) {
+    drawBrightnessToastBadge(brightnessOverlayText_);
+  }
   for (int nativeYStart = 0; nativeYStart < kPanelNativeHeight;
        nativeYStart += kMaxChunkPhysicalRows) {
     const int nativeRows = std::min(kMaxChunkPhysicalRows, kPanelNativeHeight - nativeYStart);

--- a/src/display/DisplayManager.cpp
+++ b/src/display/DisplayManager.cpp
@@ -1580,6 +1580,40 @@ void DisplayManager::drawBatteryBadge(int logicalWidth, int logicalHeight) {
   drawTinyTextAt(batteryLabel_, x, y, footerColor(), kTinyScale);
 }
 
+void DisplayManager::drawBrightnessToastBadge(const String &text) {
+  // Sun icon pixel pattern (5x7), drawn at kTinyScale
+  static constexpr uint8_t kSunRows[kTinyGlyphHeight] = {
+    0x0A, // .X.X.
+    0x04, // ..X..
+    0x0E, // .XXX.
+    0x1F, // XXXXX
+    0x0E, // .XXX.
+    0x04, // ..X..
+    0x0A, // .X.X.
+  };
+
+  const int textWidth = measureTinyTextWidth(text, kTinyScale);
+  const int iconW = kTinyGlyphWidth * kTinyScale;
+  const int iconSpacing = 4;
+  const int totalWidth = iconW + iconSpacing + textWidth;
+  const int batteryW = batteryLabel_.isEmpty()
+                           ? 0
+                           : measureTinyTextWidth(batteryLabel_, kTinyScale) + 10;
+  const int rightEdge = logicalWidth() - kFooterMarginX - batteryW;
+  const int x = rightEdge - totalWidth - 4;
+  const int y = kFooterMarginBottom;
+
+  const uint16_t color = focusColor();
+  for (int row = 0; row < kTinyGlyphHeight; ++row) {
+    for (int col = 0; col < kTinyGlyphWidth; ++col) {
+      if (kSunRows[row] & (1 << (kTinyGlyphWidth - 1 - col))) {
+        fillVirtualRect(x + col * kTinyScale, y + row * kTinyScale, kTinyScale, kTinyScale, color);
+      }
+    }
+  }
+  drawTinyTextAt(text, x + iconW + iconSpacing, y, color, kTinyScale);
+}
+
 void DisplayManager::drawPreviousSentenceHint() {
   drawTinyTextAt("<<", kFooterMarginX, kFooterMarginBottom, footerColor(), kTinyScale);
 }
@@ -1928,13 +1962,13 @@ void DisplayManager::renderPhantomRsvpWord(const String &beforeText, const Strin
                                            const String &afterText, uint8_t fontSizeLevel,
                                            const String &chapterLabel, uint8_t progressPercent,
                                            bool showFooter, const String &footerStatusLabel,
-                                           ReaderChrome chrome) {
+                                           ReaderChrome chrome, const String &overlayText) {
   const String renderKey =
       "rsvp_phantom|" + beforeText + "|" + word + "|" + afterText + "|s:" +
       String(fontSizeLevel) + "|" + chapterLabel + "|" + String(progressPercent) + "|" +
-      String(showFooter ? 1 : 0) + "|f:" + footerStatusLabel + "|b:" + batteryLabel_ +
-      "|rc:" + readerChromeKey(chrome) + "|d:" + String(darkMode_ ? 1 : 0) + "|n:" +
-      String(nightMode_ ? 1 : 0);
+      String(showFooter ? 1 : 0) + "|f:" + footerStatusLabel + "|o:" + overlayText + "|b:" +
+      batteryLabel_ + "|rc:" + readerChromeKey(chrome) + "|d:" + String(darkMode_ ? 1 : 0) +
+      "|n:" + String(nightMode_ ? 1 : 0);
   if (!initialized_ || renderKey == lastRenderKey_) {
     return;
   }
@@ -1967,6 +2001,9 @@ void DisplayManager::renderPhantomRsvpWord(const String &beforeText, const Strin
       const int afterX =
           currentX + currentLayout.maxX + kPhantomCurrentGapMedium - afterLayout.minX;
       drawSerif70TextAt(afterText, afterX, textY, phantomColor);
+    }
+    if (!overlayText.isEmpty()) {
+      drawBrightnessToastBadge(overlayText);
     }
     if (showFooter) {
       drawFooter(chapterLabel, footerStatusLabel.isEmpty() ? String(progressPercent) + "%"
@@ -2012,6 +2049,9 @@ void DisplayManager::renderPhantomRsvpWord(const String &beforeText, const Strin
         serifWordLayoutScaledPercent(afterText, -1, style.scalePercent);
     const int afterX = currentX + currentLayout.maxX + style.currentGap - afterLayout.minX;
     drawSerifTextScaledAt(afterText, afterX, textY, phantomColor, style.scalePercent);
+  }
+  if (!overlayText.isEmpty()) {
+    drawBrightnessToastBadge(overlayText);
   }
   if (showFooter) {
     drawFooter(chapterLabel, footerStatusLabel.isEmpty() ? String(progressPercent) + "%"

--- a/src/display/DisplayManager.h
+++ b/src/display/DisplayManager.h
@@ -61,6 +61,7 @@ class DisplayManager {
   bool begin();
   void setBatteryLabel(const String &label);
   void setBrightnessPercent(uint8_t percent);
+  void setBrightnessOverlay(const String &text);
   void setDarkMode(bool darkMode);
   void setNightMode(bool nightMode);
   void setUiOrientation(BoardConfig::UiOrientation orientation);
@@ -203,4 +204,5 @@ class DisplayManager {
   bool tickerPlaybackFrameActive_ = false;
   String lastRenderKey_;
   String batteryLabel_;
+  String brightnessOverlayText_;
 };

--- a/src/display/DisplayManager.h
+++ b/src/display/DisplayManager.h
@@ -84,7 +84,8 @@ class DisplayManager {
                              uint8_t fontSizeLevel, const String &chapterLabel = "",
                              uint8_t progressPercent = 0, bool showFooter = true,
                              const String &footerStatusLabel = "",
-                             ReaderChrome chrome = ReaderChrome());
+                             ReaderChrome chrome = ReaderChrome(),
+                             const String &overlayText = "");
   void renderPhantomRsvpWordWithWpm(const String &beforeText, const String &word,
                                     const String &afterText, uint8_t fontSizeLevel, uint16_t wpm,
                                     const String &chapterLabel = "",
@@ -169,6 +170,7 @@ class DisplayManager {
                                    int width, int xOffset);
   void drawBatteryBadge();
   void drawBatteryBadge(int logicalWidth, int logicalHeight);
+  void drawBrightnessToastBadge(const String &text);
   void drawPreviousSentenceHint();
   void drawFooter(const String &chapterLabel, const String &statusLabel,
                   const ReaderChrome &chrome);


### PR DESCRIPTION
Now when the user presses the physical button to cycle brightness, a transient toast overlay appears on screen showing the current brightness level as a percentage (e.g. `☀️ 75%`), then disappears automatically after 1.5 seconds.

Changes
- `App.cpp` / `App.h`: 
- cycleBrightness() now accepts nowMs and sets a timed overlay via setBrightnessOverlay(). 
- A new updateBrightnessToast() function runs every loop tick and clears the overlay once the timer expires (`kBrightnessToastMs = 1500 ms`). 
- The toast is also triggered when brightness is changed from the Settings menu.

- `DisplayManager.cpp` / `DisplayManager.h`: 
- New setBrightnessOverlay(text) method stores the overlay string and invalidates the render cache. 
- A new drawBrightnessToastBadge(text) method draws a small 5×7 sun pixel-art icon followed by the percentage text in the footer area. 
- The badge is painted on every flushScaledFrame() call and on every renderPhantomRsvpWord() variant while the overlay is active. 
- The render key for RSVP mode now includes the overlay text to force re-renders while the toast is visible.