### PR TITLE
Extract pure feed/release parsers; dedupe station-WiFi setup

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -30,9 +30,16 @@ build_unflags =
 platform = native
 framework =
 test_framework = unity
-test_filter = test_pacing
+test_filter =
+  test_pacing
+  test_release_parser
+  test_feed_parser
 test_build_src = yes
-build_src_filter = -<*> +<reader/ReadingLoop.cpp>
+build_src_filter =
+  -<*>
+  +<reader/ReadingLoop.cpp>
+  +<update/ReleaseParser.cpp>
+  +<rss/FeedParser.cpp>
 build_flags =
   -std=c++17
   -Itest/support

--- a/src/net/WifiConnection.cpp
+++ b/src/net/WifiConnection.cpp
@@ -1,0 +1,36 @@
+#include "net/WifiConnection.h"
+
+#include <WiFi.h>
+
+namespace net {
+namespace {
+
+constexpr uint32_t kWifiConnectTimeoutMs = 15000;
+constexpr uint32_t kWifiConnectPollMs = 250;
+
+}  // namespace
+
+bool connectStation(const String &ssid, const String &password, const WifiProgress &progress) {
+  WiFi.persistent(false);
+  WiFi.setAutoReconnect(false);
+  WiFi.mode(WIFI_STA);
+  WiFi.begin(ssid.c_str(), password.c_str());
+
+  const uint32_t startMs = millis();
+  while (WiFi.status() != WL_CONNECTED && millis() - startMs < kWifiConnectTimeoutMs) {
+    if (progress) {
+      const uint32_t elapsedMs = millis() - startMs;
+      progress(5 + static_cast<int>((elapsedMs * 15) / kWifiConnectTimeoutMs));
+    }
+    delay(kWifiConnectPollMs);
+  }
+
+  return WiFi.status() == WL_CONNECTED;
+}
+
+void disconnect() {
+  WiFi.disconnect(true, false);
+  WiFi.mode(WIFI_OFF);
+}
+
+}  // namespace net

--- a/src/net/WifiConnection.h
+++ b/src/net/WifiConnection.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <Arduino.h>
+
+#include <functional>
+
+// The device's only station-mode WiFi lifecycle: bring the radio up to reach
+// the internet (RSS feed checks, OTA update checks) and tear it back down.
+// Both callers shared a byte-identical connect/poll/timeout loop before this
+// module; the timeout policy now lives here in one place.
+namespace net {
+
+// Reports association progress as a percentage in [0, 100] while connecting.
+using WifiProgress = std::function<void(int percent)>;
+
+// Brings up WIFI_STA and blocks until associated or the connect timeout
+// elapses. Returns true only when connected. progress may be null.
+bool connectStation(const String &ssid, const String &password,
+                    const WifiProgress &progress = nullptr);
+
+// Disconnects and powers the radio off (WIFI_OFF).
+void disconnect();
+
+}  // namespace net

