### PR TITLE
Manage chapter footer

### DIFF
--- a/src/app/App.cpp
+++ b/src/app/App.cpp
@@ -161,14 +161,14 @@ constexpr size_t kSettingsHomeUpdateIndex = 5;
 constexpr size_t kSettingsDisplayThemeIndex = 1;
 constexpr size_t kSettingsDisplayBrightnessIndex = 2;
 constexpr size_t kSettingsDisplayHandednessIndex = 3;
-constexpr size_t kSettingsDisplayFooterIndex = 4;
-constexpr size_t kSettingsDisplayBatteryIndex = 5;
-constexpr size_t kSettingsDisplayScreensaverIndex = 6;
-constexpr size_t kSettingsDisplayReaderBatteryIndex = 7;
-constexpr size_t kSettingsDisplayReaderChapterIndex = 8;
-constexpr size_t kSettingsDisplayReaderProgressIndex = 9;
-constexpr size_t kSettingsDisplayLanguageIndex = 10;
-constexpr size_t kSettingsDisplayChapterLabelIndex = 11;
+constexpr size_t kSettingsDisplayChapterLabelIndex = 4;
+constexpr size_t kSettingsDisplayFooterIndex = 5;
+constexpr size_t kSettingsDisplayBatteryIndex = 6;
+constexpr size_t kSettingsDisplayScreensaverIndex = 7;
+constexpr size_t kSettingsDisplayReaderBatteryIndex = 8;
+constexpr size_t kSettingsDisplayReaderChapterIndex = 9;
+constexpr size_t kSettingsDisplayReaderProgressIndex = 10;
+constexpr size_t kSettingsDisplayLanguageIndex = 11;
 constexpr size_t kSettingsPacingReadingModeIndex = 1;
 constexpr size_t kSettingsPacingPauseModeIndex = 2;
 constexpr size_t kSettingsPacingWpmIndex = 3;
