### PR TITLE
feat: configurable play & pause gestures (hold & tap modes)

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,10 +177,15 @@ The goal is simple: use `PWR` as menu, back, exit, and power. Use `BOOT` for qui
 
 ### Reader Controls
 
-- Hold the screen: start reading.
-- Release after a hold: pause.
-- Double tap while paused: start locked continuous play.
-- Tap while locked continuous play is running: pause.
+- Play/Pause
+  - **Hold** mode:
+    - Hold the screen: start reading.
+    - Release after a hold: pause.
+    - Double tap while paused: start locked continuous play.
+    - Tap while locked continuous play is running: pause.
+  - **Tap** mode:
+    - Tap the screen while paused: start reading.
+    - Tap the screen while reading: pause.
 - Tap the far-left edge: rewind to the start of the current sentence, or the previous sentence if you are already at the start.
 - Swipe left or right while paused: scrub through nearby text.
 - Tap after scrubbing: return to RSVP view.
@@ -190,7 +195,7 @@ The goal is simple: use `PWR` as menu, back, exit, and power. Use `BOOT` for qui
 - Tap the bottom-right footer label: switch between progress, chapter time remaining, book time remaining, and battery display modes.
 - Tap the top-right battery label: switch between percentage, time remaining, and voltage.
 
-Pause behavior is configurable. In `Settings -> Word pacing`, choose whether taps pause instantly or at the end of the sentence.
+Play/Pause mode and pause behaviour are configurable in `Settings -> Word pacing`. Choose between hold-to-play or tap-to-toggle, and whether pausing stops instantly or waits for the end of the sentence.
 
 ### Main Menu
 
@@ -259,6 +264,7 @@ Settings are grouped by how people actually use the device.
 - RSVP or scroll reading behavior.
 - Reading speeds from 10 WPM upward, with 10 WPM steps below 100 WPM.
 - Instant pause or sentence-end pause.
+- Play/Pause mode: hold to play and release to pause, or tap to toggle.
 - Pacing reset.
 
 `Wi-Fi` includes network setup for RSS and OTA.

--- a/src/app/App.cpp
+++ b/src/app/App.cpp
@@ -169,12 +169,13 @@ constexpr size_t kSettingsDisplayReaderChapterIndex = 8;
 constexpr size_t kSettingsDisplayReaderProgressIndex = 9;
 constexpr size_t kSettingsDisplayLanguageIndex = 10;
 constexpr size_t kSettingsPacingReadingModeIndex = 1;
-constexpr size_t kSettingsPacingPauseModeIndex = 2;
-constexpr size_t kSettingsPacingWpmIndex = 3;
-constexpr size_t kSettingsPacingLongWordsIndex = 4;
-constexpr size_t kSettingsPacingComplexityIndex = 5;
-constexpr size_t kSettingsPacingPunctuationIndex = 6;
-constexpr size_t kSettingsPacingResetIndex = 7;
+constexpr size_t kSettingsPacingPauseModeIndex   = 2;
+constexpr size_t kSettingsPacingPlayModeIndex    = 3;
+constexpr size_t kSettingsPacingWpmIndex         = 4;
+constexpr size_t kSettingsPacingLongWordsIndex   = 5;
+constexpr size_t kSettingsPacingComplexityIndex  = 6;
+constexpr size_t kSettingsPacingPunctuationIndex = 7;
+constexpr size_t kSettingsPacingResetIndex       = 8;
 constexpr size_t kWifiSettingsNetworkIndex = 1;
 constexpr size_t kWifiSettingsChooseIndex = 2;
 constexpr size_t kWifiSettingsAutoUpdateIndex = 3;
@@ -215,6 +216,7 @@ constexpr const char *kPrefPacingLongMs = "pace_lms";
 constexpr const char *kPrefPacingComplexMs = "pace_cms";
 constexpr const char *kPrefPacingPunctuationMs = "pace_pms";
 constexpr const char *kPrefPauseMode = "pause_md";
+constexpr const char *kPrefPlayInputMode = "play_md";
 constexpr const char *kPrefAccurateTime = "time_est_a";
 constexpr const char *kPrefTypographyTracking = "type_trk";
 constexpr const char *kPrefTypographyAnchor = "type_anc";
@@ -684,6 +686,15 @@ void App::begin() {
     case static_cast<uint8_t>(PauseMode::SentenceEnd):
     default:
       pauseMode_ = PauseMode::SentenceEnd;
+      break;
+  }
+  switch (preferences_.getUChar(kPrefPlayInputMode,
+                                static_cast<uint8_t>(PlayInputMode::HoldToPlay))) {
+    case static_cast<uint8_t>(PlayInputMode::TapToPlay):
+      playInputMode_ = PlayInputMode::TapToPlay;
+      break;
+    default:
+      playInputMode_ = PlayInputMode::HoldToPlay;
       break;
   }
   pacingLongWordDelayMs_ =
@@ -1356,6 +1367,15 @@ void App::reloadRuntimePreferences(uint32_t nowMs, bool rerender) {
       pauseMode_ = PauseMode::SentenceEnd;
       break;
   }
+  switch (preferences_.getUChar(kPrefPlayInputMode,
+                                static_cast<uint8_t>(PlayInputMode::HoldToPlay))) {
+    case static_cast<uint8_t>(PlayInputMode::TapToPlay):
+      playInputMode_ = PlayInputMode::TapToPlay;
+      break;
+    default:
+      playInputMode_ = PlayInputMode::HoldToPlay;
+      break;
+  }
 
   pacingLongWordDelayMs_ =
       loadPacingDelayMs(preferences_, kPrefPacingLongMs, kPrefLegacyPacingLong);