--- a/src/rss/FeedParser.cpp
+++ b/src/rss/FeedParser.cpp
@@ -1,0 +1,539 @@
+#include "rss/FeedParser.h"
+
+#include <algorithm>
+#include <cctype>
+#include <cstring>
+
+#include "text/LatinText.h"
+
+namespace feedparser {
+namespace {
+
+constexpr size_t kMaxArticleChars = 24000;
+
+char lowerAscii(char c) {
+  return (c >= 'A' && c <= 'Z') ? static_cast<char>(c + ('a' - 'A')) : c;
+}
+
+int hexValue(char c) {
+  if (c >= '0' && c <= '9') {
+    return c - '0';
+  }
+  if (c >= 'a' && c <= 'f') {
+    return c - 'a' + 10;
+  }
+  if (c >= 'A' && c <= 'F') {
+    return c - 'A' + 10;
+  }
+  return -1;
+}
+
+bool parseNumericEntity(const String &entity, uint32_t &codepoint) {
+  if (!entity.startsWith("#")) {
+    return false;
+  }
+
+  codepoint = 0;
+  int base = 10;
+  size_t index = 1;
+  if (entity.length() > 2 && (entity[1] == 'x' || entity[1] == 'X')) {
+    base = 16;
+    index = 2;
+  }
+  if (index >= entity.length()) {
+    return false;
+  }
+
+  for (; index < entity.length(); ++index) {
+    const int digit =
+        base == 16 ? hexValue(entity[index])
+                   : (entity[index] >= '0' && entity[index] <= '9' ? entity[index] - '0' : -1);
+    if (digit < 0 || digit >= base) {
+      return false;
+    }
+    codepoint = codepoint * base + static_cast<uint32_t>(digit);
+  }
+
+  return codepoint <= 0x10FFFF && !(codepoint >= 0xD800 && codepoint <= 0xDFFF);
+}
+
+void appendText(String &target, const char *text) {
+  while (*text != '\0') {
+    target += *text;
+    ++text;
+  }
+}
+
+bool appendDecodedCodepoint(String &target, uint32_t codepoint) {
+  if (codepoint == 0x00AD || codepoint == 0x200B || codepoint == 0xFEFF) {
+    return true;
+  }
+  if (codepoint == '\t' || codepoint == '\n' || codepoint == '\r' || codepoint == 0x00A0 ||
+      codepoint == 0x1680 || codepoint == 0x180E || codepoint == 0x2028 ||
+      codepoint == 0x2029 || codepoint == 0x202F || codepoint == 0x205F ||
+      codepoint == 0x3000 || (codepoint >= 0x2000 && codepoint <= 0x200A)) {
+    target += ' ';
+    return true;
+  }
+
+  uint8_t storedByte = 0;
+  if (LatinText::storageByteForCodepoint(codepoint, storedByte)) {
+    target += static_cast<char>(storedByte);
+    return true;
+  }
+
+  if (codepoint >= 0xFF01 && codepoint <= 0xFF5E) {
+    target += static_cast<char>(codepoint - 0xFEE0);
+    return true;
+  }
+
+  switch (codepoint) {
+    case 0x00A2:
+      target += 'c';
+      return true;
+    case 0x00A3:
+      appendText(target, "GBP");
+      return true;
+    case 0x00A4:
+      target += '$';
+      return true;
+    case 0x00A5:
+      target += 'Y';
+      return true;
+    case 0x00A9:
+      appendText(target, "(c)");
+      return true;
+    case 0x00AE:
+      appendText(target, "(r)");
+      return true;
+    case 0x00B0:
+      appendText(target, "deg");
+      return true;
+    case 0x00B1:
+      appendText(target, "+/-");
+      return true;
+    case 0x00B2:
+      target += '2';
+      return true;
+    case 0x00B3:
+      target += '3';
+      return true;
+    case 0x00B9:
+      target += '1';
+      return true;
+    case 0x00BC:
+      appendText(target, "1/4");
+      return true;
+    case 0x00BD:
+      appendText(target, "1/2");
+      return true;
+    case 0x00BE:
+      appendText(target, "3/4");
+      return true;
+    case 0x00D7:
+      target += 'x';
+      return true;
+    case 0x00F7:
+      target += '/';
+      return true;
+    case 0x2010:
+    case 0x2011:
+    case 0x2212:
+      target += '-';
+      return true;
+    case 0x2012:
+    case 0x2013:
+    case 0x2014:
+    case 0x2015:
+      appendText(target, " - ");
+      return true;
+    case 0x2018:
+    case 0x2019:
+    case 0x201A:
+    case 0x201B:
+    case 0x2032:
+    case 0x2035:
+    case 0x2039:
+    case 0x203A:
+      target += '\'';
+      return true;
+    case 0x201C:
+    case 0x201D:
+    case 0x201E:
+    case 0x201F:
+    case 0x2033:
+    case 0x2036:
+    case 0x00AB:
+    case 0x00BB:
+      target += '"';
+      return true;
+    case 0x2022:
+    case 0x00B7:
+    case 0x2219:
+      target += '*';
+      return true;
+    case 0x2026:
+      appendText(target, "...");
+      return true;
+    default:
+      return false;
+  }
+}
+
+bool namedEntityCodepoint(const String &entity, uint32_t &codepoint) {
+  struct NamedEntity {
+    const char *name;
+    uint32_t codepoint;
+  };
+  static constexpr NamedEntity kNamedEntities[] = {
+      {"Agrave", 0x00C0}, {"Aacute", 0x00C1}, {"Acirc", 0x00C2},
+      {"Atilde", 0x00C3}, {"Auml", 0x00C4},   {"Aring", 0x00C5},
+      {"AElig", 0x00C6},  {"Ccedil", 0x00C7}, {"Egrave", 0x00C8},
+      {"Eacute", 0x00C9}, {"Ecirc", 0x00CA},  {"Euml", 0x00CB},
+      {"Igrave", 0x00CC}, {"Iacute", 0x00CD}, {"Icirc", 0x00CE},
+      {"Iuml", 0x00CF},   {"ETH", 0x00D0},    {"Ntilde", 0x00D1},
+      {"Ograve", 0x00D2}, {"Oacute", 0x00D3}, {"Ocirc", 0x00D4},
+      {"Otilde", 0x00D5}, {"Ouml", 0x00D6},   {"Oslash", 0x00D8},
+      {"Ugrave", 0x00D9}, {"Uacute", 0x00DA}, {"Ucirc", 0x00DB},
+      {"Uuml", 0x00DC},   {"Yacute", 0x00DD}, {"THORN", 0x00DE},
+      {"szlig", 0x00DF},  {"agrave", 0x00E0}, {"aacute", 0x00E1},
+      {"acirc", 0x00E2},  {"atilde", 0x00E3}, {"auml", 0x00E4},
+      {"aring", 0x00E5},  {"aelig", 0x00E6},  {"ccedil", 0x00E7},
+      {"egrave", 0x00E8}, {"eacute", 0x00E9}, {"ecirc", 0x00EA},
+      {"euml", 0x00EB},   {"igrave", 0x00EC}, {"iacute", 0x00ED},
+      {"icirc", 0x00EE},  {"iuml", 0x00EF},   {"eth", 0x00F0},
+      {"ntilde", 0x00F1}, {"ograve", 0x00F2}, {"oacute", 0x00F3},
+      {"ocirc", 0x00F4},  {"otilde", 0x00F5}, {"ouml", 0x00F6},
+      {"oslash", 0x00F8}, {"ugrave", 0x00F9}, {"uacute", 0x00FA},
+      {"ucirc", 0x00FB},  {"uuml", 0x00FC},   {"yacute", 0x00FD},
+      {"thorn", 0x00FE},  {"yuml", 0x00FF},   {"iexcl", 0x00A1},
+      {"iquest", 0x00BF}, {"copy", 0x00A9},   {"reg", 0x00AE},
+      {"deg", 0x00B0},    {"plusmn", 0x00B1}, {"sup2", 0x00B2},
+      {"sup3", 0x00B3},   {"sup1", 0x00B9},   {"frac14", 0x00BC},
+      {"frac12", 0x00BD}, {"frac34", 0x00BE}, {"laquo", 0x00AB},
+      {"raquo", 0x00BB},  {"middot", 0x00B7}, {"bull", 0x2022},
+      {"times", 0x00D7},  {"divide", 0x00F7},
+  };
+
+  for (const NamedEntity &entry : kNamedEntities) {
+    if (entity == entry.name) {
+      codepoint = entry.codepoint;
+      return true;
+    }
+  }
+  return false;
+}
+
+bool decodeXmlEntity(const String &entity, String &decoded) {
+  decoded = "";
+  if (entity == "amp") {
+    decoded += '&';
+    return true;
+  }
+  if (entity == "lt") {
+    decoded += '<';
+    return true;
+  }
+  if (entity == "gt") {
+    decoded += '>';
+    return true;
+  }
+  if (entity == "quot") {
+    decoded += '"';
+    return true;
+  }
+  if (entity == "apos") {
+    decoded += '\'';
+    return true;
+  }
+  if (entity == "nbsp") {
+    decoded += ' ';
+    return true;
+  }
+  if (entity == "ndash" || entity == "mdash") {
+    appendText(decoded, " - ");
+    return true;
+  }
+  if (entity == "hellip") {
+    appendText(decoded, "...");
+    return true;
+  }
+  if (entity == "rsquo" || entity == "lsquo" || entity == "sbquo") {
+    decoded += '\'';
+    return true;
+  }
+  if (entity == "rdquo" || entity == "ldquo" || entity == "bdquo") {
+    decoded += '"';
+    return true;
+  }
+
+  uint32_t codepoint = 0;
+  if ((parseNumericEntity(entity, codepoint) || namedEntityCodepoint(entity, codepoint)) &&
+      appendDecodedCodepoint(decoded, codepoint)) {
+    return true;
+  }
+
+  return false;
+}
+
+String decodeXmlEntitiesOnce(const String &value) {
+  String output;
+  output.reserve(value.length());
+
+  for (size_t i = 0; i < value.length(); ++i) {
+    const char c = value[i];
+    if (c != '&') {
+      output += c;
+      continue;
+    }
+
+    const int entityEnd = value.indexOf(';', i + 1);
+    if (entityEnd <= 0 || entityEnd - static_cast<int>(i) > 32) {
+      output += c;
+      continue;
+    }
+
+    String decoded;
+    const String entity = value.substring(i + 1, entityEnd);
+    if (!decodeXmlEntity(entity, decoded)) {
+      output += c;
+      continue;
+    }
+
+    output += decoded;
+    i = static_cast<size_t>(entityEnd);
+  }
+
+  return output;
+}
+
+bool matchesIgnoreCaseAt(const String &text, size_t index, const char *needle) {
+  for (size_t i = 0; needle[i] != '\0'; ++i) {
+    if (index + i >= text.length() || lowerAscii(text[index + i]) != lowerAscii(needle[i])) {
+      return false;
+    }
+  }
+  return true;
+}
+
+int indexOfIgnoreCase(const String &text, const char *needle, size_t start, size_t limit) {
+  const size_t needleLength = strlen(needle);
+  if (needleLength == 0 || start >= text.length()) {
+    return -1;
+  }
+  limit = std::min(limit, static_cast<size_t>(text.length()));
+  if (limit < needleLength) {
+    return -1;
+  }
+  for (size_t i = start; i + needleLength <= limit; ++i) {
+    if (matchesIgnoreCaseAt(text, i, needle)) {
+      return static_cast<int>(i);
+    }
+  }
+  return -1;
+}
+
+int tagEndIndex(const String &text, size_t start, size_t limit) {
+  limit = std::min(limit, static_cast<size_t>(text.length()));
+  for (size_t i = start; i < limit; ++i) {
+    if (text[i] == '>') {
+      return static_cast<int>(i);
+    }
+  }
+  return -1;
+}
+
+String valueBetween(const String &text, const String &openTag, const String &closeTag,
+                    size_t start, size_t end) {
+  const int open = indexOfIgnoreCase(text, openTag.c_str(), start, end);
+  if (open < 0 || static_cast<size_t>(open) >= end) {
+    return "";
+  }
+  const int valueStart = tagEndIndex(text, static_cast<size_t>(open), end);
+  if (valueStart < 0 || static_cast<size_t>(valueStart) >= end) {
+    return "";
+  }
+  const int close = indexOfIgnoreCase(text, closeTag.c_str(), valueStart + 1, end);
+  if (close < 0 || static_cast<size_t>(close) > end) {
+    return "";
+  }
+  return text.substring(valueStart + 1, close);
+}
+
+String attributeValue(const String &text, const String &tagPrefix, const String &attribute,
+                      size_t start, size_t end) {
+  int tagStart = indexOfIgnoreCase(text, tagPrefix.c_str(), start, end);
+  while (tagStart >= 0 && static_cast<size_t>(tagStart) < end) {
+    const int tagEnd = tagEndIndex(text, static_cast<size_t>(tagStart), end);
+    if (tagEnd < 0 || static_cast<size_t>(tagEnd) > end) {
+      return "";
+    }
+
+    const String needle = attribute + "=";
+    int attrIndex = indexOfIgnoreCase(text, needle.c_str(), tagStart, static_cast<size_t>(tagEnd));
+    if (attrIndex >= 0) {
+      int valueStart = attrIndex + needle.length();
+      while (valueStart < tagEnd && isspace(static_cast<unsigned char>(text[valueStart]))) {
+        ++valueStart;
+      }
+      if (valueStart < tagEnd) {
+        const char quote = text[valueStart];
+        if (quote == '"' || quote == '\'') {
+          ++valueStart;
+          for (int i = valueStart; i < tagEnd; ++i) {
+            if (text[i] == quote) {
+              return text.substring(valueStart, i);
+            }
+          }
+        } else {
+          int valueEnd = valueStart;
+          while (valueEnd < tagEnd && !isspace(static_cast<unsigned char>(text[valueEnd])) &&
+                 text[valueEnd] != '>') {
+            ++valueEnd;
+          }
+          if (valueEnd > valueStart) {
+            return text.substring(valueStart, valueEnd);
+          }
+        }
+      }
+    }
+
+    tagStart = indexOfIgnoreCase(text, tagPrefix.c_str(), static_cast<size_t>(tagEnd + 1), end);
+  }
+  return "";
+}
+
+String stripHtml(const String &html) {
+  String output;
+  output.reserve(std::min(static_cast<size_t>(html.length()), kMaxArticleChars));
+  bool inTag = false;
+  for (size_t i = 0; i < html.length(); ++i) {
+    const char c = html[i];
+    if (c == '<') {
+      inTag = true;
+      if (!output.endsWith(" ") && !output.endsWith("\n")) {
+        output += ' ';
+      }
+      continue;
+    }
+    if (c == '>') {
+      inTag = false;
+      continue;
+    }
+    if (!inTag) {
+      output += c;
+    }
+    if (output.length() >= kMaxArticleChars) {
+      break;
+    }
+  }
+  return output;
+}
+
+String xmlDecode(String value) {
+  value = decodeXmlEntitiesOnce(value);
+  if (value.indexOf('&') >= 0) {
+    value = decodeXmlEntitiesOnce(value);
+  }
+  return value;
+}
+
+String cleanText(String value) {
+  value.replace("<![CDATA[", "");
+  value.replace("]]>", "");
+  value = stripHtml(value);
+  value = xmlDecode(value);
+  value.replace("\r", "\n");
+  while (value.indexOf("\n\n\n") >= 0) {
+    value.replace("\n\n\n", "\n\n");
+  }
+  value.trim();
+  return value;
+}
+
+}  // namespace
+
+String hostLabelForUrl(const String &url) {
+  int start = url.indexOf("://");
+  start = start < 0 ? 0 : start + 3;
+  int end = url.indexOf('/', start);
+  if (end < 0) {
+    end = url.length();
+  }
+  String host = url.substring(start, end);
+  if (host.startsWith("www.")) {
+    host.remove(0, 4);
+  }
+  return host;
+}
+
+String sourceLabelForItem(const FeedItem &item) {
+  String source = item.link;
+  if (source.isEmpty()) {
+    return "RSS";
+  }
+
+  source = hostLabelForUrl(source);
+  if (source.isEmpty()) {
+    return "RSS";
+  }
+  return source;
+}
+
+bool parseNextItem(const String &feedBody, size_t &searchStart, FeedItem &item) {
+  int itemStart = indexOfIgnoreCase(feedBody, "<item", searchStart, feedBody.length());
+  bool atom = false;
+  if (itemStart < 0) {
+    itemStart = indexOfIgnoreCase(feedBody, "<entry", searchStart, feedBody.length());
+    atom = itemStart >= 0;
+  }
+  if (itemStart < 0) {
+    return false;
+  }
+
+  const String closeTag = atom ? "</entry>" : "</item>";
+  const int itemEnd = indexOfIgnoreCase(feedBody, closeTag.c_str(), itemStart, feedBody.length());
+  if (itemEnd < 0) {
+    return false;
+  }
+  searchStart = static_cast<size_t>(itemEnd + closeTag.length());
+
+  const size_t start = static_cast<size_t>(itemStart);
+  const size_t end = static_cast<size_t>(itemEnd);
+  item.title = cleanText(valueBetween(feedBody, "<title", "</title>", start, end));
+  item.link = cleanText(valueBetween(feedBody, "<link>", "</link>", start, end));
+  if (item.link.isEmpty()) {
+    item.link = cleanText(attributeValue(feedBody, "<link", "href", start, end));
+  }
+  if (item.link.isEmpty()) {
+    item.link = cleanText(valueBetween(feedBody, "<guid", "</guid>", start, end));
+  }
+  item.author = cleanText(valueBetween(feedBody, "<author", "</author>", start, end));
+  if (item.author.isEmpty()) {
+    item.author = cleanText(valueBetween(feedBody, "<dc:creator", "</dc:creator>", start, end));
+  }
+  if (item.author.isEmpty()) {
+    item.author = sourceLabelForItem(item);
+  }
+
+  item.body = cleanText(valueBetween(feedBody, "<content:encoded", "</content:encoded>", start, end));
+  if (item.body.isEmpty()) {
+    item.body = cleanText(valueBetween(feedBody, "<content", "</content>", start, end));
+  }
+  if (item.body.isEmpty()) {
+    item.body = cleanText(valueBetween(feedBody, "<description", "</description>", start, end));
+  }
+  if (item.body.isEmpty()) {
+    item.body = cleanText(valueBetween(feedBody, "<summary", "</summary>", start, end));
+  }
+  if (item.body.isEmpty()) {
+    item.body = item.link;
+  }
+
+  if (item.title.isEmpty()) {
+    item.title = item.link.isEmpty() ? "RSS Article" : item.link;
+  }
+  return !item.body.isEmpty();
+}
+
+}  // namespace feedparser

