### PR TITLE
feat: add configurable standby idle timer

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,158 @@
+name: Preview firmware
+
+on:
+  push:
+    tags:
+      - "preview-*"
+  workflow_dispatch:
+    inputs:
+      channel:
+        description: "Preview tag/release name, for example preview-sd-fix"
+        required: true
+        default: "preview-manual"
+      label:
+        description: "Optional release title"
+        required: false
+        default: ""
+
+permissions:
+  contents: write
+
+jobs:
+  firmware:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set preview metadata
+        id: preview
+        env:
+          DISPATCH_CHANNEL: ${{ inputs.channel }}
+          LABEL: ${{ inputs.label }}
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            CHANNEL="$DISPATCH_CHANNEL"
+          else
+            CHANNEL="$GITHUB_REF_NAME"
+          fi
+
+          SHORT_SHA="$(git rev-parse --short HEAD)"
+          BUILD_SHA="$(git rev-parse HEAD)"
+
+          if ! echo "$CHANNEL" | grep -Eq '^preview-[A-Za-z0-9._-]+$'; then
+            echo "::error::Preview channel must look like preview-name, got: ${CHANNEL}"
+            exit 1
+          fi
+
+          VERSION="${CHANNEL}-${SHORT_SHA}"
+
+          echo "channel=${CHANNEL}" >> "$GITHUB_OUTPUT"
+          echo "short_sha=${SHORT_SHA}" >> "$GITHUB_OUTPUT"
+          echo "commit_sha=${BUILD_SHA}" >> "$GITHUB_OUTPUT"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+
+          if [ -n "$LABEL" ]; then
+            echo "title=${LABEL}" >> "$GITHUB_OUTPUT"
+          else
+            echo "title=Preview ${CHANNEL}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Install PlatformIO
+        run: pip install platformio
+
+      - name: Find firmware export tool
+        id: exporter
+        shell: bash
+        run: |
+          EXPORTER="$(find . -type f -name 'export_web_firmware.py' -not -path './.git/*' -print -quit)"
+
+          if [ -z "$EXPORTER" ]; then
+            echo "::error::Could not find export_web_firmware.py"
+            exit 1
+          fi
+
+          echo "path=$EXPORTER" >> "$GITHUB_OUTPUT"
+          echo "[preview] Using firmware export tool: $EXPORTER"
+
+      - name: Export firmware assets
+        shell: bash
+        run: python3 "${{ steps.exporter.outputs.path }}" --version "${{ steps.preview.outputs.version }}"
+
+      - name: Find firmware assets
+        id: assets
+        shell: bash
+        run: |
+          FULL_BIN="$(find . -type f -name 'rsvp-nano.bin' -not -path './.git/*' -print -quit)"
+          OTA_BIN="$(find . -type f -name 'rsvp-nano-ota.bin' -not -path './.git/*' -print -quit)"
+
+          if [ -z "$FULL_BIN" ] || [ -z "$OTA_BIN" ]; then
+            echo "::error::Could not find firmware assets."
+            echo "FULL_BIN=$FULL_BIN"
+            echo "OTA_BIN=$OTA_BIN"
+            exit 1
+          fi
+
+          echo "full=$FULL_BIN" >> "$GITHUB_OUTPUT"
+          echo "ota=$OTA_BIN" >> "$GITHUB_OUTPUT"
+
+          echo "[preview] Full image: $FULL_BIN"
+          echo "[preview] OTA image: $OTA_BIN"
+
+      - name: Write preview release notes
+        run: |
+          cat > release-notes.md <<NOTES
+          Preview firmware build.
+
+          Tag/channel: \`${{ steps.preview.outputs.channel }}\`
+          Commit: \`${{ steps.preview.outputs.commit_sha }}\`
+          Build version: \`${{ steps.preview.outputs.version }}\`
+
+          Assets:
+          - \`rsvp-nano.bin\` is the full browser-flasher image for fresh installs.
+          - \`rsvp-nano-ota.bin\` is the app-only binary used by OTA updates.
+          NOTES
+
+      - name: Move preview tag to this commit
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          RELEASE_TAG: ${{ steps.preview.outputs.channel }}
+          BUILD_SHA: ${{ steps.preview.outputs.commit_sha }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git tag -f "$RELEASE_TAG" "$BUILD_SHA"
+          git push origin "refs/tags/${RELEASE_TAG}" --force
+
+      - name: Publish or update preview release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ steps.preview.outputs.channel }}
+          RELEASE_TITLE: ${{ steps.preview.outputs.title }}
+          BUILD_SHA: ${{ steps.preview.outputs.commit_sha }}
+          FULL_BIN: ${{ steps.assets.outputs.full }}
+          OTA_BIN: ${{ steps.assets.outputs.ota }}
+        run: |
+          if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
+            gh release edit "$RELEASE_TAG" \
+              --title "$RELEASE_TITLE" \
+              --notes-file release-notes.md \
+              --target "$BUILD_SHA" \
+              --prerelease
+          else
+            gh release create "$RELEASE_TAG" \
+              --title "$RELEASE_TITLE" \
+              --notes-file release-notes.md \
+              --target "$BUILD_SHA" \
+              --prerelease
+          fi
+
+          gh release upload "$RELEASE_TAG" \
+            "$FULL_BIN" \
+            "$OTA_BIN" \
+            --clobber

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Release tag to build, for example v0.0.5"
+        description: "New release tag, for example v0.0.5"
         required: true
 
 permissions:
@@ -25,24 +25,79 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set release version
-        id: version
+      - name: Set release metadata
+        id: release
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "value=${{ inputs.version }}" >> "$GITHUB_OUTPUT"
+            RELEASE_TAG="${{ inputs.version }}"
           else
-            echo "value=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+            RELEASE_TAG="${GITHUB_REF_NAME}"
           fi
+
+          if ! echo "$RELEASE_TAG" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9._-]+)?$'; then
+            echo "::error::Invalid release version: ${RELEASE_TAG}"
+            echo "::error::Use something like v0.0.5 or v0.0.5-beta.1"
+            exit 1
+          fi
+
+          BUILD_SHA="$(git rev-parse HEAD)"
+
+          echo "tag=${RELEASE_TAG}" >> "$GITHUB_OUTPUT"
+          echo "commit_sha=${BUILD_SHA}" >> "$GITHUB_OUTPUT"
+
+      - name: Ensure GitHub release does not already exist
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ steps.release.outputs.tag }}
+        run: |
+          if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
+            echo "::error::Release ${RELEASE_TAG} already exists. Real releases are immutable."
+            echo "::error::Use a fresh version tag, or use the Preview firmware workflow for replaceable builds."
+            exit 1
+          fi
+
+      - name: Prepare immutable release tag
+        env:
+          RELEASE_TAG: ${{ steps.release.outputs.tag }}
+          BUILD_SHA: ${{ steps.release.outputs.commit_sha }}
+        run: |
+          git fetch --tags origin
+
+          if git rev-parse -q --verify "refs/tags/${RELEASE_TAG}" >/dev/null; then
+            TAG_SHA="$(git rev-list -n 1 "${RELEASE_TAG}")"
+
+            if [ "$TAG_SHA" != "$BUILD_SHA" ]; then
+              echo "::error::${RELEASE_TAG} already points at ${TAG_SHA}, but this workflow checked out ${BUILD_SHA}."
+              echo "::error::Real releases are immutable. Use a fresh version tag, or use Preview firmware for mutable builds."
+              exit 1
+            fi
+
+            echo "[release] Existing tag ${RELEASE_TAG} already points at this commit."
+            exit 0
+          fi
+
+          if [ "${{ github.event_name }}" != "workflow_dispatch" ]; then
+            echo "::error::Tag ${RELEASE_TAG} does not exist during a tag-push release."
+            exit 1
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git tag "$RELEASE_TAG" "$BUILD_SHA"
+          git push origin "refs/tags/${RELEASE_TAG}"
+
+          echo "[release] Created immutable tag ${RELEASE_TAG} at ${BUILD_SHA}."
 
       - name: Install PlatformIO
         run: pip install platformio
 
       - name: Export firmware assets
-        run: python3 tools/export_web_firmware.py --version "${{ steps.version.outputs.value }}"
+        run: python3 tools/export_web_firmware.py --version "${{ steps.release.outputs.tag }}"
 
       - name: Write release notes
         env:
-          RELEASE_TAG: ${{ steps.version.outputs.value }}
+          RELEASE_TAG: ${{ steps.release.outputs.tag }}
         run: |
           NOTES_PATH="docs/releases/${RELEASE_TAG}.md"
           if [ -f "$NOTES_PATH" ]; then
@@ -60,29 +115,27 @@ jobs:
       - name: Publish GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
-          RELEASE_TAG: ${{ steps.version.outputs.value }}
+          RELEASE_TAG: ${{ steps.release.outputs.tag }}
+          BUILD_SHA: ${{ steps.release.outputs.commit_sha }}
         run: |
-          if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
-            gh release upload "$RELEASE_TAG" \
-              web/firmware/rsvp-nano.bin \
-              web/firmware/rsvp-nano-ota.bin \
-              --clobber
-          else
-            gh release create "$RELEASE_TAG" \
-              web/firmware/rsvp-nano.bin \
-              web/firmware/rsvp-nano-ota.bin \
-              --title "$RELEASE_TAG" \
-              --notes-file release-notes.md
-          fi
+          gh release create "$RELEASE_TAG" \
+            web/firmware/rsvp-nano.bin \
+            web/firmware/rsvp-nano-ota.bin \
+            --title "$RELEASE_TAG" \
+            --notes-file release-notes.md \
+            --target "$BUILD_SHA"
 
       - name: Configure GitHub Pages
+        if: github.repository == 'ionutdecebal/rsvpnano'
         uses: actions/configure-pages@v5
 
       - name: Upload GitHub Pages artifact
+        if: github.repository == 'ionutdecebal/rsvpnano'
         uses: actions/upload-pages-artifact@v3
         with:
           path: web
 
       - name: Deploy GitHub Pages
+        if: github.repository == 'ionutdecebal/rsvpnano'
         id: deployment
         uses: actions/deploy-pages@v4

--- a/src/app/App.cpp
+++ b/src/app/App.cpp
@@ -164,10 +164,11 @@ constexpr size_t kSettingsDisplayHandednessIndex = 3;
 constexpr size_t kSettingsDisplayFooterIndex = 4;
 constexpr size_t kSettingsDisplayBatteryIndex = 5;
 constexpr size_t kSettingsDisplayScreensaverIndex = 6;
-constexpr size_t kSettingsDisplayReaderBatteryIndex = 7;
-constexpr size_t kSettingsDisplayReaderChapterIndex = 8;
-constexpr size_t kSettingsDisplayReaderProgressIndex = 9;
-constexpr size_t kSettingsDisplayLanguageIndex = 10;
+constexpr size_t kSettingsDisplayStandbyTimerIndex = 7;
+constexpr size_t kSettingsDisplayReaderBatteryIndex = 8;
+constexpr size_t kSettingsDisplayReaderChapterIndex = 9;
+constexpr size_t kSettingsDisplayReaderProgressIndex = 10;
+constexpr size_t kSettingsDisplayLanguageIndex = 11;
 constexpr size_t kSettingsPacingReadingModeIndex = 1;
 constexpr size_t kSettingsPacingPauseModeIndex = 2;
 constexpr size_t kSettingsPacingWpmIndex = 3;
@@ -202,6 +203,7 @@ constexpr const char *kPrefPhantomWords = "phantom_on";
 constexpr const char *kPrefFooterMetricMode = "prog_md";
 constexpr const char *kPrefBatteryLabelMode = "bat_md";
 constexpr const char *kPrefScreensaverMode = "scrn_sv";
+constexpr const char *kPrefStandbyTimer = "stby_tmr";
 constexpr const char *kPrefReaderBatteryVisible = "read_bat";
 constexpr const char *kPrefReaderChapterVisible = "read_ch";
 constexpr const char *kPrefReaderProgressVisible = "read_pct";
@@ -686,6 +688,7 @@ void App::begin() {
       pauseMode_ = PauseMode::SentenceEnd;
       break;
   }
+  standbyTimerIndex_ = preferences_.getUChar(kPrefStandbyTimer, 0);
   pacingLongWordDelayMs_ =
       loadPacingDelayMs(preferences_, kPrefPacingLongMs, kPrefLegacyPacingLong);
   pacingComplexWordDelayMs_ =
@@ -717,6 +720,7 @@ void App::begin() {
   applyTypographySettings(0, false);
   applyPacingSettings();
   bootStartedMs_ = millis();
+  lastActivityMs_ = bootStartedMs_;
   lastStateLogMs_ = bootStartedMs_;
   lastScrollAnimationRenderMs_ = 0;
   Serial.printf("[app] version=%s\n", otaUpdater_.currentVersion().c_str());
@@ -778,6 +782,9 @@ void App::begin() {
 void App::update(uint32_t nowMs) {
   button_.update(nowMs);
   powerButton_.update(nowMs);
+  if (button_.isHeld() || powerButton_.isHeld()) {
+    lastActivityMs_ = nowMs;
+  }
   const bool standbyComboConsumed = handleStandbyCombo(nowMs);
   if (!standbyComboConsumed) {
     handleBootButton(nowMs);
@@ -839,6 +846,24 @@ void App::update(uint32_t nowMs) {
     ESP_LOGI(kAppTag, "state=%s", stateName(state_));
     Serial.printf("[app] state=%s ms=%lu\n", stateName(state_),
                   static_cast<unsigned long>(nowMs));
+  }
+
+  bool isIdle = (state_ == AppState::Paused || state_ == AppState::Menu);
+  if (state_ == AppState::Menu && menuScreen_ == MenuScreen::FocusTimerSession) {
+    isIdle = false;
+  }
+  if (otaCheckInProgress_) {
+    isIdle = false;
+  }
+
+  if (isIdle) {
+    const uint32_t timeoutMs = standbyTimerMs();
+    if (timeoutMs > 0 && nowMs - lastActivityMs_ >= timeoutMs) {
+      Serial.println("[app] standby idle timeout reached");
+      enterStandby(nowMs);
+    }
+  } else if (state_ != AppState::Standby && state_ != AppState::Sleeping) {
+    lastActivityMs_ = nowMs;
   }
 }
 
@@ -1920,6 +1945,7 @@ void App::handleTouch(uint32_t nowMs) {
   if (!touch_.poll(ev)) {
     return;
   }
+  lastActivityMs_ = nowMs;
 
   Serial.printf("[touch] phase=%s touched=%u x=%u y=%u gesture=%u state=%s\n",
                 touchPhaseName(ev.phase), ev.touched ? 1 : 0, ev.x, ev.y, ev.gesture,
@@ -2743,6 +2769,12 @@ void App::selectSettingsItem(uint32_t nowMs) {
         rebuildSettingsMenuItems();
         renderSettings();
         return;
+      case kSettingsDisplayStandbyTimerIndex:
+        standbyTimerIndex_ = (standbyTimerIndex_ + 1) % 5;
+        preferences_.putUChar(kPrefStandbyTimer, standbyTimerIndex_);
+        rebuildSettingsMenuItems();
+        renderSettings();
+        return;
       case kSettingsDisplayReaderBatteryIndex:
         readerBatteryVisibleWhilePlaying_ = !readerBatteryVisibleWhilePlaying_;
         preferences_.putBool(kPrefReaderBatteryVisible, readerBatteryVisibleWhilePlaying_);
@@ -3368,6 +3400,7 @@ void App::rebuildSettingsMenuItems() {
     settingsMenuItems_.push_back("Footer label: " + footerMetricModeLabel());
     settingsMenuItems_.push_back("Battery label: " + batteryLabelModeLabel());
     settingsMenuItems_.push_back("Screensaver: " + screensaverModeLabel());
+    settingsMenuItems_.push_back("Standby timer: " + standbyTimerLabel());
     settingsMenuItems_.push_back("Reading battery: " +
                                  onOffLabel(readerBatteryVisibleWhilePlaying_));
     settingsMenuItems_.push_back("Reading chapter: " +
@@ -4260,6 +4293,7 @@ void App::exitStandby(uint32_t nowMs) {
   pauseAtSentenceEndRequested_ = false;
   batteryWarningOverlayVisible_ = false;
   standbyButtonsReleased_ = false;
+  lastActivityMs_ = nowMs;
 
   AppState nextState = standbyReturnState_;
   if (nextState == AppState::Booting || nextState == AppState::Playing ||
@@ -5457,6 +5491,38 @@ String App::screensaverModeLabel() const {
     case ScreensaverMode::Life:
     default:
       return "Life";
+  }
+}
+
+String App::standbyTimerLabel() const {
+  switch (standbyTimerIndex_) {
+    case 1:
+      return "1 min";
+    case 2:
+      return "5 min";
+    case 3:
+      return "10 min";
+    case 4:
+      return "30 min";
+    case 0:
+    default:
+      return "Never";
+  }
+}
+
+uint32_t App::standbyTimerMs() const {
+  switch (standbyTimerIndex_) {
+    case 1:
+      return 60000UL;
+    case 2:
+      return 300000UL;
+    case 3:
+      return 600000UL;
+    case 4:
+      return 1800000UL;
+    case 0:
+    default:
+      return 0;
   }
 }
 

--- a/src/app/App.h
+++ b/src/app/App.h
@@ -352,6 +352,8 @@ class App {
   String footerMetricModeLabel() const;
   String batteryLabelModeLabel() const;
   String screensaverModeLabel() const;
+  String standbyTimerLabel() const;
+  uint32_t standbyTimerMs() const;
   String batteryTimeRemainingLabel() const;
   String batteryVoltageLabel() const;
   String formatBatteryTimeRemaining(uint32_t minutes) const;
@@ -422,6 +424,7 @@ class App {
   TouchIntent pausedTouchIntent_ = TouchIntent::None;
 
   uint32_t bootStartedMs_ = 0;
+  uint32_t lastActivityMs_ = 0;
   uint32_t lastStateLogMs_ = 0;
   uint32_t wpmFeedbackUntilMs_ = 0;
   uint32_t lastProgressSaveMs_ = 0;
@@ -453,6 +456,7 @@ class App {
   size_t sdCardRepairConfirmSelectedIndex_ = 0;
   size_t updateConfirmSelectedIndex_ = 0;
   size_t focusTimerGenreSelectedIndex_ = 0;
+  uint8_t standbyTimerIndex_ = 0;
   uint8_t brightnessLevelIndex_ = 4;
   uint8_t readerFontSizeIndex_ = 0;
   uint16_t pacingLongWordDelayMs_ = 200;


### PR DESCRIPTION
A configurable standby idle timer that automatically puts the device into Standby mode after a period of
inactivity.

1. Idle Tracking: Tracks the time since the last user interaction (touch or physical button press).
2. Smart Idle States: The idle timer specifically increments when the device is fully idle ( Menu or Paused  states). Foreground tasks like active reading, Pomodoro sessions ( FocusTimerSession ), file transfers, and OTA checks deliberately keep the device awake.
3. Configuration Menu: Adds a new Standby timer option under  Settings -> Display  with intervals of 1, 5, 10, 30 minutes, and a "Never" option. 
4. NVS Persistence: The selected interval is saved in the NVS so the preference is retained across reboots.