### PR TITLE
Target manual firmware releases at workflow commit

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,158 @@
+name: Preview firmware
+
+on:
+  push:
+    tags:
+      - "preview-*"
+  workflow_dispatch:
+    inputs:
+      channel:
+        description: "Preview tag/release name, for example preview-sd-fix"
+        required: true
+        default: "preview-manual"
+      label:
+        description: "Optional release title"
+        required: false
+        default: ""
+
+permissions:
+  contents: write
+
+jobs:
+  firmware:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set preview metadata
+        id: preview
+        env:
+          DISPATCH_CHANNEL: ${{ inputs.channel }}
+          LABEL: ${{ inputs.label }}
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            CHANNEL="$DISPATCH_CHANNEL"
+          else
+            CHANNEL="$GITHUB_REF_NAME"
+          fi
+
+          SHORT_SHA="$(git rev-parse --short HEAD)"
+          BUILD_SHA="$(git rev-parse HEAD)"
+
+          if ! echo "$CHANNEL" | grep -Eq '^preview-[A-Za-z0-9._-]+$'; then
+            echo "::error::Preview channel must look like preview-name, got: ${CHANNEL}"
+            exit 1
+          fi
+
+          VERSION="${CHANNEL}-${SHORT_SHA}"
+
+          echo "channel=${CHANNEL}" >> "$GITHUB_OUTPUT"
+          echo "short_sha=${SHORT_SHA}" >> "$GITHUB_OUTPUT"
+          echo "commit_sha=${BUILD_SHA}" >> "$GITHUB_OUTPUT"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+
+          if [ -n "$LABEL" ]; then
+            echo "title=${LABEL}" >> "$GITHUB_OUTPUT"
+          else
+            echo "title=Preview ${CHANNEL}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Install PlatformIO
+        run: pip install platformio
+
+      - name: Find firmware export tool
+        id: exporter
+        shell: bash
+        run: |
+          EXPORTER="$(find . -type f -name 'export_web_firmware.py' -not -path './.git/*' -print -quit)"
+
+          if [ -z "$EXPORTER" ]; then
+            echo "::error::Could not find export_web_firmware.py"
+            exit 1
+          fi
+
+          echo "path=$EXPORTER" >> "$GITHUB_OUTPUT"
+          echo "[preview] Using firmware export tool: $EXPORTER"
+
+      - name: Export firmware assets
+        shell: bash
+        run: python3 "${{ steps.exporter.outputs.path }}" --version "${{ steps.preview.outputs.version }}"
+
+      - name: Find firmware assets
+        id: assets
+        shell: bash
+        run: |
+          FULL_BIN="$(find . -type f -name 'rsvp-nano.bin' -not -path './.git/*' -print -quit)"
+          OTA_BIN="$(find . -type f -name 'rsvp-nano-ota.bin' -not -path './.git/*' -print -quit)"
+
+          if [ -z "$FULL_BIN" ] || [ -z "$OTA_BIN" ]; then
+            echo "::error::Could not find firmware assets."
+            echo "FULL_BIN=$FULL_BIN"
+            echo "OTA_BIN=$OTA_BIN"
+            exit 1
+          fi
+
+          echo "full=$FULL_BIN" >> "$GITHUB_OUTPUT"
+          echo "ota=$OTA_BIN" >> "$GITHUB_OUTPUT"
+
+          echo "[preview] Full image: $FULL_BIN"
+          echo "[preview] OTA image: $OTA_BIN"
+
+      - name: Write preview release notes
+        run: |
+          cat > release-notes.md <<NOTES
+          Preview firmware build.
+
+          Tag/channel: \`${{ steps.preview.outputs.channel }}\`
+          Commit: \`${{ steps.preview.outputs.commit_sha }}\`
+          Build version: \`${{ steps.preview.outputs.version }}\`
+
+          Assets:
+          - \`rsvp-nano.bin\` is the full browser-flasher image for fresh installs.
+          - \`rsvp-nano-ota.bin\` is the app-only binary used by OTA updates.
+          NOTES
+
+      - name: Move preview tag to this commit
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          RELEASE_TAG: ${{ steps.preview.outputs.channel }}
+          BUILD_SHA: ${{ steps.preview.outputs.commit_sha }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git tag -f "$RELEASE_TAG" "$BUILD_SHA"
+          git push origin "refs/tags/${RELEASE_TAG}" --force
+
+      - name: Publish or update preview release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ steps.preview.outputs.channel }}
+          RELEASE_TITLE: ${{ steps.preview.outputs.title }}
+          BUILD_SHA: ${{ steps.preview.outputs.commit_sha }}
+          FULL_BIN: ${{ steps.assets.outputs.full }}
+          OTA_BIN: ${{ steps.assets.outputs.ota }}
+        run: |
+          if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
+            gh release edit "$RELEASE_TAG" \
+              --title "$RELEASE_TITLE" \
+              --notes-file release-notes.md \
+              --target "$BUILD_SHA" \
+              --prerelease
+          else
+            gh release create "$RELEASE_TAG" \
+              --title "$RELEASE_TITLE" \
+              --notes-file release-notes.md \
+              --target "$BUILD_SHA" \
+              --prerelease
+          fi
+
+          gh release upload "$RELEASE_TAG" \
+            "$FULL_BIN" \
+            "$OTA_BIN" \
+            --clobber

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Release tag to build, for example v0.0.5"
+        description: "New release tag, for example v0.0.5"
         required: true
 
 permissions:
@@ -25,24 +25,79 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set release version
-        id: version
+      - name: Set release metadata
+        id: release
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "value=${{ inputs.version }}" >> "$GITHUB_OUTPUT"
+            RELEASE_TAG="${{ inputs.version }}"
           else
-            echo "value=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+            RELEASE_TAG="${GITHUB_REF_NAME}"
           fi
+
+          if ! echo "$RELEASE_TAG" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9._-]+)?$'; then
+            echo "::error::Invalid release version: ${RELEASE_TAG}"
+            echo "::error::Use something like v0.0.5 or v0.0.5-beta.1"
+            exit 1
+          fi
+
+          BUILD_SHA="$(git rev-parse HEAD)"
+
+          echo "tag=${RELEASE_TAG}" >> "$GITHUB_OUTPUT"
+          echo "commit_sha=${BUILD_SHA}" >> "$GITHUB_OUTPUT"
+
+      - name: Ensure GitHub release does not already exist
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ steps.release.outputs.tag }}
+        run: |
+          if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
+            echo "::error::Release ${RELEASE_TAG} already exists. Real releases are immutable."
+            echo "::error::Use a fresh version tag, or use the Preview firmware workflow for replaceable builds."
+            exit 1
+          fi
+
+      - name: Prepare immutable release tag
+        env:
+          RELEASE_TAG: ${{ steps.release.outputs.tag }}
+          BUILD_SHA: ${{ steps.release.outputs.commit_sha }}
+        run: |
+          git fetch --tags origin
+
+          if git rev-parse -q --verify "refs/tags/${RELEASE_TAG}" >/dev/null; then
+            TAG_SHA="$(git rev-list -n 1 "${RELEASE_TAG}")"
+
+            if [ "$TAG_SHA" != "$BUILD_SHA" ]; then
+              echo "::error::${RELEASE_TAG} already points at ${TAG_SHA}, but this workflow checked out ${BUILD_SHA}."
+              echo "::error::Real releases are immutable. Use a fresh version tag, or use Preview firmware for mutable builds."
+              exit 1
+            fi
+
+            echo "[release] Existing tag ${RELEASE_TAG} already points at this commit."
+            exit 0
+          fi
+
+          if [ "${{ github.event_name }}" != "workflow_dispatch" ]; then
+            echo "::error::Tag ${RELEASE_TAG} does not exist during a tag-push release."
+            exit 1
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git tag "$RELEASE_TAG" "$BUILD_SHA"
+          git push origin "refs/tags/${RELEASE_TAG}"
+
+          echo "[release] Created immutable tag ${RELEASE_TAG} at ${BUILD_SHA}."
 
       - name: Install PlatformIO
         run: pip install platformio
 
       - name: Export firmware assets
-        run: python3 tools/export_web_firmware.py --version "${{ steps.version.outputs.value }}"
+        run: python3 tools/export_web_firmware.py --version "${{ steps.release.outputs.tag }}"
 
       - name: Write release notes
         env:
-          RELEASE_TAG: ${{ steps.version.outputs.value }}
+          RELEASE_TAG: ${{ steps.release.outputs.tag }}
         run: |
           NOTES_PATH="docs/releases/${RELEASE_TAG}.md"
           if [ -f "$NOTES_PATH" ]; then
@@ -60,29 +115,27 @@ jobs:
       - name: Publish GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
-          RELEASE_TAG: ${{ steps.version.outputs.value }}
+          RELEASE_TAG: ${{ steps.release.outputs.tag }}
+          BUILD_SHA: ${{ steps.release.outputs.commit_sha }}
         run: |
-          if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
-            gh release upload "$RELEASE_TAG" \
-              web/firmware/rsvp-nano.bin \
-              web/firmware/rsvp-nano-ota.bin \
-              --clobber
-          else
-            gh release create "$RELEASE_TAG" \
-              web/firmware/rsvp-nano.bin \
-              web/firmware/rsvp-nano-ota.bin \
-              --title "$RELEASE_TAG" \
-              --notes-file release-notes.md
-          fi
+          gh release create "$RELEASE_TAG" \
+            web/firmware/rsvp-nano.bin \
+            web/firmware/rsvp-nano-ota.bin \
+            --title "$RELEASE_TAG" \
+            --notes-file release-notes.md \
+            --target "$BUILD_SHA"
 
       - name: Configure GitHub Pages
+        if: github.repository == 'ionutdecebal/rsvpnano'
         uses: actions/configure-pages@v5
 
       - name: Upload GitHub Pages artifact
+        if: github.repository == 'ionutdecebal/rsvpnano'
         uses: actions/upload-pages-artifact@v3
         with:
           path: web
 
       - name: Deploy GitHub Pages
+        if: github.repository == 'ionutdecebal/rsvpnano'
         id: deployment
         uses: actions/deploy-pages@v4


### PR DESCRIPTION
1. Ensure manually created firmware releases target the exact workflow commit instead of defaulting to the repository default branch.
2. Fail release runs when the requested tag already exists but points at a different commit, so assets are not uploaded to a misleading release.
3. Preview.yml workflow for preview features, meant to be used with names such as "preview/<name>". This one can be overwritten, so pushing the tag to a different commit updates the release.
4. Both workflow_dispatch and on tag push triggers for release and preview, with correct commit tracking.