--- a/src/rss/FeedParser.h
+++ b/src/rss/FeedParser.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <Arduino.h>
+
+// Pure parsing of RSS/Atom feed bodies into article items, plus the text
+// normalization (HTML stripping, XML entity decoding, character folding) that
+// turns feed markup into reader-ready text. No networking, no SD access -- safe
+// to unit test on the host with the Arduino String shim.
+namespace feedparser {
+
+struct FeedItem {
+  String title;
+  String link;
+  String author;
+  String body;
+};
+
+// Parses the next <item> (RSS) or <entry> (Atom) starting at searchStart and
+// advances searchStart past it. Returns false when no further item is found or
+// the item has no usable body text.
+bool parseNextItem(const String &feedBody, size_t &searchStart, FeedItem &item);
+
+// The bare host of a URL: scheme and a leading "www." removed, path dropped.
+// Returns "" when no host can be found.
+String hostLabelForUrl(const String &url);
+
+// A human label for an item's origin: its link's host, or "RSS" when absent.
+String sourceLabelForItem(const FeedItem &item);
+
+}  // namespace feedparser

--- a/src/rss/RssFeedManager.cpp
+++ b/src/rss/RssFeedManager.cpp
@@ -7,7 +7,8 @@
 #include <algorithm>
 #include <vector>
 
