### PR TITLE
Improved timer

### DIFF
--- a/src/app/App.cpp
+++ b/src/app/App.cpp
@@ -5237,7 +5237,7 @@ void App::renderFocusTimerSession() {
                                       "Restart", focusTimer_.progressPercent(millis()));
       return;
     case FocusTimer::State::WaitAfterTouch:
-      display_.renderFocusTimerScreen("WORK", "", "", "Flip to continue");
+      display_.renderFocusTimerScreen("BEGIN", "", "", "Flip to restart");
       return;
     case FocusTimer::State::WorkRunning:
       display_.renderFocusTimerScreen("WORK", "", remainingLabel, "",
@@ -5252,7 +5252,7 @@ void App::renderFocusTimerSession() {
                                       -1, true);
       return;
     case FocusTimer::State::WaitAfterBreak:
-      display_.renderFocusTimerScreen("WORK", "", "", "Flip to begin");
+      display_.renderFocusTimerScreen("BEGIN", "", "", "Flip to restart");
       return;
     case FocusTimer::State::Cancelled:
       display_.renderFocusTimerScreen("BEGIN", "", "", "Place to begin again");

--- a/src/app/App.cpp
+++ b/src/app/App.cpp
@@ -225,7 +225,13 @@ constexpr const char *kPrefWifiSsid = "wifi_ssid";
 constexpr const char *kPrefWifiPass = "wifi_pass";
 constexpr const char *kPrefOtaAuto = "ota_auto";
 constexpr const char *kPrefOtaOwner = "ota_owner";
-constexpr const char *kPrefTimerDuration = "tmr_dur";
+constexpr const char *kPrefTimerDurationByGenre[FocusTimer::kGenreCount] = {
+    "tmr_dur_0",  // Chores
+    "tmr_dur_1",  // RsvpNano (Work)
+    "tmr_dur_2",  // StrengthLabs (Fitness)
+    "tmr_dur_3",  // SelfCare
+    "tmr_dur_4",  // Other
+};
 constexpr size_t kReaderFontSizeCount = 3;
 constexpr size_t kPhantomBeforeCharTargets[] = {64, 96, 144};
 constexpr size_t kPhantomAfterCharTargets[] = {96, 144, 208};
@@ -619,7 +625,11 @@ void App::begin() {
   if (brightnessLevelIndex_ >= kBrightnessLevelCount) {
     brightnessLevelIndex_ = kBrightnessLevelCount - 1;
   }
-  focusTimer_.setTouchDurationIndex(preferences_.getUChar(kPrefTimerDuration, 0));
+  for (uint8_t i = 0; i < FocusTimer::kGenreCount; i++) {
+    focusTimer_.setTouchDurationIndexForGenre(
+        static_cast<FocusTimer::Genre>(i),
+        preferences_.getUChar(kPrefTimerDurationByGenre[i], 0));
+  }
   phantomWordsEnabled_ = preferences_.getBool(kPrefPhantomWords, phantomWordsEnabled_);
   readerBatteryVisibleWhilePlaying_ =
       preferences_.getBool(kPrefReaderBatteryVisible, readerBatteryVisibleWhilePlaying_);
@@ -2305,7 +2315,10 @@ void App::applyFocusTimerTouch(const TouchEvent &event, uint32_t nowMs) {
       absDeltaX >= static_cast<int>(kSwipeThresholdPx) &&
       absDeltaX > absDeltaY + static_cast<int>(kAxisBiasPx)) {
     focusTimer_.stepTouchDuration(deltaX > 0 ? 1 : -1);
-    preferences_.putUChar(kPrefTimerDuration, focusTimer_.touchDurationIndex());
+    const uint8_t genreIdx = static_cast<uint8_t>(focusTimer_.genre());
+    if (genreIdx < FocusTimer::kGenreCount) {
+      preferences_.putUChar(kPrefTimerDurationByGenre[genreIdx], focusTimer_.touchDurationIndex());
+    }
     renderFocusTimerSession();
     return;
   }

--- a/src/app/App.cpp
+++ b/src/app/App.cpp
@@ -2347,6 +2347,7 @@ void App::resetFocusTimer() {
   focusTimerCancelHoldTriggered_ = false;
   pausedTouch_.active = false;
   focusTimerGenreSelectedIndex_ = kFocusTimerGenreBackIndex;
+  applyReaderUiOrientation();
 }
 
 void App::rebuildFocusTimerGenreMenuItems() {

--- a/src/app/App.cpp
+++ b/src/app/App.cpp
@@ -2277,8 +2277,6 @@ void App::applyFocusTimerTouch(const TouchEvent &event, uint32_t nowMs) {
   const int deltaY = static_cast<int>(pausedTouch_.lastY) - static_cast<int>(pausedTouch_.startY);
   const int absDeltaX = abs(deltaX);
   const int absDeltaY = abs(deltaY);
-  const bool tapLike = absDeltaX <= static_cast<int>(kTapSlopPx) &&
-                       absDeltaY <= static_cast<int>(kTapSlopPx);
 
   if (focusTimer_.isActiveTimerRunning() && !focusTimerCancelHoldTriggered_ &&
       event.phase != TouchPhase::End &&
@@ -2303,10 +2301,13 @@ void App::applyFocusTimerTouch(const TouchEvent &event, uint32_t nowMs) {
     return;
   }
 
-  if (tapLike && focusTimer_.state() == FocusTimer::State::WaitForTouchStart) {
-    focusTimer_.cycleTouchDuration();
+  if (focusTimer_.state() == FocusTimer::State::WaitForTouchStart &&
+      absDeltaX >= static_cast<int>(kSwipeThresholdPx) &&
+      absDeltaX > absDeltaY + static_cast<int>(kAxisBiasPx)) {
+    focusTimer_.stepTouchDuration(deltaX > 0 ? 1 : -1);
     preferences_.putUChar(kPrefTimerDuration, focusTimer_.touchDurationIndex());
     renderFocusTimerSession();
+    return;
   }
 }
 
@@ -5214,7 +5215,7 @@ void App::renderFocusTimerSession() {
       return;
     case FocusTimer::State::WaitForTouchStart: {
       const String durationLabel = formatFocusTimerDuration(focusTimer_.selectedTouchDurationMs());
-      display_.renderFocusTimerScreen("BEGIN", "", durationLabel, "Tap To Change\nPlace to Start");
+      display_.renderFocusTimerScreen("BEGIN", "", durationLabel, "Swipe to Change\nPlace to Start");
       return;
     }
     case FocusTimer::State::TouchRunning:

--- a/src/app/App.cpp
+++ b/src/app/App.cpp
@@ -5236,9 +5236,11 @@ void App::renderFocusTimerSession() {
       display_.renderFocusTimerScreen("BEGIN", "", remainingLabel, "",
                                       "Restart", focusTimer_.progressPercent(millis()));
       return;
-    case FocusTimer::State::WaitAfterTouch:
-      display_.renderFocusTimerScreen("BEGIN", "", "", "Flip to restart");
+    case FocusTimer::State::WaitAfterTouch: {
+      const String durationLabel = formatFocusTimerDuration(focusTimer_.selectedTouchDurationMs());
+      display_.renderFocusTimerScreen("BEGIN", "", durationLabel, "Flip to restart");
       return;
+    }
     case FocusTimer::State::WorkRunning:
       display_.renderFocusTimerScreen("WORK", "", remainingLabel, "",
                                       "", focusTimer_.progressPercent(millis()));

--- a/src/app/App.cpp
+++ b/src/app/App.cpp
@@ -225,6 +225,7 @@ constexpr const char *kPrefWifiSsid = "wifi_ssid";
 constexpr const char *kPrefWifiPass = "wifi_pass";
 constexpr const char *kPrefOtaAuto = "ota_auto";
 constexpr const char *kPrefOtaOwner = "ota_owner";
+constexpr const char *kPrefTimerDuration = "tmr_dur";
 constexpr size_t kReaderFontSizeCount = 3;
 constexpr size_t kPhantomBeforeCharTargets[] = {64, 96, 144};
 constexpr size_t kPhantomAfterCharTargets[] = {96, 144, 208};
@@ -618,6 +619,7 @@ void App::begin() {
   if (brightnessLevelIndex_ >= kBrightnessLevelCount) {
     brightnessLevelIndex_ = kBrightnessLevelCount - 1;
   }
+  focusTimer_.setTouchDurationIndex(preferences_.getUChar(kPrefTimerDuration, 0));
   phantomWordsEnabled_ = preferences_.getBool(kPrefPhantomWords, phantomWordsEnabled_);
   readerBatteryVisibleWhilePlaying_ =
       preferences_.getBool(kPrefReaderBatteryVisible, readerBatteryVisibleWhilePlaying_);
@@ -2303,6 +2305,7 @@ void App::applyFocusTimerTouch(const TouchEvent &event, uint32_t nowMs) {
 
   if (tapLike && focusTimer_.state() == FocusTimer::State::WaitForTouchStart) {
     focusTimer_.cycleTouchDuration();
+    preferences_.putUChar(kPrefTimerDuration, focusTimer_.touchDurationIndex());
     renderFocusTimerSession();
   }
 }

--- a/src/app/App.cpp
+++ b/src/app/App.cpp
@@ -5211,7 +5211,7 @@ void App::renderFocusTimerSession() {
       return;
     case FocusTimer::State::WaitForTouchStart: {
       const String durationLabel = formatFocusTimerDuration(focusTimer_.selectedTouchDurationMs());
-      display_.renderFocusTimerScreen("BEGIN", "", durationLabel, "Tap To Change");
+      display_.renderFocusTimerScreen("BEGIN", "", durationLabel, "Tap To Change\nPlace to Start");
       return;
     }
     case FocusTimer::State::TouchRunning:

--- a/src/app/App.cpp
+++ b/src/app/App.cpp
@@ -5220,7 +5220,7 @@ void App::renderFocusTimerSession() {
     }
     case FocusTimer::State::TouchRunning:
       display_.renderFocusTimerScreen("BEGIN", "", remainingLabel, "",
-                                      "", focusTimer_.progressPercent(millis()));
+                                      "Restart", focusTimer_.progressPercent(millis()));
       return;
     case FocusTimer::State::WaitAfterTouch:
       display_.renderFocusTimerScreen("WORK", "", "", "Flip to continue");

--- a/src/app/App.cpp
+++ b/src/app/App.cpp
@@ -2301,7 +2301,10 @@ void App::applyFocusTimerTouch(const TouchEvent &event, uint32_t nowMs) {
     return;
   }
 
-  (void)tapLike;
+  if (tapLike && focusTimer_.state() == FocusTimer::State::WaitForTouchStart) {
+    focusTimer_.cycleTouchDuration();
+    renderFocusTimerSession();
+  }
 }
 
 void App::openFocusTimer() {
@@ -5206,9 +5209,11 @@ void App::renderFocusTimerSession() {
     case FocusTimer::State::GenreSelect:
       renderFocusTimerGenres();
       return;
-    case FocusTimer::State::WaitForTouchStart:
-      display_.renderFocusTimerScreen("BEGIN", "", "", "Place on short side");
+    case FocusTimer::State::WaitForTouchStart: {
+      const String durationLabel = formatFocusTimerDuration(focusTimer_.selectedTouchDurationMs());
+      display_.renderFocusTimerScreen("BEGIN", "", durationLabel, "Tap To Change");
       return;
+    }
     case FocusTimer::State::TouchRunning:
       display_.renderFocusTimerScreen("BEGIN", "", remainingLabel, "",
                                       "", focusTimer_.progressPercent(millis()));
@@ -5742,6 +5747,17 @@ void App::applyReaderUiOrientation() {
 BoardConfig::UiOrientation App::readerUiOrientation() const {
   return uiRotated180() ? BoardConfig::UiOrientation::LandscapeFlipped
                         : BoardConfig::UiOrientation::Landscape;
+}
+
+String App::formatFocusTimerDuration(uint32_t durationMs) const {
+  const uint32_t totalSeconds = durationMs / 1000UL;
+  const uint32_t minutes = totalSeconds / 60UL;
+  const uint32_t seconds = totalSeconds % 60UL;
+  char buffer[8];
+  std::snprintf(buffer, sizeof(buffer), "%02lu:%02lu",
+                static_cast<unsigned long>(minutes),
+                static_cast<unsigned long>(seconds));
+  return String(buffer);
 }
 
 String App::formatFocusTimerRemaining(uint32_t nowMs) const {

--- a/src/app/App.h
+++ b/src/app/App.h
@@ -399,6 +399,7 @@ class App {
   DisplayManager::TypographyConfig effectiveTypographyConfig() const;
   uint32_t currentReaderContentToken() const;
   String formatFocusTimerRemaining(uint32_t nowMs) const;
+  String formatFocusTimerDuration(uint32_t durationMs) const;
   String focusTimerCountsLabel() const;
   void playFocusTimerCompletionCue();
 

--- a/src/display/DisplayManager.cpp
+++ b/src/display/DisplayManager.cpp
@@ -3387,6 +3387,14 @@ void DisplayManager::renderFocusTimerScreen(const String &mode, const String &ge
         drawTinyTextAt180Clipped(footer, footerX, footerY, inverseTextColor, footerScale,
                                  fillX, fillY, fillWidth, fillHeight);
       }
+      if (portraitFocusLayout) {
+        // Divider mirrored: same gap above text as BEGIN's divider is below BEGIN
+        const int footerDividerWidth =
+            std::min(contentWidth, 40 + (static_cast<int>(footer.length()) * 12));
+        const int footerDividerX = contentX + ((contentWidth - footerDividerWidth) / 2);
+        const int footerDividerY = footerY - 20 - 2;
+        fillVirtualRect(footerDividerX, footerDividerY, footerDividerWidth, 2, accent);
+      }
     }
 
     if (fillWidth > 0 && fillHeight > 0) {

--- a/src/display/DisplayManager.cpp
+++ b/src/display/DisplayManager.cpp
@@ -18,6 +18,12 @@
 #include "text/LatinText.h"
 
 namespace {
+constexpr uint16_t rgb565(uint8_t r, uint8_t g, uint8_t b) {
+    return static_cast<uint16_t>(((r & 0xF8U) << 8) |
+                                 ((g & 0xFCU) << 3) |
+                                 (b >> 3));
+}
+
 constexpr int kDisplayWidth = BoardConfig::DISPLAY_WIDTH;
 constexpr int kDisplayHeight = BoardConfig::DISPLAY_HEIGHT;
 constexpr int kPanelNativeWidth = BoardConfig::PANEL_NATIVE_WIDTH;
@@ -146,10 +152,6 @@ void mapPhysicalToLogical(BoardConfig::UiOrientation orientation, int physicalX,
       logicalY = kDisplayHeight - 1 - physicalX;
       break;
   }
-}
-
-uint16_t rgb565(uint8_t r, uint8_t g, uint8_t b) {
-  return static_cast<uint16_t>(((r & 0xF8U) << 8) | ((g & 0xFCU) << 3) | (b >> 3));
 }
 
 struct TinyGlyph {
@@ -3314,7 +3316,7 @@ void DisplayManager::renderFocusTimerScreen(const String &mode, const String &ge
     const int timerX = centeredXForTiny(timer, timerScale);
 
     drawTinyTextAt(mode, titleX, titleY, baseTextColor, titleScale);
-    drawTinyTextAt(timer, timerX, timerY, baseTextColor, timerScale);
+    drawTinyTextAt(timer, timerX, timerY, accent, timerScale);
 
     if (fillWidth > 0 && fillHeight > 0) {
       drawTinyTextAtClipped(mode, titleX, titleY, inverseTextColor, titleScale, fillX, fillY,
@@ -3338,26 +3340,43 @@ void DisplayManager::renderFocusTimerScreen(const String &mode, const String &ge
       const int dividerWidth =
           std::min(contentWidth, 40 + (static_cast<int>(mode.length()) * 12));
       const int dividerX = contentX + ((contentWidth - dividerWidth) / 2);
-      fillVirtualRect(dividerX, dividerY, dividerWidth, 2, instructionColor);
+      fillVirtualRect(dividerX, dividerY, dividerWidth, 2, accent);
     }
 
     drawTinyTextAt(mode, centeredXForTiny(mode, titleScale), titleY, baseTextColor, titleScale);
 
-    if (!instruction.isEmpty()) {
-      const std::vector<String> lines =
-          wrapTinyLines(instruction, instructionBlockWidth, instructionScale);
-      const int lineHeight = (kTinyGlyphHeight * instructionScale) + instructionScale + 4;
-      int y = titleY + (kTinyGlyphHeight * titleScale) + (portrait ? 42 : 28);
-      if (portraitFocusLayout) {
-        y = dividerY + 66;
+    const std::vector<String> lines = wrapTinyLines(instruction, instructionBlockWidth, instructionScale);
+    const int lineHeight = (kTinyGlyphHeight * instructionScale) + instructionScale + 4;
+    int y = titleY + (kTinyGlyphHeight * titleScale) + (portrait ? 42 : 28);
+    if (portraitFocusLayout) {
+      y = dividerY + 66;
+    }
+
+    if (!timer.isEmpty()) {
+      int timerStaticScale = portrait ? 4 : 5;
+      while (timerStaticScale > 1 && measureTinyTextWidth(timer, timerStaticScale) > contentWidth) {
+        --timerStaticScale;
       }
-      for (const String &line : lines) {
-        drawTinyTextAt(line,
-                       centeredXWithin(line, instructionScale, instructionBlockX,
-                                       instructionBlockWidth),
-                       y, instructionColor, instructionScale);
-        y += lineHeight;
-      }
+      drawTinyTextAt(timer, centeredXForTiny(timer, timerStaticScale), y, accent,
+                     timerStaticScale);
+      y += (kTinyGlyphHeight * timerStaticScale) + timerStaticScale + 20;
+    }
+
+    // First paragraph (e.g. "Tap To Change") → baseTextColor (white)
+    // Second paragraph (e.g. "Place to Start") → instructionColor (accent)
+    const int newlinePos = instruction.indexOf('\n');
+    const String instructionPart1 = (newlinePos >= 0) ? instruction.substring(0, newlinePos) : instruction;
+    const std::vector<String> part1Lines = wrapTinyLines(instructionPart1, instructionBlockWidth, instructionScale);
+    const size_t part1Count = (newlinePos >= 0) ? part1Lines.size() : 0;
+
+    for (size_t i = 0; i < lines.size(); ++i) {
+      const String &line = lines[i];
+      const uint16_t lineColor = (i < part1Count) ? baseTextColor : instructionColor;
+      drawTinyTextAt(line,
+                     centeredXWithin(line, instructionScale, instructionBlockX,
+                                     instructionBlockWidth),
+                     y, lineColor, instructionScale);
+      y += lineHeight;
     }
   }
 

--- a/src/display/DisplayManager.cpp
+++ b/src/display/DisplayManager.cpp
@@ -3091,7 +3091,6 @@ void DisplayManager::renderFocusTimerScreen(const String &mode, const String &ge
                                             const String &footer, int progressPercent,
                                             bool breakAccent) {
   (void)genre;
-  (void)footer;
   progressPercent = std::max(-1, std::min(100, progressPercent));
   const int virtualWidth = logicalWidth();
   const int virtualHeight = logicalHeight();
@@ -3317,6 +3316,20 @@ void DisplayManager::renderFocusTimerScreen(const String &mode, const String &ge
 
     drawTinyTextAt(mode, titleX, titleY, baseTextColor, titleScale);
     drawTinyTextAt(timer, timerX, timerY, accent, timerScale);
+
+    if (!footer.isEmpty()) {
+      int footerScale = titleScale;
+      while (footerScale > 1 && measureTinyTextWidth(footer, footerScale) > contentWidth) {
+        --footerScale;
+      }
+      const int footerY = virtualHeight - (kTinyGlyphHeight * footerScale) - (portrait ? 8 : 6);
+      const int footerX = centeredXForTiny(footer, footerScale);
+      drawTinyTextAt(footer, footerX, footerY, baseTextColor, footerScale);
+      if (fillWidth > 0 && fillHeight > 0) {
+        drawTinyTextAtClipped(footer, footerX, footerY, inverseTextColor, footerScale,
+                              fillX, fillY, fillWidth, fillHeight);
+      }
+    }
 
     if (fillWidth > 0 && fillHeight > 0) {
       drawTinyTextAtClipped(mode, titleX, titleY, inverseTextColor, titleScale, fillX, fillY,

--- a/src/display/DisplayManager.cpp
+++ b/src/display/DisplayManager.cpp
@@ -1535,6 +1535,34 @@ void DisplayManager::drawTinyGlyph(int x, int y, char c, uint16_t color, int sca
   }
 }
 
+void DisplayManager::drawTinyTextAt180(const String &text, int x, int y, uint16_t color,
+                                       int scale) {
+  const uint16_t panel = panelColor(color);
+  const int n = static_cast<int>(text.length());
+  for (int ci = 0; ci < n; ++ci) {
+    const int charBaseX = x + (n - 1 - ci) * (kTinyGlyphWidth + kTinyGlyphSpacing) * scale;
+    const uint8_t *rows = tinyRowsFor(text[ci]);
+    for (int row = 0; row < kTinyGlyphHeight; ++row) {
+      const int dstRow = kTinyGlyphHeight - 1 - row;
+      for (int col = 0; col < kTinyGlyphWidth; ++col) {
+        if ((rows[row] & (1 << (kTinyGlyphWidth - 1 - col))) == 0) {
+          continue;
+        }
+        const int dstCol = kTinyGlyphWidth - 1 - col;
+        for (int yy = 0; yy < scale; ++yy) {
+          const int dstY = y + dstRow * scale + yy;
+          if (dstY < 0 || dstY >= kVirtualBufferHeight) continue;
+          for (int xx = 0; xx < scale; ++xx) {
+            const int dstX = charBaseX + dstCol * scale + xx;
+            if (dstX < 0 || dstX >= kVirtualBufferWidth) continue;
+            virtualFrame_[dstY * kVirtualBufferWidth + dstX] = panel;
+          }
+        }
+      }
+    }
+  }
+}
+
 void DisplayManager::drawTinyTextAt(const String &text, int x, int y, uint16_t color, int scale) {
   int cursorX = x;
   for (size_t i = 0; i < text.length(); ++i) {
@@ -3275,6 +3303,35 @@ void DisplayManager::renderFocusTimerScreen(const String &mode, const String &ge
     }
   };
 
+  auto drawTinyTextAt180Clipped = [&](const String &text, int x, int y, uint16_t color, int scale,
+                                      int clipX, int clipY, int clipWidth, int clipHeight) {
+    if (clipWidth <= 0 || clipHeight <= 0) return;
+    const int clipXEnd = clipX + clipWidth;
+    const int clipYEnd = clipY + clipHeight;
+    const uint16_t panel = panelColor(color);
+    const int n = static_cast<int>(text.length());
+    for (int ci = 0; ci < n; ++ci) {
+      const int charBaseX = x + (n - 1 - ci) * (kTinyGlyphWidth + kTinyGlyphSpacing) * scale;
+      const uint8_t *rows = tinyRowsFor(text[ci]);
+      for (int row = 0; row < kTinyGlyphHeight; ++row) {
+        const int dstRow = kTinyGlyphHeight - 1 - row;
+        for (int col = 0; col < kTinyGlyphWidth; ++col) {
+          if ((rows[row] & (1 << (kTinyGlyphWidth - 1 - col))) == 0) continue;
+          const int dstCol = kTinyGlyphWidth - 1 - col;
+          for (int yy = 0; yy < scale; ++yy) {
+            const int dstY = y + dstRow * scale + yy;
+            if (dstY < 0 || dstY >= kVirtualBufferHeight || dstY < clipY || dstY >= clipYEnd) continue;
+            for (int xx = 0; xx < scale; ++xx) {
+              const int dstX = charBaseX + dstCol * scale + xx;
+              if (dstX < 0 || dstX >= kVirtualBufferWidth || dstX < clipX || dstX >= clipXEnd) continue;
+              virtualFrame_[dstY * kVirtualBufferWidth + dstX] = panel;
+            }
+          }
+        }
+      }
+    }
+  };
+
   auto centeredXForTiny = [&](const String &text, int scale) {
     const int textWidth = measureTinyTextWidth(text, scale);
     return std::max(contentX, contentX + ((contentWidth - textWidth) / 2));
@@ -3322,12 +3379,13 @@ void DisplayManager::renderFocusTimerScreen(const String &mode, const String &ge
       while (footerScale > 1 && measureTinyTextWidth(footer, footerScale) > contentWidth) {
         --footerScale;
       }
-      const int footerY = virtualHeight - (kTinyGlyphHeight * footerScale) - (portrait ? 8 : 6);
+      // Mirror titleY padding: same distance from bottom as titleY is from top
+      const int footerY = virtualHeight - titleY - (kTinyGlyphHeight * footerScale);
       const int footerX = centeredXForTiny(footer, footerScale);
-      drawTinyTextAt(footer, footerX, footerY, baseTextColor, footerScale);
+      drawTinyTextAt180(footer, footerX, footerY, baseTextColor, footerScale);
       if (fillWidth > 0 && fillHeight > 0) {
-        drawTinyTextAtClipped(footer, footerX, footerY, inverseTextColor, footerScale,
-                              fillX, fillY, fillWidth, fillHeight);
+        drawTinyTextAt180Clipped(footer, footerX, footerY, inverseTextColor, footerScale,
+                                 fillX, fillY, fillWidth, fillHeight);
       }
     }
 

--- a/src/display/DisplayManager.h
+++ b/src/display/DisplayManager.h
@@ -161,6 +161,7 @@ class DisplayManager {
                              uint8_t scalePercent);
   void drawTinyGlyph(int x, int y, char c, uint16_t color, int scale);
   void drawTinyTextAt(const String &text, int x, int y, uint16_t color, int scale);
+  void drawTinyTextAt180(const String &text, int x, int y, uint16_t color, int scale);
   void drawTinyTextCentered(const String &text, int y, uint16_t color, int scale);
   void drawTinyTextCentered(const String &text, int y, uint16_t color, int scale, int width,
                             int xOffset);

--- a/src/timer/FocusTimer.cpp
+++ b/src/timer/FocusTimer.cpp
@@ -36,6 +36,11 @@ constexpr uint32_t kTouchDurations[] = {
     20UL * 60UL * 1000UL,
     25UL * 60UL * 1000UL,
     30UL * 60UL * 1000UL,
+    35UL * 60UL * 1000UL,
+    40UL * 60UL * 1000UL,
+    45UL * 60UL * 1000UL,
+    50UL * 60UL * 1000UL,
+    60UL * 60UL * 1000UL,
 };
 constexpr size_t kTouchDurationCount = sizeof(kTouchDurations) / sizeof(kTouchDurations[0]);
 
@@ -246,6 +251,14 @@ bool FocusTimer::consumeCompletionCue() {
 void FocusTimer::cycleTouchDuration() {
   touchDurationIndex_ = static_cast<uint8_t>((touchDurationIndex_ + 1) % kTouchDurationCount);
 }
+
+void FocusTimer::setTouchDurationIndex(uint8_t index) {
+  if (index < kTouchDurationCount) {
+    touchDurationIndex_ = index;
+  }
+}
+
+uint8_t FocusTimer::touchDurationIndex() const { return touchDurationIndex_; }
 
 uint32_t FocusTimer::selectedTouchDurationMs() const {
   return kTouchDurations[touchDurationIndex_];
@@ -480,7 +493,7 @@ void FocusTimer::clearSession() {
   completedTouchBlocks_ = 0;
   completedWorkBlocks_ = 0;
   completedBreakBlocks_ = 0;
-  touchDurationIndex_ = 0;
+  // touchDurationIndex_ is intentionally preserved across sessions
 }
 
 void FocusTimer::startMode(TimerMode mode, uint32_t nowMs, uint32_t durationMs,

--- a/src/timer/FocusTimer.cpp
+++ b/src/timer/FocusTimer.cpp
@@ -85,6 +85,10 @@ void FocusTimer::update(uint32_t nowMs) {
         completeActiveTimer();
         resetOrientationStability();
         transitionTo(State::WaitAfterTouch, nowMs);
+      } else if (isShortSide(stableOrientation_) &&
+                 stableOrientation_ == oppositeShortSide(lastShortSide_)) {
+        startMode(TimerMode::Touch, nowMs, kTouchDurations[touchDurationIndex_], stableOrientation_);
+        resetOrientationStability();
       }
       break;
 

--- a/src/timer/FocusTimer.cpp
+++ b/src/timer/FocusTimer.cpp
@@ -252,6 +252,14 @@ void FocusTimer::cycleTouchDuration() {
   touchDurationIndex_ = static_cast<uint8_t>((touchDurationIndex_ + 1) % kTouchDurationCount);
 }
 
+void FocusTimer::stepTouchDuration(int direction) {
+  if (direction > 0 && touchDurationIndex_ < kTouchDurationCount - 1) {
+    ++touchDurationIndex_;
+  } else if (direction < 0 && touchDurationIndex_ > 0) {
+    --touchDurationIndex_;
+  }
+}
+
 void FocusTimer::setTouchDurationIndex(uint8_t index) {
   if (index < kTouchDurationCount) {
     touchDurationIndex_ = index;

--- a/src/timer/FocusTimer.cpp
+++ b/src/timer/FocusTimer.cpp
@@ -25,9 +25,19 @@ constexpr uint32_t kOrientationStableMs = 700;
 constexpr uint32_t kTouchStartArmDelayMs = 350;
 constexpr uint32_t kPostTimerFlipGraceMs = 900;
 constexpr uint32_t kFeedbackMs = 900;
-constexpr uint32_t kTouchDurationMs = 2UL * 60UL * 1000UL;
 constexpr uint32_t kWorkDurationMs = 20UL * 60UL * 1000UL;
 constexpr uint32_t kBreakDurationMs = 5UL * 60UL * 1000UL;
+
+constexpr uint32_t kTouchDurations[] = {
+    2UL * 60UL * 1000UL,
+    5UL * 60UL * 1000UL,
+    10UL * 60UL * 1000UL,
+    15UL * 60UL * 1000UL,
+    20UL * 60UL * 1000UL,
+    25UL * 60UL * 1000UL,
+    30UL * 60UL * 1000UL,
+};
+constexpr size_t kTouchDurationCount = sizeof(kTouchDurations) / sizeof(kTouchDurations[0]);
 
 constexpr float kSideAxisThreshold = 0.78f;
 constexpr float kCrossAxisLimit = 0.42f;
@@ -60,7 +70,7 @@ void FocusTimer::update(uint32_t nowMs) {
 
     case State::WaitForTouchStart:
       if (orientationInputArmed(nowMs) && isShortSide(stableOrientation_)) {
-        startMode(TimerMode::Touch, nowMs, kTouchDurationMs, stableOrientation_);
+        startMode(TimerMode::Touch, nowMs, kTouchDurations[touchDurationIndex_], stableOrientation_);
         transitionTo(State::TouchRunning, nowMs);
       }
       break;
@@ -231,6 +241,14 @@ bool FocusTimer::consumeCompletionCue() {
   const bool pending = completionCuePending_;
   completionCuePending_ = false;
   return pending;
+}
+
+void FocusTimer::cycleTouchDuration() {
+  touchDurationIndex_ = static_cast<uint8_t>((touchDurationIndex_ + 1) % kTouchDurationCount);
+}
+
+uint32_t FocusTimer::selectedTouchDurationMs() const {
+  return kTouchDurations[touchDurationIndex_];
 }
 
 const char *FocusTimer::genreLabel(Genre genre) {
@@ -462,6 +480,7 @@ void FocusTimer::clearSession() {
   completedTouchBlocks_ = 0;
   completedWorkBlocks_ = 0;
   completedBreakBlocks_ = 0;
+  touchDurationIndex_ = 0;
 }
 
 void FocusTimer::startMode(TimerMode mode, uint32_t nowMs, uint32_t durationMs,

--- a/src/timer/FocusTimer.cpp
+++ b/src/timer/FocusTimer.cpp
@@ -75,7 +75,7 @@ void FocusTimer::update(uint32_t nowMs) {
 
     case State::WaitForTouchStart:
       if (orientationInputArmed(nowMs) && isShortSide(stableOrientation_)) {
-        startMode(TimerMode::Touch, nowMs, kTouchDurations[touchDurationIndex_], stableOrientation_);
+        startMode(TimerMode::Touch, nowMs, kTouchDurations[touchDurationByGenre_[genreIdx()]], stableOrientation_);
         transitionTo(State::TouchRunning, nowMs);
       }
       break;
@@ -87,7 +87,7 @@ void FocusTimer::update(uint32_t nowMs) {
         transitionTo(State::WaitAfterTouch, nowMs);
       } else if (isShortSide(stableOrientation_) &&
                  stableOrientation_ == oppositeShortSide(lastShortSide_)) {
-        startMode(TimerMode::Touch, nowMs, kTouchDurations[touchDurationIndex_], stableOrientation_);
+        startMode(TimerMode::Touch, nowMs, kTouchDurations[touchDurationByGenre_[genreIdx()]], stableOrientation_);
         resetOrientationStability();
       }
       break;
@@ -253,27 +253,40 @@ bool FocusTimer::consumeCompletionCue() {
 }
 
 void FocusTimer::cycleTouchDuration() {
-  touchDurationIndex_ = static_cast<uint8_t>((touchDurationIndex_ + 1) % kTouchDurationCount);
+  uint8_t &idx = touchDurationByGenre_[genreIdx()];
+  idx = static_cast<uint8_t>((idx + 1) % kTouchDurationCount);
 }
 
 void FocusTimer::stepTouchDuration(int direction) {
-  if (direction > 0 && touchDurationIndex_ < kTouchDurationCount - 1) {
-    ++touchDurationIndex_;
-  } else if (direction < 0 && touchDurationIndex_ > 0) {
-    --touchDurationIndex_;
+  uint8_t &idx = touchDurationByGenre_[genreIdx()];
+  if (direction > 0 && idx < kTouchDurationCount - 1) {
+    ++idx;
+  } else if (direction < 0 && idx > 0) {
+    --idx;
   }
 }
 
-void FocusTimer::setTouchDurationIndex(uint8_t index) {
-  if (index < kTouchDurationCount) {
-    touchDurationIndex_ = index;
+void FocusTimer::setTouchDurationIndexForGenre(Genre genre, uint8_t index) {
+  const uint8_t g = static_cast<uint8_t>(genre);
+  if (g < kGenreCount && index < kTouchDurationCount) {
+    touchDurationByGenre_[g] = index;
   }
 }
 
-uint8_t FocusTimer::touchDurationIndex() const { return touchDurationIndex_; }
+uint8_t FocusTimer::touchDurationIndexForGenre(Genre genre) const {
+  const uint8_t g = static_cast<uint8_t>(genre);
+  return g < kGenreCount ? touchDurationByGenre_[g] : 0;
+}
+
+uint8_t FocusTimer::touchDurationIndex() const { return touchDurationByGenre_[genreIdx()]; }
 
 uint32_t FocusTimer::selectedTouchDurationMs() const {
-  return kTouchDurations[touchDurationIndex_];
+  return kTouchDurations[touchDurationByGenre_[genreIdx()]];
+}
+
+uint8_t FocusTimer::genreIdx() const {
+  const uint8_t idx = static_cast<uint8_t>(genre_);
+  return idx < kGenreCount ? idx : 0;
 }
 
 const char *FocusTimer::genreLabel(Genre genre) {
@@ -505,7 +518,7 @@ void FocusTimer::clearSession() {
   completedTouchBlocks_ = 0;
   completedWorkBlocks_ = 0;
   completedBreakBlocks_ = 0;
-  // touchDurationIndex_ is intentionally preserved across sessions
+  // touchDurationByGenre_ is intentionally preserved across sessions
 }
 
 void FocusTimer::startMode(TimerMode mode, uint32_t nowMs, uint32_t durationMs,

--- a/src/timer/FocusTimer.cpp
+++ b/src/timer/FocusTimer.cpp
@@ -96,9 +96,9 @@ void FocusTimer::update(uint32_t nowMs) {
       if (!orientationInputArmed(nowMs)) {
         break;
       }
-      if (stableOrientation_ == oppositeShortSide(lastShortSide_)) {
-        startMode(TimerMode::Work, nowMs, kWorkDurationMs, stableOrientation_);
-        transitionTo(State::WorkRunning, nowMs);
+      if (isShortSide(stableOrientation_)) {
+        resetOrientationStability();
+        transitionTo(State::WaitForTouchStart, nowMs);
       } else if (stableOrientation_ == OrientationState::LongSide) {
         startMode(TimerMode::Break, nowMs, kBreakDurationMs, OrientationState::LongSide);
         transitionTo(State::BreakRunning, nowMs);
@@ -136,8 +136,8 @@ void FocusTimer::update(uint32_t nowMs) {
 
     case State::WaitAfterBreak:
       if (orientationInputArmed(nowMs) && isShortSide(stableOrientation_)) {
-        startMode(TimerMode::Work, nowMs, kWorkDurationMs, stableOrientation_);
-        transitionTo(State::WorkRunning, nowMs);
+        resetOrientationStability();
+        transitionTo(State::WaitForTouchStart, nowMs);
       }
       break;
 

--- a/src/timer/FocusTimer.cpp
+++ b/src/timer/FocusTimer.cpp
@@ -96,7 +96,7 @@ void FocusTimer::update(uint32_t nowMs) {
       if (!orientationInputArmed(nowMs)) {
         break;
       }
-      if (isShortSide(stableOrientation_)) {
+      if (stableOrientation_ == oppositeShortSide(lastShortSide_)) {
         resetOrientationStability();
         transitionTo(State::WaitForTouchStart, nowMs);
       } else if (stableOrientation_ == OrientationState::LongSide) {

--- a/src/timer/FocusTimer.h
+++ b/src/timer/FocusTimer.h
@@ -36,6 +36,7 @@ class FocusTimer {
   void chooseGenre(Genre genre, uint32_t nowMs);
   void cancelActiveTimer(uint32_t nowMs);
   void cycleTouchDuration();
+  void stepTouchDuration(int direction);
   void setTouchDurationIndex(uint8_t index);
   uint8_t touchDurationIndex() const;
   void abandon();

--- a/src/timer/FocusTimer.h
+++ b/src/timer/FocusTimer.h
@@ -36,6 +36,8 @@ class FocusTimer {
   void chooseGenre(Genre genre, uint32_t nowMs);
   void cancelActiveTimer(uint32_t nowMs);
   void cycleTouchDuration();
+  void setTouchDurationIndex(uint8_t index);
+  uint8_t touchDurationIndex() const;
   void abandon();
 
   bool available() const;

--- a/src/timer/FocusTimer.h
+++ b/src/timer/FocusTimer.h
@@ -30,6 +30,8 @@ class FocusTimer {
     Complete,
   };
 
+  static constexpr uint8_t kGenreCount = 5;
+
   bool begin();
   void open();
   void update(uint32_t nowMs);
@@ -37,8 +39,9 @@ class FocusTimer {
   void cancelActiveTimer(uint32_t nowMs);
   void cycleTouchDuration();
   void stepTouchDuration(int direction);
-  void setTouchDurationIndex(uint8_t index);
+  void setTouchDurationIndexForGenre(Genre genre, uint8_t index);
   uint8_t touchDurationIndex() const;
+  uint8_t touchDurationIndexForGenre(Genre genre) const;
   void abandon();
 
   bool available() const;
@@ -89,6 +92,7 @@ class FocusTimer {
   void stopActiveTimer();
   void completeActiveTimer();
   bool timerExpired(uint32_t nowMs) const;
+  uint8_t genreIdx() const;
   static bool isShortSide(OrientationState orientation);
   static OrientationState oppositeShortSide(OrientationState orientation);
   static BoardConfig::UiOrientation portraitOrientationForShortSide(
@@ -96,7 +100,7 @@ class FocusTimer {
 
   bool imuAvailable_ = false;
   float accelScale_ = 4.0f / 32768.0f;
-  uint8_t touchDurationIndex_ = 0;
+  uint8_t touchDurationByGenre_[kGenreCount] = {};
   OrientationState rawOrientation_ = OrientationState::Unknown;
   OrientationState stableOrientation_ = OrientationState::Unknown;
   OrientationState candidateOrientation_ = OrientationState::Unknown;

--- a/src/timer/FocusTimer.h
+++ b/src/timer/FocusTimer.h
@@ -35,6 +35,7 @@ class FocusTimer {
   void update(uint32_t nowMs);
   void chooseGenre(Genre genre, uint32_t nowMs);
   void cancelActiveTimer(uint32_t nowMs);
+  void cycleTouchDuration();
   void abandon();
 
   bool available() const;
@@ -43,6 +44,7 @@ class FocusTimer {
   Genre genre() const;
   BoardConfig::UiOrientation uiOrientation() const;
   uint32_t remainingMs(uint32_t nowMs) const;
+  uint32_t selectedTouchDurationMs() const;
   uint8_t progressPercent(uint32_t nowMs) const;
   uint8_t completedTouchBlocks() const;
   uint8_t completedWorkBlocks() const;
@@ -91,6 +93,7 @@ class FocusTimer {
 
   bool imuAvailable_ = false;
   float accelScale_ = 4.0f / 32768.0f;
+  uint8_t touchDurationIndex_ = 0;
   OrientationState rawOrientation_ = OrientationState::Unknown;
   OrientationState stableOrientation_ = OrientationState::Unknown;
   OrientationState candidateOrientation_ = OrientationState::Unknown;


### PR DESCRIPTION
The Focus Timer received several UX improvements: custom touch duration with swipe-to-change, duration persistence across sessions and divided by timer type, flip-to-restart while running, a "Restart" label at the bottom of the screen (rotated 180°, with underline divider), and a bug fix to restore landscape orientation when exiting the timer.

Changes
- `FocusTimer.cpp` / `FocusTimer.h`: 
- The fixed kTouchDurationMs (2 min) is replaced by an array of 12 presets from 2 min to 60 min. 
- New methods stepTouchDuration(direction), cycleTouchDuration(), setTouchDurationIndex(), and selectedTouchDurationMs() allow the index to be read and written. touchDurationIndex_ is intentionally preserved across sessions (not reset on clearSession()`). 
- The `TouchRunning state now detects a flip to the opposite short side and immediately restarts the touch timer, enabling the flip-to-restart gesture.

- `App.cpp` / `App.h`: 
- Swipe left/right on the timer screen calls focusTimer_.stepTouchDuration() and persists the index to NVS (`Preferences`). The last used duration is restored at boot via setTouchDurationIndex(). renderFocusTimerSession() passes the selected duration label and a "Restart" label to the display. 
- resetFocusTimer() now calls applyReaderUiOrientation() to restore landscape mode when leaving the timer screen.
- `DisplayManager.cpp` / `DisplayManager.h`: 
- renderFocusTimerScreen() was extended to accept a bottom restart label and a progress bar. The restart label is drawn rotated 180° at the bottom of the screen with a matching underline divider that mirrors the BEGIN label's divider at the top.
- Fixed an issue where restarting a timer after it ended would incorrectly switch to the next timer category.