@@ -1999,6 +2019,9 @@ void App::applyPausedTouchGesture(const TouchEvent &event, uint32_t nowMs) {
         if (playLocked_ || pauseAtSentenceEndRequested_) {
           resetReaderTapTracking();
           requestReaderPauseAtSentenceEnd(nowMs);
+        } else if (playInputMode_ == PlayInputMode::TapToPlay) {
+          resetReaderTapTracking();
+          requestReaderPauseAtSentenceEnd(nowMs);
         } else {
           handleReaderTap(event.x, event.y, nowMs);
         }
@@ -2009,7 +2032,8 @@ void App::applyPausedTouchGesture(const TouchEvent &event, uint32_t nowMs) {
     return;
   }
 
-  if (!previewBrowseMode && !ended && pausedTouchIntent_ == TouchIntent::None &&
+  if (playInputMode_ == PlayInputMode::HoldToPlay &&
+      !previewBrowseMode && !ended && pausedTouchIntent_ == TouchIntent::None &&
       pressDurationMs >= kTouchPlayHoldMs && tapLike) {
     resetReaderTapTracking();
     touchPlayHeld_ = true;
@@ -2087,6 +2111,11 @@ void App::applyPausedTouchGesture(const TouchEvent &event, uint32_t nowMs) {
       resetReaderTapTracking();
       contextViewVisible_ = false;
       renderActiveReader(nowMs);
+    } else if (tapLike && playInputMode_ == PlayInputMode::TapToPlay) {
+      resetReaderTapTracking();
+      wpmFeedbackVisible_ = false;
+      playLocked_ = true;
+      setState(AppState::Playing, nowMs);
     } else if (tapLike) {
       handleReaderTap(event.x, event.y, nowMs);
     } else {
@@ -2793,6 +2822,14 @@ void App::selectSettingsItem(uint32_t nowMs) {
       rebuildSettingsMenuItems();
       renderSettings();
       return;
+    case kSettingsPacingPlayModeIndex:
+      playInputMode_ = playInputMode_ == PlayInputMode::HoldToPlay
+                           ? PlayInputMode::TapToPlay : PlayInputMode::HoldToPlay;
+      preferences_.putUChar(kPrefPlayInputMode, static_cast<uint8_t>(playInputMode_));
+      Serial.printf("[settings] play input mode=%s\n", playInputModeLabel().c_str());
+      rebuildSettingsMenuItems();
+      renderSettings();
+      return;
     case kSettingsPacingWpmIndex:
       reader_.setWpm(nextReaderWpmSetting(reader_.wpm()));
       preferences_.putUShort(kPrefWpm, reader_.wpm());
@@ -3379,6 +3416,7 @@ void App::rebuildSettingsMenuItems() {
     settingsMenuItems_.push_back(uiText(UiText::Back));
     settingsMenuItems_.push_back("Reading mode: " + readerModeLabel());
     settingsMenuItems_.push_back("Pause behaviour: " + pauseModeLabel());
+    settingsMenuItems_.push_back("Play/Pause: " + playInputModeLabel());
     settingsMenuItems_.push_back("Base speed: " + String(reader_.wpm()) + " WPM");
     settingsMenuItems_.push_back(uiText(UiText::LongWords) + ": " +
                                  pacingDelayLabel(pacingLongWordDelayMs_));
@@ -3716,6 +3754,10 @@ String App::readerModeLabel() const {
 
 String App::pauseModeLabel() const {
   return pauseMode_ == PauseMode::Instant ? "Instant" : "Sentence";
+}
+
+String App::playInputModeLabel() const {
+  return playInputMode_ == PlayInputMode::TapToPlay ? "Tap" : "Hold";
 }
 
 String App::handednessLabel() const {

--- a/src/app/App.h
+++ b/src/app/App.h
@@ -119,6 +119,11 @@ class App {
     Instant = 1,
   };
 
+  enum class PlayInputMode : uint8_t {
+    HoldToPlay = 0,
+    TapToPlay  = 1,
+  };
+
   enum class TextEntryPurpose : uint8_t {
     None,
     WifiPassword,
@@ -270,6 +275,7 @@ class App {
   String uiLanguageLabel() const;
   String readerModeLabel() const;
   String pauseModeLabel() const;
+  String playInputModeLabel() const;
   String handednessLabel() const;
   String readerFontSizeLabel() const;
   String readerTypefaceLabel() const;
@@ -546,6 +552,7 @@ class App {
   BatteryLabelMode batteryLabelMode_ = BatteryLabelMode::Percent;
   ScreensaverMode screensaverMode_ = ScreensaverMode::Life;
   PauseMode pauseMode_ = PauseMode::SentenceEnd;
+  PlayInputMode playInputMode_ = PlayInputMode::HoldToPlay;
   bool darkMode_ = true;
   bool nightMode_ = false;
   UiLanguage uiLanguage_ = UiLanguage::English;


### PR DESCRIPTION
This PR adds configurable play/pause controls. The normal hold gestures and new tap gestures. When in tap mode tapping will toggle play and pause. I've added a setting to configure this in the pacing menu next to the pause behavior. 