@@ -3376,6 +3376,7 @@ void App::rebuildSettingsMenuItems() {
     settingsMenuItems_.push_back(uiText(UiText::Brightness) + ": " +
                                  String(currentBrightnessPercent()) + "%");
     settingsMenuItems_.push_back("Reader hand: " + handednessLabel());
+    settingsMenuItems_.push_back("Chapter label: " + onOffLabel(chapterLabelEnabled_));
     settingsMenuItems_.push_back("Footer label: " + footerMetricModeLabel());
     settingsMenuItems_.push_back("Battery label: " + batteryLabelModeLabel());
     settingsMenuItems_.push_back("Screensaver: " + screensaverModeLabel());
@@ -3386,7 +3387,6 @@ void App::rebuildSettingsMenuItems() {
     settingsMenuItems_.push_back("Reading percent: " +
                                  onOffLabel(readerProgressVisibleWhilePlaying_));
     settingsMenuItems_.push_back(uiText(UiText::Language) + ": " + uiLanguageLabel());
-    settingsMenuItems_.push_back("Chapter label: " + onOffLabel(chapterLabelEnabled_));
   } else if (menuScreen_ == MenuScreen::SettingsPacing) {
     settingsMenuItems_.push_back(uiText(UiText::Back));
     settingsMenuItems_.push_back("Reading mode: " + readerModeLabel());

--- a/src/app/App.cpp
+++ b/src/app/App.cpp
@@ -206,7 +206,9 @@ constexpr const char *kPrefScreensaverMode = "scrn_sv";
 constexpr const char *kPrefReaderBatteryVisible = "read_bat";
 constexpr const char *kPrefReaderChapterVisible = "read_ch";
 constexpr const char *kPrefReaderProgressVisible = "read_pct";
-constexpr const char *kPrefChapterLabelEnabled = "ch_lbl_on";
+constexpr const char *kPrefChapterLabelEnabled = "ch_lbl_on";   // legacy key (unused)
+constexpr const char *kPrefChapterLabelRsvp = "ch_lbl_rsvp";   // default true
+constexpr const char *kPrefChapterLabelScroll = "ch_lbl_scroll"; // default false
 constexpr const char *kPrefReaderFontSize = "font_size";
 constexpr const char *kPrefReaderTypeface = "typeface";
 constexpr const char *kPrefTypographyFocusHighlight = "type_hlt";
@@ -625,8 +627,6 @@ void App::begin() {
       preferences_.getBool(kPrefReaderBatteryVisible, readerBatteryVisibleWhilePlaying_);
   readerChapterVisibleWhilePlaying_ =
       preferences_.getBool(kPrefReaderChapterVisible, readerChapterVisibleWhilePlaying_);
-  chapterLabelEnabled_ =
-      preferences_.getBool(kPrefChapterLabelEnabled, chapterLabelEnabled_);
   readerProgressVisibleWhilePlaying_ =
       preferences_.getBool(kPrefReaderProgressVisible, readerProgressVisibleWhilePlaying_);
   uiLanguage_ =
@@ -634,6 +634,9 @@ void App::begin() {
           kPrefUiLanguage, static_cast<uint8_t>(uiLanguage_)));
   readerMode_ = readerModeFromSetting(
       preferences_.getUChar(kPrefReaderMode, static_cast<uint8_t>(readerMode_)));
+  // Load chapter label per reading mode (RSVP defaults ON, Scroll defaults OFF)
+  chapterLabelEnabled_ = preferences_.getBool(
+      chapterLabelPrefKey(), chapterLabelDefaultForMode(readerMode_));
   handednessMode_ = handednessModeFromSetting(
       preferences_.getUChar(kPrefHandedness, static_cast<uint8_t>(handednessMode_)));
   readerFontSizeIndex_ = preferences_.getUChar(kPrefReaderFontSize, readerFontSizeIndex_);
@@ -1476,6 +1479,9 @@ void App::cycleUiLanguage(uint32_t nowMs) {
 void App::cycleReaderMode(uint32_t nowMs) {
   readerMode_ = nextReaderMode(readerMode_);
   preferences_.putUChar(kPrefReaderMode, static_cast<uint8_t>(readerMode_));
+  // Reload chapter label default for the new mode
+  chapterLabelEnabled_ = preferences_.getBool(
+      chapterLabelPrefKey(), chapterLabelDefaultForMode(readerMode_));
   Serial.printf("[display] reader mode=%s\n", readerModeLabel().c_str());
   invalidateContextPreviewWindow();
 
@@ -2771,7 +2777,7 @@ void App::selectSettingsItem(uint32_t nowMs) {
         return;
       case kSettingsDisplayChapterLabelIndex:
         chapterLabelEnabled_ = !chapterLabelEnabled_;
-        preferences_.putBool(kPrefChapterLabelEnabled, chapterLabelEnabled_);
+        preferences_.putBool(chapterLabelPrefKey(), chapterLabelEnabled_);
         rebuildSettingsMenuItems();
         renderSettings();
         return;
@@ -5390,6 +5396,14 @@ String App::cleanedChapterTitle(const String &raw, const String &fallback) const
     return cleaned.isEmpty() ? fallback : cleaned;
   }
   return raw;
+}
+
+const char *App::chapterLabelPrefKey() const {
+  return (readerMode_ == ReaderMode::Scroll) ? kPrefChapterLabelScroll : kPrefChapterLabelRsvp;
+}
+
+bool App::chapterLabelDefaultForMode(ReaderMode mode) {
+  return mode != ReaderMode::Scroll;
 }
 
 String App::currentFooterMetricLabel() const {

--- a/src/app/App.cpp
+++ b/src/app/App.cpp
@@ -168,6 +168,7 @@ constexpr size_t kSettingsDisplayReaderBatteryIndex = 7;
 constexpr size_t kSettingsDisplayReaderChapterIndex = 8;
 constexpr size_t kSettingsDisplayReaderProgressIndex = 9;
 constexpr size_t kSettingsDisplayLanguageIndex = 10;
+constexpr size_t kSettingsDisplayChapterLabelIndex = 11;
 constexpr size_t kSettingsPacingReadingModeIndex = 1;
 constexpr size_t kSettingsPacingPauseModeIndex = 2;
 constexpr size_t kSettingsPacingWpmIndex = 3;
@@ -205,6 +206,7 @@ constexpr const char *kPrefScreensaverMode = "scrn_sv";
 constexpr const char *kPrefReaderBatteryVisible = "read_bat";
 constexpr const char *kPrefReaderChapterVisible = "read_ch";
 constexpr const char *kPrefReaderProgressVisible = "read_pct";
+constexpr const char *kPrefChapterLabelEnabled = "ch_lbl_on";
 constexpr const char *kPrefReaderFontSize = "font_size";
 constexpr const char *kPrefReaderTypeface = "typeface";
 constexpr const char *kPrefTypographyFocusHighlight = "type_hlt";
@@ -623,6 +625,8 @@ void App::begin() {
       preferences_.getBool(kPrefReaderBatteryVisible, readerBatteryVisibleWhilePlaying_);
   readerChapterVisibleWhilePlaying_ =
       preferences_.getBool(kPrefReaderChapterVisible, readerChapterVisibleWhilePlaying_);
+  chapterLabelEnabled_ =
+      preferences_.getBool(kPrefChapterLabelEnabled, chapterLabelEnabled_);
   readerProgressVisibleWhilePlaying_ =
       preferences_.getBool(kPrefReaderProgressVisible, readerProgressVisibleWhilePlaying_);
   uiLanguage_ =
@@ -1704,7 +1708,8 @@ DisplayManager::ReaderChrome App::readerChrome() const {
   DisplayManager::ReaderChrome chrome;
   const bool reading = isActivelyReading();
   chrome.showBattery = !reading || readerBatteryVisibleWhilePlaying_;
-  chrome.showChapter = !reading || readerChapterVisibleWhilePlaying_;
+  const bool chapterAllowed = chapterLabelEnabled_ && !scrollModeEnabled();
+  chrome.showChapter = chapterAllowed && (!reading || readerChapterVisibleWhilePlaying_);
   chrome.showProgress = !reading || readerProgressVisibleWhilePlaying_;
   chrome.showPreviousSentenceHint = !contextViewVisible_ || scrollModeEnabled();
   return chrome;
@@ -2764,6 +2769,12 @@ void App::selectSettingsItem(uint32_t nowMs) {
       case kSettingsDisplayLanguageIndex:
         cycleUiLanguage(nowMs);
         return;
+      case kSettingsDisplayChapterLabelIndex:
+        chapterLabelEnabled_ = !chapterLabelEnabled_;
+        preferences_.putBool(kPrefChapterLabelEnabled, chapterLabelEnabled_);
+        rebuildSettingsMenuItems();
+        renderSettings();
+        return;
       default:
         return;
     }
@@ -3375,6 +3386,7 @@ void App::rebuildSettingsMenuItems() {
     settingsMenuItems_.push_back("Reading percent: " +
                                  onOffLabel(readerProgressVisibleWhilePlaying_));
     settingsMenuItems_.push_back(uiText(UiText::Language) + ": " + uiLanguageLabel());
+    settingsMenuItems_.push_back("Chapter label: " + onOffLabel(chapterLabelEnabled_));
   } else if (menuScreen_ == MenuScreen::SettingsPacing) {
     settingsMenuItems_.push_back(uiText(UiText::Back));
     settingsMenuItems_.push_back("Reading mode: " + readerModeLabel());
@@ -5360,11 +5372,24 @@ size_t App::currentChapterIndex() const {
 
 String App::currentChapterLabel() const {
   const size_t chapterIndex = currentChapterIndex();
+  const String fallback = currentBookTitle_.isEmpty() ? uiText(UiText::Start) : currentBookTitle_;
   if (chapterIndex >= chapterMarkers_.size()) {
-    return currentBookTitle_.isEmpty() ? uiText(UiText::Start) : currentBookTitle_;
+    return fallback;
   }
+  return cleanedChapterTitle(chapterMarkers_[chapterIndex].title, fallback);
+}
 
-  return chapterMarkers_[chapterIndex].title;
+String App::cleanedChapterTitle(const String &raw, const String &fallback) const {
+  if (raw.isEmpty()) return fallback;
+  // Strip leading "N." prefix (e.g. "2.EbookTitle" -> "EbookTitle")
+  size_t i = 0;
+  while (i < (size_t)raw.length() && isDigit(raw[i])) i++;
+  if (i > 0 && i < (size_t)raw.length() && raw[i] == '.') {
+    String cleaned = raw.substring(i + 1);
+    cleaned.trim();
+    return cleaned.isEmpty() ? fallback : cleaned;
+  }
+  return raw;
 }
 
 String App::currentFooterMetricLabel() const {

--- a/src/app/App.h
+++ b/src/app/App.h
@@ -347,6 +347,7 @@ class App {
   String chapterMenuLabel(size_t chapterIndex) const;
   size_t currentChapterIndex() const;
   String currentChapterLabel() const;
+  String cleanedChapterTitle(const String &raw, const String &fallback) const;
   String currentFooterMetricLabel() const;
   String currentBatteryLabel() const;
   String footerMetricModeLabel() const;
@@ -542,6 +543,7 @@ class App {
   bool readerBatteryVisibleWhilePlaying_ = true;
   bool readerChapterVisibleWhilePlaying_ = false;
   bool readerProgressVisibleWhilePlaying_ = false;
+  bool chapterLabelEnabled_ = true;
   FooterMetricMode footerMetricMode_ = FooterMetricMode::Percentage;
   BatteryLabelMode batteryLabelMode_ = BatteryLabelMode::Percent;
   ScreensaverMode screensaverMode_ = ScreensaverMode::Life;

--- a/src/app/App.h
+++ b/src/app/App.h
@@ -348,6 +348,8 @@ class App {
   size_t currentChapterIndex() const;
   String currentChapterLabel() const;
   String cleanedChapterTitle(const String &raw, const String &fallback) const;
+  const char *chapterLabelPrefKey() const;
+  static bool chapterLabelDefaultForMode(ReaderMode mode);
   String currentFooterMetricLabel() const;
   String currentBatteryLabel() const;
   String footerMetricModeLabel() const;


### PR DESCRIPTION
Chapter title cleanup — strips numeric prefixes from EPUB spine titles (e.g. "2.Ebook Dungeon 14" → "Ebook Dungeon 14") displayed in the footer while reading. (can be improved further)

Show/hide chapter label — in Page Scroll mode the label is hidden by default; in RSVP mode it is visible by default. Each preference is saved separately per mode.

Toggle in Display Settings — adds a “Chapter label: On/Off” option in the Display settings (above Footer label), allowing the chapter label to be enabled or disabled at any time.