-#include "text/LatinText.h"
+#include "net/WifiConnection.h"
+#include "rss/FeedParser.h"
 
 namespace {
 
@@ -18,8 +19,6 @@ constexpr const char *kConfigPaths[] = {
 constexpr const char *kBooksPath = "/books";
 constexpr const char *kArticleFilesPath = "/books/articles";
 constexpr const char *kStatusTitle = "RSS";
-constexpr uint32_t kWifiConnectTimeoutMs = 15000;
-constexpr uint32_t kWifiConnectPollMs = 250;
 constexpr uint32_t kFeedTotalTimeoutMs = 30000;
 constexpr uint32_t kFeedIdleTimeoutMs = 5000;
 constexpr uint32_t kFeedProgressIntervalMs = 1000;
@@ -46,353 +45,7 @@ bool isSafeFilenameChar(char c) {
          c == '-' || c == '_' || c == ' ' || c == '.';
 }
 
-char lowerAscii(char c) {
-  return (c >= 'A' && c <= 'Z') ? static_cast<char>(c + ('a' - 'A')) : c;
-}
-
-int hexValue(char c) {
-  if (c >= '0' && c <= '9') {
-    return c - '0';
-  }
-  if (c >= 'a' && c <= 'f') {
-    return c - 'a' + 10;
-  }
-  if (c >= 'A' && c <= 'F') {
-    return c - 'A' + 10;
-  }
-  return -1;
-}
-
-bool parseNumericEntity(const String &entity, uint32_t &codepoint) {
-  if (!entity.startsWith("#")) {
-    return false;
-  }
-
-  codepoint = 0;
-  int base = 10;
-  size_t index = 1;
-  if (entity.length() > 2 && (entity[1] == 'x' || entity[1] == 'X')) {
-    base = 16;
-    index = 2;
-  }
-  if (index >= entity.length()) {
-    return false;
-  }
-
-  for (; index < entity.length(); ++index) {
-    const int digit =
-        base == 16 ? hexValue(entity[index])
-                   : (entity[index] >= '0' && entity[index] <= '9' ? entity[index] - '0' : -1);
-    if (digit < 0 || digit >= base) {
-      return false;
-    }
-    codepoint = codepoint * base + static_cast<uint32_t>(digit);
-  }
-
-  return codepoint <= 0x10FFFF && !(codepoint >= 0xD800 && codepoint <= 0xDFFF);
-}
-
-void appendText(String &target, const char *text) {
-  while (*text != '\0') {
-    target += *text;
-    ++text;
-  }
-}
-
-bool appendDecodedCodepoint(String &target, uint32_t codepoint) {
-  if (codepoint == 0x00AD || codepoint == 0x200B || codepoint == 0xFEFF) {
-    return true;
-  }
-  if (codepoint == '\t' || codepoint == '\n' || codepoint == '\r' || codepoint == 0x00A0 ||
-      codepoint == 0x1680 || codepoint == 0x180E || codepoint == 0x2028 ||
-      codepoint == 0x2029 || codepoint == 0x202F || codepoint == 0x205F ||
-      codepoint == 0x3000 || (codepoint >= 0x2000 && codepoint <= 0x200A)) {
-    target += ' ';
-    return true;
-  }
-
-  uint8_t storedByte = 0;
-  if (LatinText::storageByteForCodepoint(codepoint, storedByte)) {
-    target += static_cast<char>(storedByte);
-    return true;
-  }
-
-  if (codepoint >= 0xFF01 && codepoint <= 0xFF5E) {
-    target += static_cast<char>(codepoint - 0xFEE0);
-    return true;
-  }
-
-  switch (codepoint) {
-    case 0x00A2:
-      target += 'c';
-      return true;
-    case 0x00A3:
-      appendText(target, "GBP");
-      return true;
-    case 0x00A4:
-      target += '$';
-      return true;
-    case 0x00A5:
-      target += 'Y';
-      return true;
-    case 0x00A9:
-      appendText(target, "(c)");
-      return true;
-    case 0x00AE:
-      appendText(target, "(r)");
-      return true;
-    case 0x00B0:
-      appendText(target, "deg");
-      return true;
-    case 0x00B1:
-      appendText(target, "+/-");
-      return true;
-    case 0x00B2:
-      target += '2';
-      return true;
-    case 0x00B3:
-      target += '3';
-      return true;
-    case 0x00B9:
-      target += '1';
-      return true;
-    case 0x00BC:
-      appendText(target, "1/4");
-      return true;
-    case 0x00BD:
-      appendText(target, "1/2");
-      return true;
-    case 0x00BE:
-      appendText(target, "3/4");
-      return true;
-    case 0x00D7:
-      target += 'x';
-      return true;
-    case 0x00F7:
-      target += '/';
-      return true;
-    case 0x2010:
-    case 0x2011:
-    case 0x2212:
-      target += '-';
-      return true;
-    case 0x2012:
-    case 0x2013:
-    case 0x2014:
-    case 0x2015:
-      appendText(target, " - ");
-      return true;
-    case 0x2018:
-    case 0x2019:
-    case 0x201A:
-    case 0x201B:
-    case 0x2032:
-    case 0x2035:
-    case 0x2039:
-    case 0x203A:
-      target += '\'';
-      return true;
-    case 0x201C:
-    case 0x201D:
-    case 0x201E:
-    case 0x201F:
-    case 0x2033:
-    case 0x2036:
-    case 0x00AB:
-    case 0x00BB:
-      target += '"';
-      return true;
-    case 0x2022:
-    case 0x00B7:
-    case 0x2219:
-      target += '*';
-      return true;
-    case 0x2026:
-      appendText(target, "...");
-      return true;
-    default:
-      return false;
-  }
-}
-
-bool namedEntityCodepoint(const String &entity, uint32_t &codepoint) {
-  struct NamedEntity {
-    const char *name;
-    uint32_t codepoint;
-  };
-  static constexpr NamedEntity kNamedEntities[] = {
-      {"Agrave", 0x00C0}, {"Aacute", 0x00C1}, {"Acirc", 0x00C2},
-      {"Atilde", 0x00C3}, {"Auml", 0x00C4},   {"Aring", 0x00C5},
-      {"AElig", 0x00C6},  {"Ccedil", 0x00C7}, {"Egrave", 0x00C8},
-      {"Eacute", 0x00C9}, {"Ecirc", 0x00CA},  {"Euml", 0x00CB},
-      {"Igrave", 0x00CC}, {"Iacute", 0x00CD}, {"Icirc", 0x00CE},
-      {"Iuml", 0x00CF},   {"ETH", 0x00D0},    {"Ntilde", 0x00D1},
-      {"Ograve", 0x00D2}, {"Oacute", 0x00D3}, {"Ocirc", 0x00D4},
-      {"Otilde", 0x00D5}, {"Ouml", 0x00D6},   {"Oslash", 0x00D8},
-      {"Ugrave", 0x00D9}, {"Uacute", 0x00DA}, {"Ucirc", 0x00DB},
-      {"Uuml", 0x00DC},   {"Yacute", 0x00DD}, {"THORN", 0x00DE},
-      {"szlig", 0x00DF},  {"agrave", 0x00E0}, {"aacute", 0x00E1},
-      {"acirc", 0x00E2},  {"atilde", 0x00E3}, {"auml", 0x00E4},
-      {"aring", 0x00E5},  {"aelig", 0x00E6},  {"ccedil", 0x00E7},
-      {"egrave", 0x00E8}, {"eacute", 0x00E9}, {"ecirc", 0x00EA},
-      {"euml", 0x00EB},   {"igrave", 0x00EC}, {"iacute", 0x00ED},
-      {"icirc", 0x00EE},  {"iuml", 0x00EF},   {"eth", 0x00F0},
-      {"ntilde", 0x00F1}, {"ograve", 0x00F2}, {"oacute", 0x00F3},
-      {"ocirc", 0x00F4},  {"otilde", 0x00F5}, {"ouml", 0x00F6},
-      {"oslash", 0x00F8}, {"ugrave", 0x00F9}, {"uacute", 0x00FA},
-      {"ucirc", 0x00FB},  {"uuml", 0x00FC},   {"yacute", 0x00FD},
-      {"thorn", 0x00FE},  {"yuml", 0x00FF},   {"iexcl", 0x00A1},
-      {"iquest", 0x00BF}, {"copy", 0x00A9},   {"reg", 0x00AE},
-      {"deg", 0x00B0},    {"plusmn", 0x00B1}, {"sup2", 0x00B2},
-      {"sup3", 0x00B3},   {"sup1", 0x00B9},   {"frac14", 0x00BC},
-      {"frac12", 0x00BD}, {"frac34", 0x00BE}, {"laquo", 0x00AB},
-      {"raquo", 0x00BB},  {"middot", 0x00B7}, {"bull", 0x2022},
-      {"times", 0x00D7},  {"divide", 0x00F7},
-  };
-
-  for (const NamedEntity &entry : kNamedEntities) {
-    if (entity == entry.name) {
-      codepoint = entry.codepoint;
-      return true;
-    }
-  }
-  return false;
-}
-
-bool decodeXmlEntity(const String &entity, String &decoded) {
-  decoded = "";
-  if (entity == "amp") {
-    decoded += '&';
-    return true;
-  }
-  if (entity == "lt") {
-    decoded += '<';
-    return true;
-  }
-  if (entity == "gt") {
-    decoded += '>';
-    return true;
-  }
-  if (entity == "quot") {
-    decoded += '"';
-    return true;
-  }
-  if (entity == "apos") {
-    decoded += '\'';
-    return true;
-  }
-  if (entity == "nbsp") {
-    decoded += ' ';
-    return true;
-  }
-  if (entity == "ndash" || entity == "mdash") {
-    appendText(decoded, " - ");
-    return true;
-  }
-  if (entity == "hellip") {
-    appendText(decoded, "...");
-    return true;
-  }
-  if (entity == "rsquo" || entity == "lsquo" || entity == "sbquo") {
-    decoded += '\'';
-    return true;
-  }
-  if (entity == "rdquo" || entity == "ldquo" || entity == "bdquo") {
-    decoded += '"';
-    return true;
-  }
-
-  uint32_t codepoint = 0;
-  if ((parseNumericEntity(entity, codepoint) || namedEntityCodepoint(entity, codepoint)) &&
-      appendDecodedCodepoint(decoded, codepoint)) {
-    return true;
-  }
-
-  return false;
-}
-
-String decodeXmlEntitiesOnce(const String &value) {
-  String output;
-  output.reserve(value.length());
-
-  for (size_t i = 0; i < value.length(); ++i) {
-    const char c = value[i];
-    if (c != '&') {
-      output += c;
-      continue;
-    }
-
-    const int entityEnd = value.indexOf(';', i + 1);
-    if (entityEnd <= 0 || entityEnd - static_cast<int>(i) > 32) {
-      output += c;
-      continue;
-    }
-
-    String decoded;
-    const String entity = value.substring(i + 1, entityEnd);
-    if (!decodeXmlEntity(entity, decoded)) {
-      output += c;
-      continue;
-    }
-
-    output += decoded;
-    i = static_cast<size_t>(entityEnd);
-  }
-
-  return output;
-}
-
-bool matchesIgnoreCaseAt(const String &text, size_t index, const char *needle) {
-  for (size_t i = 0; needle[i] != '\0'; ++i) {
-    if (index + i >= text.length() || lowerAscii(text[index + i]) != lowerAscii(needle[i])) {
-      return false;
-    }
-  }
-  return true;
-}
-
-int indexOfIgnoreCase(const String &text, const char *needle, size_t start, size_t limit) {
-  const size_t needleLength = strlen(needle);
-  if (needleLength == 0 || start >= text.length()) {
-    return -1;
-  }
-  limit = std::min(limit, static_cast<size_t>(text.length()));
-  if (limit < needleLength) {
-    return -1;
-  }
-  for (size_t i = start; i + needleLength <= limit; ++i) {
-    if (matchesIgnoreCaseAt(text, i, needle)) {
-      return static_cast<int>(i);
-    }
-  }
-  return -1;
-}
-
-int tagEndIndex(const String &text, size_t start, size_t limit) {
-  limit = std::min(limit, static_cast<size_t>(text.length()));
-  for (size_t i = start; i < limit; ++i) {
-    if (text[i] == '>') {
-      return static_cast<int>(i);
-    }
-  }
-  return -1;
-}
-
 String userAgent() { return String("RSVP-Nano-RSS/1.0"); }
-
-String hostLabelForUrl(const String &url) {
-  int start = url.indexOf("://");
-  start = start < 0 ? 0 : start + 3;
-  int end = url.indexOf('/', start);
-  if (end < 0) {
-    end = url.length();
-  }
-  String host = url.substring(start, end);
-  if (host.startsWith("www.")) {
-    host.remove(0, 4);
-  }
-  return host;
-}
 
 String feedProgressLabel(uint8_t feedIndex, uint8_t feedCount) {
   return "Feed " + String(feedIndex) + "/" + String(feedCount);
@@ -568,7 +221,7 @@ RssFeedManager::Result RssFeedManager::checkFeeds(const OtaUpdater::Config &wifi
     const uint8_t displayIndex = feedIndex + 1;
     const uint8_t feedCount = feeds.size();
     report(callback, context, feedProgressLabel(displayIndex, feedCount),
-           "Downloading " + hostLabelForUrl(line), 15 + displayIndex * 8);
+           "Downloading " + feedparser::hostLabelForUrl(line), 15 + displayIndex * 8);
 
     String feedBody;
     String error;
@@ -615,26 +268,12 @@ RssFeedManager::Result RssFeedManager::checkFeeds(const OtaUpdater::Config &wifi
 
 bool RssFeedManager::connectWiFi(const OtaUpdater::Config &wifiConfig, StatusCallback callback,
                                  void *context) {
-  WiFi.persistent(false);
-  WiFi.setAutoReconnect(false);
-  WiFi.mode(WIFI_STA);
-  WiFi.begin(wifiConfig.wifiSsid.c_str(), wifiConfig.wifiPassword.c_str());
-
-  const uint32_t startMs = millis();
-  while (WiFi.status() != WL_CONNECTED && millis() - startMs < kWifiConnectTimeoutMs) {
-    const uint32_t elapsedMs = millis() - startMs;
-    const int progress = 5 + static_cast<int>((elapsedMs * 12) / kWifiConnectTimeoutMs);
-    report(callback, context, "Connecting Wi-Fi", wifiConfig.wifiSsid, progress);
-    delay(kWifiConnectPollMs);
-  }
-
-  return WiFi.status() == WL_CONNECTED;
+  return net::connectStation(wifiConfig.wifiSsid, wifiConfig.wifiPassword, [&](int percent) {
+    report(callback, context, "Connecting Wi-Fi", wifiConfig.wifiSsid, percent);
+  });
 }
 
-void RssFeedManager::disconnectWiFi() {
-  WiFi.disconnect(true, false);
-  WiFi.mode(WIFI_OFF);
-}
+void RssFeedManager::disconnectWiFi() { net::disconnect(); }
 
 bool RssFeedManager::fetchUrl(const String &url, String &body, String &error,
                               uint8_t feedIndex, uint8_t feedCount,
@@ -662,7 +301,7 @@ bool RssFeedManager::fetchUrl(const String &url, String &body, String &error,
     }
 
     report(callback, context, feedProgressLabel(feedIndex, feedCount),
-           "Requesting " + hostLabelForUrl(currentUrl), 18 + feedIndex * 7);
+           "Requesting " + feedparser::hostLabelForUrl(currentUrl), 18 + feedIndex * 7);
     const int statusCode = http.GET();
     if (isRedirectStatus(statusCode)) {
       String location = http.header("Location");
@@ -677,7 +316,7 @@ bool RssFeedManager::fetchUrl(const String &url, String &body, String &error,
       Serial.printf("[rss] redirect %u url=%s\n", static_cast<unsigned int>(statusCode),
                     currentUrl.c_str());
       report(callback, context, feedProgressLabel(feedIndex, feedCount),
-             "Redirecting to " + hostLabelForUrl(currentUrl), 18 + feedIndex * 7);
+             "Redirecting to " + feedparser::hostLabelForUrl(currentUrl), 18 + feedIndex * 7);
       delay(250);
       continue;
     }
@@ -789,8 +428,8 @@ bool RssFeedManager::processFeed(const String &feedUrl, const String &feedBody,
   report(callback, context, feedProgressLabel(feedIndex, feedCount), "Parsing items",
          24 + feedIndex * 7);
   while (itemCount < kMaxItemsPerFeed && result.articlesSaved < kMaxArticlesPerCheck) {
-    FeedItem item;
-    if (!parseNextItem(feedBody, searchStart, item)) {
+    feedparser::FeedItem item;
+    if (!feedparser::parseNextItem(feedBody, searchStart, item)) {
       break;
     }
     ++itemCount;
@@ -822,63 +461,8 @@ bool RssFeedManager::processFeed(const String &feedUrl, const String &feedBody,
   return itemCount > 0;
 }
 
-bool RssFeedManager::parseNextItem(const String &feedBody, size_t &searchStart, FeedItem &item) {
-  int itemStart = indexOfIgnoreCase(feedBody, "<item", searchStart, feedBody.length());
-  bool atom = false;
-  if (itemStart < 0) {
-    itemStart = indexOfIgnoreCase(feedBody, "<entry", searchStart, feedBody.length());
-    atom = itemStart >= 0;
-  }
-  if (itemStart < 0) {
-    return false;
-  }
-
-  const String closeTag = atom ? "</entry>" : "</item>";
-  const int itemEnd = indexOfIgnoreCase(feedBody, closeTag.c_str(), itemStart, feedBody.length());
-  if (itemEnd < 0) {
-    return false;
-  }
-  searchStart = static_cast<size_t>(itemEnd + closeTag.length());
-
-  const size_t start = static_cast<size_t>(itemStart);
-  const size_t end = static_cast<size_t>(itemEnd);
-  item.title = cleanText(valueBetween(feedBody, "<title", "</title>", start, end));
-  item.link = cleanText(valueBetween(feedBody, "<link>", "</link>", start, end));
-  if (item.link.isEmpty()) {
-    item.link = cleanText(attributeValue(feedBody, "<link", "href", start, end));
-  }
-  if (item.link.isEmpty()) {
-    item.link = cleanText(valueBetween(feedBody, "<guid", "</guid>", start, end));
-  }
-  item.author = cleanText(valueBetween(feedBody, "<author", "</author>", start, end));
-  if (item.author.isEmpty()) {
-    item.author = cleanText(valueBetween(feedBody, "<dc:creator", "</dc:creator>", start, end));
-  }
-  if (item.author.isEmpty()) {
-    item.author = sourceLabelForItem(item);
-  }
-
-  item.body = cleanText(valueBetween(feedBody, "<content:encoded", "</content:encoded>", start, end));
-  if (item.body.isEmpty()) {
-    item.body = cleanText(valueBetween(feedBody, "<content", "</content>", start, end));
-  }
-  if (item.body.isEmpty()) {
-    item.body = cleanText(valueBetween(feedBody, "<description", "</description>", start, end));
-  }
-  if (item.body.isEmpty()) {
-    item.body = cleanText(valueBetween(feedBody, "<summary", "</summary>", start, end));
-  }
-  if (item.body.isEmpty()) {
-    item.body = item.link;
-  }
-
-  if (item.title.isEmpty()) {
-    item.title = item.link.isEmpty() ? "RSS Article" : item.link;
-  }
-  return !item.body.isEmpty();
-}
-
-bool RssFeedManager::saveItem(const FeedItem &item, Preferences &preferences, Result &result) {
+bool RssFeedManager::saveItem(const feedparser::FeedItem &item, Preferences &preferences,
+                              Result &result) {
   SD_MMC.mkdir(kBooksPath);
   SD_MMC.mkdir(kArticleFilesPath);
   const String finalPath = String(kArticleFilesPath) + "/" + filenameForItem(item);
@@ -895,7 +479,8 @@ bool RssFeedManager::saveItem(const FeedItem &item, Preferences &preferences, Re
   file.print("@title ");
   file.println(metadataSafe(item.title));
   file.print("@author ");
-  file.println(metadataSafe(item.author.isEmpty() ? sourceLabelForItem(item) : item.author));
+  file.println(
+      metadataSafe(item.author.isEmpty() ? feedparser::sourceLabelForItem(item) : item.author));
   if (!item.link.isEmpty()) {
     file.print("@source ");
     file.println(metadataSafe(item.link));
@@ -923,147 +508,26 @@ bool RssFeedManager::saveItem(const FeedItem &item, Preferences &preferences, Re
   return true;
 }
 
-bool RssFeedManager::itemAlreadySeen(const FeedItem &item, Preferences &preferences) {
+bool RssFeedManager::itemAlreadySeen(const feedparser::FeedItem &item, Preferences &preferences) {
   return preferences.getBool(seenKeyForItem(item).c_str(), false);
 }
 
-void RssFeedManager::markItemSeen(const FeedItem &item, Preferences &preferences) {
+void RssFeedManager::markItemSeen(const feedparser::FeedItem &item, Preferences &preferences) {
   preferences.putBool(seenKeyForItem(item).c_str(), true);
 }
 
-String RssFeedManager::seenKeyForItem(const FeedItem &item) const {
+String RssFeedManager::seenKeyForItem(const feedparser::FeedItem &item) const {
   char key[16];
   std::snprintf(key, sizeof(key), "rss%08lx", static_cast<unsigned long>(fnv1a(itemIdentity(item))));
   return String(key);
 }
 
-String RssFeedManager::itemIdentity(const FeedItem &item) const {
+String RssFeedManager::itemIdentity(const feedparser::FeedItem &item) const {
   return item.link.isEmpty() ? item.title : item.link;
 }
 
-String RssFeedManager::valueBetween(const String &text, const String &openTag,
-                                    const String &closeTag, size_t start, size_t end) const {
-  const int open = indexOfIgnoreCase(text, openTag.c_str(), start, end);
-  if (open < 0 || static_cast<size_t>(open) >= end) {
-    return "";
-  }
-  const int valueStart = tagEndIndex(text, static_cast<size_t>(open), end);
-  if (valueStart < 0 || static_cast<size_t>(valueStart) >= end) {
-    return "";
-  }
-  const int close = indexOfIgnoreCase(text, closeTag.c_str(), valueStart + 1, end);
-  if (close < 0 || static_cast<size_t>(close) > end) {
-    return "";
-  }
-  return text.substring(valueStart + 1, close);
-}
-
-String RssFeedManager::attributeValue(const String &text, const String &tagPrefix,
-                                      const String &attribute, size_t start, size_t end) const {
-  int tagStart = indexOfIgnoreCase(text, tagPrefix.c_str(), start, end);
-  while (tagStart >= 0 && static_cast<size_t>(tagStart) < end) {
-    const int tagEnd = tagEndIndex(text, static_cast<size_t>(tagStart), end);
-    if (tagEnd < 0 || static_cast<size_t>(tagEnd) > end) {
-      return "";
-    }
-
-    const String needle = attribute + "=";
-    int attrIndex = indexOfIgnoreCase(text, needle.c_str(), tagStart, static_cast<size_t>(tagEnd));
-    if (attrIndex >= 0) {
-      int valueStart = attrIndex + needle.length();
-      while (valueStart < tagEnd && isspace(static_cast<unsigned char>(text[valueStart]))) {
-        ++valueStart;
-      }
-      if (valueStart < tagEnd) {
-        const char quote = text[valueStart];
-        if (quote == '"' || quote == '\'') {
-          ++valueStart;
-          for (int i = valueStart; i < tagEnd; ++i) {
-            if (text[i] == quote) {
-              return text.substring(valueStart, i);
-            }
-          }
-        } else {
-          int valueEnd = valueStart;
-          while (valueEnd < tagEnd && !isspace(static_cast<unsigned char>(text[valueEnd])) &&
-                 text[valueEnd] != '>') {
-            ++valueEnd;
-          }
-          if (valueEnd > valueStart) {
-            return text.substring(valueStart, valueEnd);
-          }
-        }
-      }
-    }
-
-    tagStart = indexOfIgnoreCase(text, tagPrefix.c_str(), static_cast<size_t>(tagEnd + 1), end);
-  }
-  return "";
-}
-
-String RssFeedManager::cleanText(String value) const {
-  value.replace("<![CDATA[", "");
-  value.replace("]]>", "");
-  value = stripHtml(value);
-  value = xmlDecode(value);
-  value.replace("\r", "\n");
-  while (value.indexOf("\n\n\n") >= 0) {
-    value.replace("\n\n\n", "\n\n");
-  }
-  value.trim();
-  return value;
-}
-
-String RssFeedManager::stripHtml(const String &html) const {
-  String output;
-  output.reserve(std::min(static_cast<size_t>(html.length()), kMaxArticleChars));
-  bool inTag = false;
-  for (size_t i = 0; i < html.length(); ++i) {
-    const char c = html[i];
-    if (c == '<') {
-      inTag = true;
-      if (!output.endsWith(" ") && !output.endsWith("\n")) {
-        output += ' ';
-      }
-      continue;
-    }
-    if (c == '>') {
-      inTag = false;
-      continue;
-    }
-    if (!inTag) {
-      output += c;
-    }
-    if (output.length() >= kMaxArticleChars) {
-      break;
-    }
-  }
-  return output;
-}
-
-String RssFeedManager::xmlDecode(String value) const {
-  value = decodeXmlEntitiesOnce(value);
-  if (value.indexOf('&') >= 0) {
-    value = decodeXmlEntitiesOnce(value);
-  }
-  return value;
-}
-
-String RssFeedManager::sourceLabelForItem(const FeedItem &item) const {
-  String source = item.link;
-  if (source.isEmpty()) {
-    return "RSS";
-  }
-
-  source = hostLabelForUrl(source);
-  if (source.isEmpty()) {
-    return "RSS";
-  }
-  return source;
-}
-
-String RssFeedManager::filenameForItem(const FeedItem &item) const {
-  String name = xmlDecode(item.title);
+String RssFeedManager::filenameForItem(const feedparser::FeedItem &item) const {
+  String name = item.title;  // already HTML-stripped and entity-decoded by FeedParser
   String cleaned;
   cleaned.reserve(80);
   for (size_t i = 0; i < name.length() && cleaned.length() < 72; ++i) {

--- a/src/rss/RssFeedManager.h
+++ b/src/rss/RssFeedManager.h
@@ -3,6 +3,7 @@
 #include <Arduino.h>
 #include <Preferences.h>
 
+#include "rss/FeedParser.h"
 #include "update/OtaUpdater.h"
 
 class RssFeedManager {
@@ -21,13 +22,6 @@ class RssFeedManager {
                     StatusCallback callback = nullptr, void *context = nullptr);
 
  private:
-  struct FeedItem {
-    String title;
-    String link;
-    String author;
-    String body;
-  };
-
   bool connectWiFi(const OtaUpdater::Config &wifiConfig, StatusCallback callback, void *context);
   void disconnectWiFi();
   bool fetchUrl(const String &url, String &body, String &error, uint8_t feedIndex,
@@ -35,21 +29,12 @@ class RssFeedManager {
   bool processFeed(const String &feedUrl, const String &feedBody, Preferences &preferences,
                    Result &result, uint8_t feedIndex, uint8_t feedCount, StatusCallback callback,
                    void *context);
-  bool parseNextItem(const String &feedBody, size_t &searchStart, FeedItem &item);
-  bool saveItem(const FeedItem &item, Preferences &preferences, Result &result);
-  bool itemAlreadySeen(const FeedItem &item, Preferences &preferences);
-  void markItemSeen(const FeedItem &item, Preferences &preferences);
-  String seenKeyForItem(const FeedItem &item) const;
-  String itemIdentity(const FeedItem &item) const;
-  String valueBetween(const String &text, const String &openTag, const String &closeTag,
-                      size_t start, size_t end) const;
-  String attributeValue(const String &text, const String &tagPrefix, const String &attribute,
-                        size_t start, size_t end) const;
-  String cleanText(String value) const;
-  String stripHtml(const String &html) const;
-  String xmlDecode(String value) const;
-  String sourceLabelForItem(const FeedItem &item) const;
-  String filenameForItem(const FeedItem &item) const;
+  bool saveItem(const feedparser::FeedItem &item, Preferences &preferences, Result &result);
+  bool itemAlreadySeen(const feedparser::FeedItem &item, Preferences &preferences);
+  void markItemSeen(const feedparser::FeedItem &item, Preferences &preferences);
+  String seenKeyForItem(const feedparser::FeedItem &item) const;
+  String itemIdentity(const feedparser::FeedItem &item) const;
+  String filenameForItem(const feedparser::FeedItem &item) const;
   String metadataSafe(String value) const;
   uint32_t fnv1a(const String &value) const;
   void report(StatusCallback callback, void *context, const String &line1, const String &line2,

--- a/src/update/OtaUpdater.cpp
+++ b/src/update/OtaUpdater.cpp
@@ -8,6 +8,9 @@
 #include <WiFi.h>
 #include <WiFiClientSecure.h>
 
+#include "net/WifiConnection.h"
+#include "update/ReleaseParser.h"
+
 #ifndef RSVP_FIRMWARE_VERSION
 #define RSVP_FIRMWARE_VERSION "dev"
 #endif
@@ -18,27 +21,11 @@ constexpr const char *kConfigPaths[] = {
     "/config/ota.conf",
     "/ota.conf",
 };
-constexpr uint32_t kWifiConnectTimeoutMs = 15000;
-constexpr uint32_t kWifiConnectPollMs = 250;
 constexpr size_t kMaxReleaseJsonBytes = 32768;
 constexpr const char *kStatusTitle = "OTA";
 const char *kRedirectHeaderKeys[] = {
     "Location",
 };
-
-bool isAsciiWhitespace(char c) {
-  switch (c) {
-    case ' ':
-    case '\t':
-    case '\n':
-    case '\r':
-    case '\f':
-    case '\v':
-      return true;
-    default:
-      return false;
-  }
-}
 
 String trimCopy(String value) {
   value.trim();
@@ -49,125 +36,6 @@ bool parseBoolValue(const String &value) {
   String lowered = trimCopy(value);
   lowered.toLowerCase();
   return lowered == "1" || lowered == "true" || lowered == "yes" || lowered == "on";
-}
-
-String jsonUnescape(const String &input) {
-  String output;
-  output.reserve(input.length());
-
-  bool escaping = false;
-  for (size_t i = 0; i < input.length(); ++i) {
-    const char c = input[i];
-    if (escaping) {
-      switch (c) {
-        case '"':
-        case '\\':
-        case '/':
-          output += c;
-          break;
-        case 'b':
-          output += '\b';
-          break;
-        case 'f':
-          output += '\f';
-          break;
-        case 'n':
-          output += '\n';
-          break;
-        case 'r':
-          output += '\r';
-          break;
-        case 't':
-          output += '\t';
-          break;
-        default:
-          output += c;
-          break;
-      }
-      escaping = false;
-      continue;
-    }
-
-    if (c == '\\') {
-      escaping = true;
-      continue;
-    }
-
-    output += c;
-  }
-
-  return output;
-}
-
-bool parseJsonStringAt(const String &json, int quoteIndex, String &value) {
-  if (quoteIndex < 0 || static_cast<size_t>(quoteIndex) >= json.length() ||
-      json[quoteIndex] != '"') {
-    return false;
-  }
-
-  String raw;
-  raw.reserve(64);
-  bool escaping = false;
-  for (size_t i = static_cast<size_t>(quoteIndex) + 1; i < json.length(); ++i) {
-    const char c = json[i];
-    if (!escaping && c == '"') {
-      value = jsonUnescape(raw);
-      return true;
-    }
-
-    raw += c;
-    if (escaping) {
-      escaping = false;
-    } else if (c == '\\') {
-      escaping = true;
-    }
-  }
-
-  return false;
-}
-
-bool extractJsonStringValue(const String &json, const char *key, size_t searchStart, String &value,
-                            int *keyPosition = nullptr) {
-  const String pattern = "\"" + String(key) + "\"";
-  const int keyIndex = json.indexOf(pattern, static_cast<unsigned int>(searchStart));
-  if (keyIndex < 0) {
-    return false;
-  }
-
-  const int colonIndex = json.indexOf(':', keyIndex + pattern.length());
-  if (colonIndex < 0) {
-    return false;
-  }
-
-  int quoteIndex = colonIndex + 1;
-  while (static_cast<size_t>(quoteIndex) < json.length() && isAsciiWhitespace(json[quoteIndex])) {
-    ++quoteIndex;
-  }
-  if (static_cast<size_t>(quoteIndex) >= json.length() || json[quoteIndex] != '"') {
-    return false;
-  }
-
-  if (keyPosition != nullptr) {
-    *keyPosition = keyIndex;
-  }
-  return parseJsonStringAt(json, quoteIndex, value);
-}
-
-bool extractAssetDownloadUrl(const String &json, const String &assetName, String &assetUrl) {
-  size_t searchStart = 0;
-  String candidateName;
-  int nameKeyIndex = -1;
-  while (extractJsonStringValue(json, "name", searchStart, candidateName, &nameKeyIndex)) {
-    if (candidateName == assetName &&
-        extractJsonStringValue(json, "browser_download_url",
-                               static_cast<size_t>(std::max(0, nameKeyIndex)), assetUrl)) {
-      return true;
-    }
-
-    searchStart = static_cast<size_t>(nameKeyIndex) + 1;
-  }
-
-  return false;
 }
 
 String readBodyLimited(HTTPClient &http, size_t maxBytes) {
@@ -297,26 +165,12 @@ bool OtaUpdater::loadConfigFromPath(const char *path, Config &config) const {
 
 bool OtaUpdater::connectWiFi(const Config &config, StatusCallback callback,
                              void *context) const {
-  WiFi.persistent(false);
-  WiFi.setAutoReconnect(false);
-  WiFi.mode(WIFI_STA);
-  WiFi.begin(config.wifiSsid.c_str(), config.wifiPassword.c_str());
-
-  const uint32_t startMs = millis();
-  while (WiFi.status() != WL_CONNECTED && millis() - startMs < kWifiConnectTimeoutMs) {
-    const uint32_t elapsedMs = millis() - startMs;
-    const int progress = 5 + static_cast<int>((elapsedMs * 15) / kWifiConnectTimeoutMs);
-    reportStatus(callback, context, kStatusTitle, "Connecting Wi-Fi", config.wifiSsid, progress);
-    delay(kWifiConnectPollMs);
-  }
-
-  return WiFi.status() == WL_CONNECTED;
+  return net::connectStation(config.wifiSsid, config.wifiPassword, [&](int percent) {
+    reportStatus(callback, context, kStatusTitle, "Connecting Wi-Fi", config.wifiSsid, percent);
+  });
 }
 
-void OtaUpdater::disconnectWiFi() const {
-  WiFi.disconnect(true, false);
-  WiFi.mode(WIFI_OFF);
-}
+void OtaUpdater::disconnectWiFi() const { net::disconnect(); }
 
 bool OtaUpdater::fetchLatestRelease(const Config &config, LatestRelease &release,
                                     String &errorDetail, StatusCallback callback,
@@ -357,13 +211,15 @@ bool OtaUpdater::fetchLatestRelease(const Config &config, LatestRelease &release
   const String body = readBodyLimited(http, kMaxReleaseJsonBytes);
   http.end();
 
-  if (!extractJsonStringValue(body, "tag_name", 0, release.tagName) || release.tagName.isEmpty()) {
+  releaseparser::ReleaseInfo parsed;
+  if (!releaseparser::parse(body, config.assetName, parsed)) {
     errorDetail = "Release tag missing";
     return false;
   }
+  release.tagName = parsed.tagName;
+  release.assetUrl = parsed.assetUrl;
 
-  if (!extractAssetDownloadUrl(body, config.assetName, release.assetUrl) ||
-      release.assetUrl.isEmpty()) {
+  if (release.assetUrl.isEmpty()) {
     errorDetail = config.assetName + " missing";
     return false;
   }

--- a/src/update/ReleaseParser.cpp
+++ b/src/update/ReleaseParser.cpp
@@ -1,0 +1,151 @@
+#include "update/ReleaseParser.h"
+
+#include <algorithm>
+
+namespace releaseparser {
+namespace {
+
+bool isAsciiWhitespace(char c) {
+  switch (c) {
+    case ' ':
+    case '\t':
+    case '\n':
+    case '\r':
+    case '\f':
+    case '\v':
+      return true;
+    default:
+      return false;
+  }
+}
+
+String jsonUnescape(const String &input) {
+  String output;
+  output.reserve(input.length());
+
+  bool escaping = false;
+  for (size_t i = 0; i < input.length(); ++i) {
+    const char c = input[i];
+    if (escaping) {
+      switch (c) {
+        case '"':
+        case '\\':
+        case '/':
+          output += c;
+          break;
+        case 'b':
+          output += '\b';
+          break;
+        case 'f':
+          output += '\f';
+          break;
+        case 'n':
+          output += '\n';
+          break;
+        case 'r':
+          output += '\r';
+          break;
+        case 't':
+          output += '\t';
+          break;
+        default:
+          output += c;
+          break;
+      }
+      escaping = false;
+      continue;
+    }
+
+    if (c == '\\') {
+      escaping = true;
+      continue;
+    }
+
+    output += c;
+  }
+
+  return output;
+}
+
+bool parseJsonStringAt(const String &json, int quoteIndex, String &value) {
+  if (quoteIndex < 0 || static_cast<size_t>(quoteIndex) >= json.length() ||
+      json[quoteIndex] != '"') {
+    return false;
+  }
+
+  String raw;
+  raw.reserve(64);
+  bool escaping = false;
+  for (size_t i = static_cast<size_t>(quoteIndex) + 1; i < json.length(); ++i) {
+    const char c = json[i];
+    if (!escaping && c == '"') {
+      value = jsonUnescape(raw);
+      return true;
+    }
+
+    raw += c;
+    if (escaping) {
+      escaping = false;
+    } else if (c == '\\') {
+      escaping = true;
+    }
+  }
+
+  return false;
+}
+
+bool extractJsonStringValue(const String &json, const char *key, size_t searchStart, String &value,
+                            int *keyPosition = nullptr) {
+  const String pattern = "\"" + String(key) + "\"";
+  const int keyIndex = json.indexOf(pattern, static_cast<unsigned int>(searchStart));
+  if (keyIndex < 0) {
+    return false;
+  }
+
+  const int colonIndex = json.indexOf(':', keyIndex + pattern.length());
+  if (colonIndex < 0) {
+    return false;
+  }
+
+  int quoteIndex = colonIndex + 1;
+  while (static_cast<size_t>(quoteIndex) < json.length() && isAsciiWhitespace(json[quoteIndex])) {
+    ++quoteIndex;
+  }
+  if (static_cast<size_t>(quoteIndex) >= json.length() || json[quoteIndex] != '"') {
+    return false;
+  }
+
+  if (keyPosition != nullptr) {
+    *keyPosition = keyIndex;
+  }
+  return parseJsonStringAt(json, quoteIndex, value);
+}
+
+bool extractAssetDownloadUrl(const String &json, const String &assetName, String &assetUrl) {
+  size_t searchStart = 0;
+  String candidateName;
+  int nameKeyIndex = -1;
+  while (extractJsonStringValue(json, "name", searchStart, candidateName, &nameKeyIndex)) {
+    if (candidateName == assetName &&
+        extractJsonStringValue(json, "browser_download_url",
+                               static_cast<size_t>(std::max(0, nameKeyIndex)), assetUrl)) {
+      return true;
+    }
+
+    searchStart = static_cast<size_t>(nameKeyIndex) + 1;
+  }
+
+  return false;
+}
+
+}  // namespace
+
+bool parse(const String &json, const String &assetName, ReleaseInfo &out) {
+  out = ReleaseInfo();
+  const bool haveTag = extractJsonStringValue(json, "tag_name", 0, out.tagName) &&
+                       !out.tagName.isEmpty();
+  extractAssetDownloadUrl(json, assetName, out.assetUrl);
+  return haveTag;
+}
+
+}  // namespace releaseparser

--- a/src/update/ReleaseParser.h
+++ b/src/update/ReleaseParser.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <Arduino.h>
+
+// Pure parsing of a GitHub "releases/latest" JSON payload. No networking, no
+// SD access -- safe to unit test on the host with the Arduino String shim.
+namespace releaseparser {
+
+struct ReleaseInfo {
+  String tagName;   // empty if the payload had no usable tag_name
+  String assetUrl;  // empty if no asset matched assetName
+};
+
+// Extracts the release tag and the browser_download_url of the asset whose
+// "name" equals assetName. Fills whatever it finds; missing fields stay empty.
+// Returns true when a non-empty tag was found.
+bool parse(const String &json, const String &assetName, ReleaseInfo &out);
+
+}  // namespace releaseparser

--- a/test/support/Arduino.h
+++ b/test/support/Arduino.h
@@ -4,6 +4,7 @@
 #include <cctype>
 #include <cstddef>
 #include <cstdint>
+#include <cstdio>
 #include <cstring>
 #include <string>
 
@@ -14,6 +15,11 @@ class String {
   String() = default;
   String(const char *cs) : s_(cs ? cs : "") {}
   String(char c) : s_(1, c) {}
+  String(const std::string &s) : s_(s) {}
+  String(int value) : s_(std::to_string(value)) {}
+  String(unsigned int value) : s_(std::to_string(value)) {}
+  String(long value) : s_(std::to_string(value)) {}
+  String(unsigned long value) : s_(std::to_string(value)) {}
   String(const String &) = default;
   String(String &&) = default;
   String &operator=(const String &) = default;
@@ -33,9 +39,31 @@ class String {
     s_ += c;
     return *this;
   }
+  String &operator+=(const char *cs) {
+    if (cs) s_ += cs;
+    return *this;
+  }
   String &operator+=(const String &o) {
     s_ += o.s_;
     return *this;
+  }
+
+  friend String operator+(String lhs, const String &rhs) {
+    lhs.s_ += rhs.s_;
+    return lhs;
+  }
+  friend String operator+(String lhs, const char *rhs) {
+    if (rhs) lhs.s_ += rhs;
+    return lhs;
+  }
+  friend String operator+(String lhs, char rhs) {
+    lhs.s_ += rhs;
+    return lhs;
+  }
+  friend String operator+(const char *lhs, const String &rhs) {
+    String out(lhs);
+    out.s_ += rhs.s_;
+    return out;
   }
 
   bool operator==(const char *cs) const { return s_ == (cs ? cs : ""); }
@@ -45,6 +73,14 @@ class String {
 
   void reserve(size_t n) { s_.reserve(n); }
 
+  bool startsWith(const char *prefix) const {
+    if (!prefix) return false;
+    const size_t pl = std::strlen(prefix);
+    if (pl > s_.size()) return false;
+    return s_.compare(0, pl, prefix) == 0;
+  }
+  bool startsWith(const String &prefix) const { return startsWith(prefix.s_.c_str()); }
+
   bool endsWith(const char *suffix) const {
     if (!suffix) return false;
     const size_t sl = std::strlen(suffix);
@@ -53,8 +89,70 @@ class String {
   }
   bool endsWith(const String &suffix) const { return endsWith(suffix.s_.c_str()); }
 
+  int indexOf(char c, unsigned int from = 0) const {
+    const size_t pos = s_.find(c, from);
+    return pos == std::string::npos ? -1 : static_cast<int>(pos);
+  }
+  int indexOf(const char *needle, unsigned int from = 0) const {
+    if (!needle) return -1;
+    const size_t pos = s_.find(needle, from);
+    return pos == std::string::npos ? -1 : static_cast<int>(pos);
+  }
+  int indexOf(const String &needle, unsigned int from = 0) const {
+    return indexOf(needle.s_.c_str(), from);
+  }
+  int lastIndexOf(char c) const {
+    const size_t pos = s_.rfind(c);
+    return pos == std::string::npos ? -1 : static_cast<int>(pos);
+  }
+
+  String substring(unsigned int beginIndex) const {
+    if (beginIndex >= s_.size()) return String();
+    return String(s_.substr(beginIndex));
+  }
+  String substring(unsigned int beginIndex, unsigned int endIndex) const {
+    if (beginIndex > endIndex) std::swap(beginIndex, endIndex);
+    if (beginIndex >= s_.size()) return String();
+    endIndex = std::min(endIndex, static_cast<unsigned int>(s_.size()));
+    return String(s_.substr(beginIndex, endIndex - beginIndex));
+  }
+
+  void replace(const char *find, const char *repl) {
+    if (!find || !*find) return;
+    const std::string f(find);
+    const std::string r(repl ? repl : "");
+    size_t pos = 0;
+    while ((pos = s_.find(f, pos)) != std::string::npos) {
+      s_.replace(pos, f.size(), r);
+      pos += r.size();
+    }
+  }
+  void replace(const String &find, const String &repl) {
+    replace(find.s_.c_str(), repl.s_.c_str());
+  }
+
+  void remove(unsigned int index, unsigned int count) {
+    if (index >= s_.size()) return;
+    s_.erase(index, count);
+  }
+  void remove(unsigned int index) {
+    if (index >= s_.size()) return;
+    s_.erase(index);
+  }
+
+  void trim() {
+    size_t begin = 0;
+    while (begin < s_.size() && std::isspace(static_cast<unsigned char>(s_[begin]))) ++begin;
+    size_t end = s_.size();
+    while (end > begin && std::isspace(static_cast<unsigned char>(s_[end - 1]))) --end;
+    s_ = s_.substr(begin, end - begin);
+  }
+
   void toLowerCase() {
     for (char &c : s_) c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+  }
+  void toUpperCase() {
+    for (char &c : s_) c = static_cast<char>(std::toupper(static_cast<unsigned char>(c)));
   }
 
   const char *c_str() const { return s_.c_str(); }

--- a/test/test_feed_parser/test_main.cpp
+++ b/test/test_feed_parser/test_main.cpp
@@ -1,0 +1,127 @@
+#include <unity.h>
+
+#include "rss/FeedParser.h"
+
+namespace {
+
+feedparser::FeedItem firstItem(const String &feed) {
+  size_t cursor = 0;
+  feedparser::FeedItem item;
+  feedparser::parseNextItem(feed, cursor, item);
+  return item;
+}
+
+}  // namespace
+
+void test_parses_rss_item_fields() {
+  const String feed =
+      "<rss><channel>"
+      "<item>"
+      "<title>Hello World</title>"
+      "<link>https://example.com/a</link>"
+      "<description>Body text here.</description>"
+      "</item>"
+      "</channel></rss>";
+  const feedparser::FeedItem item = firstItem(feed);
+  TEST_ASSERT_EQUAL_STRING("Hello World", item.title.c_str());
+  TEST_ASSERT_EQUAL_STRING("https://example.com/a", item.link.c_str());
+  TEST_ASSERT_EQUAL_STRING("Body text here.", item.body.c_str());
+}
+
+void test_parses_atom_entry_with_href_link() {
+  const String feed =
+      "<feed>"
+      "<entry>"
+      "<title>Atom Title</title>"
+      "<link href=\"https://example.com/atom\"/>"
+      "<summary>Summary body.</summary>"
+      "</entry>"
+      "</feed>";
+  const feedparser::FeedItem item = firstItem(feed);
+  TEST_ASSERT_EQUAL_STRING("Atom Title", item.title.c_str());
+  TEST_ASSERT_EQUAL_STRING("https://example.com/atom", item.link.c_str());
+  TEST_ASSERT_EQUAL_STRING("Summary body.", item.body.c_str());
+}
+
+void test_decodes_entities_and_strips_html() {
+  // stripHtml runs before entity decoding, so real markup tags become spaces
+  // and named entities decode to their character.
+  const String feed =
+      "<rss><channel><item>"
+      "<title>Tom &amp; Jerry</title>"
+      "<link>https://example.com/x</link>"
+      "<description><p>Hello <b>there</b></p></description>"
+      "</item></channel></rss>";
+  const feedparser::FeedItem item = firstItem(feed);
+  TEST_ASSERT_EQUAL_STRING("Tom & Jerry", item.title.c_str());
+  TEST_ASSERT_EQUAL_STRING("Hello there", item.body.c_str());
+}
+
+void test_unwraps_cdata_in_body() {
+  const String feed =
+      "<rss><channel><item>"
+      "<title>T</title>"
+      "<link>https://example.com/y</link>"
+      "<description><![CDATA[Plain cdata text]]></description>"
+      "</item></channel></rss>";
+  const feedparser::FeedItem item = firstItem(feed);
+  TEST_ASSERT_EQUAL_STRING("Plain cdata text", item.body.c_str());
+}
+
+void test_falls_back_to_host_for_author() {
+  const String feed =
+      "<rss><channel><item>"
+      "<title>No Author</title>"
+      "<link>https://www.example.com/post</link>"
+      "<description>Body.</description>"
+      "</item></channel></rss>";
+  const feedparser::FeedItem item = firstItem(feed);
+  TEST_ASSERT_EQUAL_STRING("example.com", item.author.c_str());
+}
+
+void test_prefers_dc_creator_author() {
+  const String feed =
+      "<rss><channel><item>"
+      "<title>T</title>"
+      "<link>https://example.com/z</link>"
+      "<dc:creator>Jane Doe</dc:creator>"
+      "<description>Body.</description>"
+      "</item></channel></rss>";
+  const feedparser::FeedItem item = firstItem(feed);
+  TEST_ASSERT_EQUAL_STRING("Jane Doe", item.author.c_str());
+}
+
+void test_iterates_multiple_items_then_stops() {
+  const String feed =
+      "<rss><channel>"
+      "<item><title>One</title><link>https://e.com/1</link><description>b1</description></item>"
+      "<item><title>Two</title><link>https://e.com/2</link><description>b2</description></item>"
+      "</channel></rss>";
+  size_t cursor = 0;
+  feedparser::FeedItem a;
+  feedparser::FeedItem b;
+  feedparser::FeedItem c;
+  TEST_ASSERT_TRUE(feedparser::parseNextItem(feed, cursor, a));
+  TEST_ASSERT_TRUE(feedparser::parseNextItem(feed, cursor, b));
+  TEST_ASSERT_FALSE(feedparser::parseNextItem(feed, cursor, c));
+  TEST_ASSERT_EQUAL_STRING("One", a.title.c_str());
+  TEST_ASSERT_EQUAL_STRING("Two", b.title.c_str());
+}
+
+void test_host_label_strips_scheme_and_www() {
+  TEST_ASSERT_EQUAL_STRING("example.com",
+                           feedparser::hostLabelForUrl("https://www.example.com/path?x=1").c_str());
+}
+
+int main(void) {
+  UNITY_BEGIN();
+  RUN_TEST(test_parses_rss_item_fields);
+  RUN_TEST(test_parses_atom_entry_with_href_link);
+  RUN_TEST(test_decodes_entities_and_strips_html);
+  RUN_TEST(test_unwraps_cdata_in_body);
+  RUN_TEST(test_falls_back_to_host_for_author);
+  RUN_TEST(test_prefers_dc_creator_author);
+  RUN_TEST(test_iterates_multiple_items_then_stops);
+  RUN_TEST(test_host_label_strips_scheme_and_www);
+  return UNITY_END();
+}

--- a/test/test_release_parser/test_main.cpp
+++ b/test/test_release_parser/test_main.cpp
@@ -1,0 +1,80 @@
+#include <unity.h>
+
+#include "update/ReleaseParser.h"
+
+namespace {
+
+const char *kAsset = "rsvp-nano-ota.bin";
+
+releaseparser::ReleaseInfo parseJson(const String &json) {
+  releaseparser::ReleaseInfo out;
+  releaseparser::parse(json, kAsset, out);
+  return out;
+}
+
+}  // namespace
+
+void test_extracts_tag_and_matching_asset_url() {
+  const String json =
+      "{\"tag_name\":\"v0.0.6\",\"assets\":["
+      "{\"name\":\"other.bin\",\"browser_download_url\":\"https://example.com/other.bin\"},"
+      "{\"name\":\"rsvp-nano-ota.bin\",\"browser_download_url\":\"https://example.com/ota.bin\"}"
+      "]}";
+  releaseparser::ReleaseInfo out;
+  TEST_ASSERT_TRUE(releaseparser::parse(json, kAsset, out));
+  TEST_ASSERT_EQUAL_STRING("v0.0.6", out.tagName.c_str());
+  TEST_ASSERT_EQUAL_STRING("https://example.com/ota.bin", out.assetUrl.c_str());
+}
+
+void test_returns_false_when_tag_missing() {
+  const String json = "{\"assets\":[]}";
+  releaseparser::ReleaseInfo out;
+  TEST_ASSERT_FALSE(releaseparser::parse(json, kAsset, out));
+  TEST_ASSERT_TRUE(out.tagName.isEmpty());
+}
+
+void test_asset_url_empty_when_no_asset_matches() {
+  const String json =
+      "{\"tag_name\":\"v1.2.3\",\"assets\":["
+      "{\"name\":\"wrong.bin\",\"browser_download_url\":\"https://example.com/wrong.bin\"}]}";
+  const releaseparser::ReleaseInfo out = parseJson(json);
+  TEST_ASSERT_EQUAL_STRING("v1.2.3", out.tagName.c_str());
+  TEST_ASSERT_TRUE(out.assetUrl.isEmpty());
+}
+
+void test_handles_whitespace_after_colon() {
+  const String json = "{ \"tag_name\" :   \"v9\" }";
+  const releaseparser::ReleaseInfo out = parseJson(json);
+  TEST_ASSERT_EQUAL_STRING("v9", out.tagName.c_str());
+}
+
+void test_unescapes_forward_slashes_in_url() {
+  const String json =
+      "{\"tag_name\":\"v2\",\"assets\":["
+      "{\"name\":\"rsvp-nano-ota.bin\","
+      "\"browser_download_url\":\"https:\\/\\/example.com\\/path\\/ota.bin\"}]}";
+  const releaseparser::ReleaseInfo out = parseJson(json);
+  TEST_ASSERT_EQUAL_STRING("https://example.com/path/ota.bin", out.assetUrl.c_str());
+}
+
+void test_picks_url_after_matching_name_not_a_neighbor() {
+  // The matching asset is the second entry; its url must come from after its name.
+  const String json =
+      "{\"tag_name\":\"v3\",\"assets\":["
+      "{\"name\":\"a.bin\",\"browser_download_url\":\"https://example.com/a.bin\"},"
+      "{\"name\":\"rsvp-nano-ota.bin\",\"browser_download_url\":\"https://example.com/correct.bin\"}"
+      "]}";
+  const releaseparser::ReleaseInfo out = parseJson(json);
+  TEST_ASSERT_EQUAL_STRING("https://example.com/correct.bin", out.assetUrl.c_str());
+}
+
+int main(void) {
+  UNITY_BEGIN();
+  RUN_TEST(test_extracts_tag_and_matching_asset_url);
+  RUN_TEST(test_returns_false_when_tag_missing);
+  RUN_TEST(test_asset_url_empty_when_no_asset_matches);
+  RUN_TEST(test_handles_whitespace_after_colon);
+  RUN_TEST(test_unescapes_forward_slashes_in_url);
+  RUN_TEST(test_picks_url_after_matching_name_not_a_neighbor);
+  return UNITY_END();
+}


### PR DESCRIPTION
## Why

`RssFeedManager` (~1.1k lines) and `OtaUpdater` (~600 lines) each mixed three concerns: WiFi/HTTP transport, response parsing, and feature orchestration. Two consequences:

- **The parsing could only run on the device.** RSS/Atom parsing and GitHub-release JSON parsing — the fiddly text-mangling where bugs hide — had no tests.
- **The WiFi connect loop was duplicated byte-for-byte** between the two managers (same `WIFI_STA` setup, same 15 s timeout, same poll cadence).

## What

Pull the pure logic out behind small interfaces. The managers keep their public interfaces and behavior and delegate:

| New module | Responsibility | Shape |
|---|---|---|
| `rss/FeedParser` | RSS/Atom item parsing + HTML stripping + XML entity decoding + character folding | `String` in → `FeedItem` out |
| `update/ReleaseParser` | GitHub `releases/latest` JSON → tag + asset URL | `String` in → `ReleaseInfo` out |
| `net/WifiConnection` | the single `WIFI_STA` connect/poll/timeout loop both managers shared | timeout policy now in one place |

Net effect in the two managers: **−737 / +147**.

## Tests

`FeedParser` and `ReleaseParser` get host-side unit tests (14 cases), joining `ReadingLoop` as the only natively-tested modules. The `test/support/Arduino.h` `String` shim was extended (`indexOf`/`substring`/`startsWith`/`replace`/`trim`/…) to support them.

- ✅ `pio test -e native_test` — **73 cases pass** (pacing 59, feed 8, release 6)
- ✅ `pio run -e waveshare_esp32s3_usb_msc` builds clean
- ✅ `pio run -e waveshare_esp32s3` builds clean

## Behavior notes

- Managers' public APIs and runtime behavior are unchanged.
- One cosmetic change: the RSS WiFi-connect **progress ramp** is unified with OTA's (`*12` → `*15`); affects only the progress-bar fill while connecting.

## Deferred follow-up

A fuller `InternetSession` GET seam (one transport behind a fake adapter) was considered. Held off because the two fetch paths genuinely differ — RSS does manual-redirect + relative-URL resolution + idle-timeout + labeled per-KB progress + a 384 KB cap; OTA metadata uses strict-follow + a 32 KB cap — and RSS's `checkFeeds` also reads/writes SD + Preferences, so it needs FileSystem/Preferences seams before it's testable. That unification is a larger, behavior-sensitive change and is better on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)