### PR TITLE
Architecture pass: extract parsers, screensavers, and a shared settings-key registry

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -34,12 +34,14 @@ test_filter =
   test_pacing
   test_release_parser
   test_feed_parser
+  test_life_grid
 test_build_src = yes
 build_src_filter =
   -<*>
   +<reader/ReadingLoop.cpp>
   +<update/ReleaseParser.cpp>
   +<rss/FeedParser.cpp>
+  +<standby/LifeGrid.cpp>
 build_flags =
   -std=c++17
   -Itest/support

--- a/platformio.ini
+++ b/platformio.ini
@@ -30,9 +30,16 @@ build_unflags =
 platform = native
 framework =
 test_framework = unity
-test_filter = test_pacing
+test_filter =
+  test_pacing
+  test_release_parser
+  test_feed_parser
 test_build_src = yes
-build_src_filter = -<*> +<reader/ReadingLoop.cpp>
+build_src_filter =
+  -<*>
+  +<reader/ReadingLoop.cpp>
+  +<update/ReleaseParser.cpp>
+  +<rss/FeedParser.cpp>
 build_flags =
   -std=c++17
   -Itest/support

--- a/src/app/App.cpp
+++ b/src/app/App.cpp
@@ -11,6 +11,7 @@
 #include <vector>
 
 #include "board/BoardConfig.h"
+#include "settings/PreferenceKeys.h"
 
 #ifndef RSVP_USB_TRANSFER_ENABLED
 #define RSVP_USB_TRANSFER_ENABLED 0
@@ -188,43 +189,9 @@ constexpr size_t kWifiNetworksBackIndex = 0;
 constexpr size_t kWifiNetworksFirstItemIndex = 1;
 constexpr size_t kFocusTimerGenreBackIndex = 0;
 constexpr size_t kFocusTimerGenreFirstIndex = 1;
-constexpr const char *kPrefsNamespace = "rsvp";
-constexpr const char *kPrefBookPath = "book";
-constexpr const char *kPrefLegacyWordIndex = "word";
-constexpr const char *kPrefWpm = "wpm";
-constexpr const char *kPrefBrightness = "bright";
-constexpr const char *kPrefDarkMode = "dark";
-constexpr const char *kPrefNightMode = "night";
-constexpr const char *kPrefUiLanguage = "ui_lang";
-constexpr const char *kPrefReaderMode = "read_mode";
-constexpr const char *kPrefHandedness = "handed";
-constexpr const char *kPrefPhantomWords = "phantom_on";
-constexpr const char *kPrefFooterMetricMode = "prog_md";
-constexpr const char *kPrefBatteryLabelMode = "bat_md";
-constexpr const char *kPrefScreensaverMode = "scrn_sv";
-constexpr const char *kPrefReaderBatteryVisible = "read_bat";
-constexpr const char *kPrefReaderChapterVisible = "read_ch";
-constexpr const char *kPrefReaderProgressVisible = "read_pct";
-constexpr const char *kPrefReaderFontSize = "font_size";
-constexpr const char *kPrefReaderTypeface = "typeface";
-constexpr const char *kPrefTypographyFocusHighlight = "type_hlt";
-constexpr const char *kPrefLegacyPacingLong = "pace_len";
-constexpr const char *kPrefLegacyPacingComplex = "pace_cpx";
-constexpr const char *kPrefLegacyPacingPunctuation = "pace_pnc";
-constexpr const char *kPrefPacingLongMs = "pace_lms";
-constexpr const char *kPrefPacingComplexMs = "pace_cms";
-constexpr const char *kPrefPacingPunctuationMs = "pace_pms";
-constexpr const char *kPrefPauseMode = "pause_md";
-constexpr const char *kPrefAccurateTime = "time_est_a";
-constexpr const char *kPrefTypographyTracking = "type_trk";
-constexpr const char *kPrefTypographyAnchor = "type_anc";
-constexpr const char *kPrefTypographyGuideWidth = "type_wid";
-constexpr const char *kPrefTypographyGuideGap = "type_gap";
-constexpr const char *kPrefRecentSeq = "seq";
-constexpr const char *kPrefWifiSsid = "wifi_ssid";
-constexpr const char *kPrefWifiPass = "wifi_pass";
-constexpr const char *kPrefOtaAuto = "ota_auto";
-constexpr const char *kPrefOtaOwner = "ota_owner";
+// Preference keys are defined once in settings/PreferenceKeys.h and shared with
+// the web companion; pull them into scope so existing call sites are unchanged.
+using namespace settings;
 constexpr size_t kReaderFontSizeCount = 3;
 constexpr size_t kPhantomBeforeCharTargets[] = {64, 96, 144};
 constexpr size_t kPhantomAfterCharTargets[] = {96, 144, 208};

--- a/src/app/App.cpp
+++ b/src/app/App.cpp
@@ -384,113 +384,6 @@ String storedOrFallbackLabel(const String &value, const String &fallback) {
   return value.isEmpty() ? fallback : value;
 }
 
-size_t packedLifeWordCount(size_t cellCount) { return (cellCount + 31U) / 32U; }
-
-bool packedLifeCellAlive(const std::vector<uint32_t> &cells, size_t index) {
-  const size_t word = index / 32U;
-  if (word >= cells.size()) {
-    return false;
-  }
-  return (cells[word] & (1UL << (index % 32U))) != 0;
-}
-
-void setPackedLifeCell(std::vector<uint32_t> &cells, size_t index, bool alive) {
-  const size_t word = index / 32U;
-  if (word >= cells.size()) {
-    return;
-  }
-  const uint32_t mask = 1UL << (index % 32U);
-  if (alive) {
-    cells[word] |= mask;
-  } else {
-    cells[word] &= ~mask;
-  }
-}
-
-uint32_t advanceStandbyRng(uint32_t &rng) {
-  rng = (rng * 1664525UL) + 1013904223UL;
-  return rng;
-}
-
-struct LifePoint {
-  int8_t x;
-  int8_t y;
-};
-
-void setPackedLifeCellAt(std::vector<uint32_t> &cells, uint16_t columns, uint16_t rows, int x,
-                         int y, bool alive) {
-  if (x < 0 || y < 0 || x >= static_cast<int>(columns) || y >= static_cast<int>(rows)) {
-    return;
-  }
-  setPackedLifeCell(cells, static_cast<size_t>(y) * columns + static_cast<size_t>(x), alive);
-}
-
-void clearPackedLifeRect(std::vector<uint32_t> &cells, uint16_t columns, uint16_t rows, int x,
-                         int y, int width, int height) {
-  const int xEnd = std::min(static_cast<int>(columns), x + width);
-  const int yEnd = std::min(static_cast<int>(rows), y + height);
-  for (int cy = std::max(0, y); cy < yEnd; ++cy) {
-    for (int cx = std::max(0, x); cx < xEnd; ++cx) {
-      setPackedLifeCellAt(cells, columns, rows, cx, cy, false);
-    }
-  }
-}
-
-void stampPackedLifePattern(std::vector<uint32_t> &cells, uint16_t columns, uint16_t rows,
-                            const LifePoint *points, size_t pointCount, int originX,
-                            int originY) {
-  for (size_t i = 0; i < pointCount; ++i) {
-    setPackedLifeCellAt(cells, columns, rows, originX + points[i].x, originY + points[i].y, true);
-  }
-}
-
-void clearAndStampPackedLifePattern(std::vector<uint32_t> &cells, uint16_t columns, uint16_t rows,
-                                    const LifePoint *points, size_t pointCount, int originX,
-                                    int originY, int width, int height) {
-  if (originX < 0 || originY < 0 || originX + width > static_cast<int>(columns) ||
-      originY + height > static_cast<int>(rows)) {
-    return;
-  }
-  constexpr int kPatternMargin = 5;
-  clearPackedLifeRect(cells, columns, rows, originX - kPatternMargin, originY - kPatternMargin,
-                      width + kPatternMargin * 2, height + kPatternMargin * 2);
-  stampPackedLifePattern(cells, columns, rows, points, pointCount, originX, originY);
-}
-
-constexpr LifePoint kLifeGlider[] = {
-    {1, 0},
-    {2, 1},
-    {0, 2},
-    {1, 2},
-    {2, 2},
-};
-
-constexpr LifePoint kLifeLightweightSpaceship[] = {
-    {1, 0}, {4, 0}, {0, 1}, {0, 2}, {4, 2}, {0, 3}, {1, 3}, {2, 3}, {3, 3},
-};
-
-constexpr LifePoint kLifePentadecathlon[] = {
-    {2, 0}, {2, 1}, {1, 2}, {3, 2}, {2, 3}, {2, 4},
-    {2, 5}, {2, 6}, {1, 7}, {3, 7}, {2, 8}, {2, 9},
-};
-
-constexpr LifePoint kLifePulsar[] = {
-    {2, 0},  {3, 0},  {4, 0},  {8, 0},  {9, 0},  {10, 0}, {0, 2},  {5, 2},
-    {7, 2},  {12, 2}, {0, 3},  {5, 3},  {7, 3},  {12, 3}, {0, 4},  {5, 4},
-    {7, 4},  {12, 4}, {2, 5},  {3, 5},  {4, 5},  {8, 5},  {9, 5},  {10, 5},
-    {2, 7},  {3, 7},  {4, 7},  {8, 7},  {9, 7},  {10, 7}, {0, 8},  {5, 8},
-    {7, 8},  {12, 8}, {0, 9},  {5, 9},  {7, 9},  {12, 9}, {0, 10}, {5, 10},
-    {7, 10}, {12, 10}, {2, 12}, {3, 12}, {4, 12}, {8, 12}, {9, 12}, {10, 12},
-};
-
-constexpr LifePoint kLifeGosperGliderGun[] = {
-    {24, 0}, {22, 1}, {24, 1}, {12, 2}, {13, 2}, {20, 2}, {21, 2}, {34, 2}, {35, 2},
-    {11, 3}, {15, 3}, {20, 3}, {21, 3}, {34, 3}, {35, 3}, {0, 4},  {1, 4},
-    {10, 4}, {16, 4}, {20, 4}, {21, 4}, {0, 5},  {1, 5},  {10, 5}, {14, 5},
-    {16, 5}, {17, 5}, {22, 5}, {24, 5}, {10, 6}, {16, 6}, {24, 6}, {11, 7},
-    {15, 7}, {12, 8}, {13, 8},
-};
-
 void copyOtaLabel(char *destination, size_t destinationSize, const String &source) {
   if (destination == nullptr || destinationSize == 0) {
     return;
@@ -4276,372 +4169,50 @@ void App::exitStandby(uint32_t nowMs) {
   setState(nextState, nowMs);
 }
 
+uint32_t App::standbyRngSeed(uint32_t nowMs) const {
+  return nowMs ^ micros() ^ (static_cast<uint32_t>(reader_.currentIndex() + 1) * 2654435761UL) ^
+         (static_cast<uint32_t>(batteryDisplayedPercent_) << 24);
+}
+
 void App::seedStandbyScreensaver(uint32_t nowMs) {
   if (screensaverMode_ != ScreensaverMode::ScreenOff && standbyScreenOffActive_) {
     display_.wakeFromSleep();
     standbyScreenOffActive_ = false;
   }
 
+  if (screensaverMode_ == ScreensaverMode::ScreenOff) {
+    screensaver_.reset();
+    seedStandbyScreenOff(nowMs);
+    return;
+  }
+
+  standby::Kind kind = standby::Kind::Life;
   switch (screensaverMode_) {
     case ScreensaverMode::Maze:
-      seedStandbyMaze(nowMs);
-      return;
+      kind = standby::Kind::Maze;
+      break;
     case ScreensaverMode::Voronoi:
-      seedStandbyVoronoi(nowMs);
-      return;
-    case ScreensaverMode::ScreenOff:
-      seedStandbyScreenOff(nowMs);
-      return;
+      kind = standby::Kind::Voronoi;
+      break;
     case ScreensaverMode::Life:
     default:
-      seedStandbyLife(nowMs);
-      return;
+      kind = standby::Kind::Life;
+      break;
   }
+  screensaver_ = standby::makeScreensaver(kind, kStandbyLifeColumns, kStandbyLifeRows);
+  screensaver_->seed(standbyRngSeed(nowMs));
 }
 
 void App::stepStandbyScreensaver(uint32_t nowMs) {
   (void)nowMs;
-  switch (screensaverMode_) {
-    case ScreensaverMode::Maze:
-      stepStandbyMaze();
-      return;
-    case ScreensaverMode::Voronoi:
-      stepStandbyVoronoi();
-      return;
-    case ScreensaverMode::ScreenOff:
-      return;
-    case ScreensaverMode::Life:
-    default:
-      stepStandbyLife();
-      return;
+  if (screensaver_) {
+    screensaver_->step();
   }
-}
-
-void App::seedStandbyLife(uint32_t nowMs) {
-  const size_t cellCount =
-      static_cast<size_t>(kStandbyLifeColumns) * static_cast<size_t>(kStandbyLifeRows);
-  standbyLifeCells_.assign(packedLifeWordCount(cellCount), 0);
-  standbyLifeNextCells_.assign(packedLifeWordCount(cellCount), 0);
-  standbyScreensaverDimCells_.clear();
-  standbyMazeVisited_.clear();
-  standbyMazeStack_.clear();
-  standbyVoronoiX_.clear();
-  standbyVoronoiY_.clear();
-  standbyVoronoiDx_.clear();
-  standbyVoronoiDy_.clear();
-  standbyLifeGeneration_ = 0;
-
-  standbyScreensaverRng_ =
-      nowMs ^ micros() ^ (static_cast<uint32_t>(reader_.currentIndex() + 1) * 2654435761UL) ^
-      (static_cast<uint32_t>(batteryDisplayedPercent_) << 24);
-  for (size_t i = 0; i < cellCount; ++i) {
-    setPackedLifeCell(standbyLifeCells_, i, (advanceStandbyRng(standbyScreensaverRng_) >> 24) < 12);
-  }
-
-  clearAndStampPackedLifePattern(standbyLifeCells_, kStandbyLifeColumns, kStandbyLifeRows,
-                                 kLifeGosperGliderGun,
-                                 sizeof(kLifeGosperGliderGun) / sizeof(kLifeGosperGliderGun[0]),
-                                 18, 18, 36, 9);
-  clearAndStampPackedLifePattern(standbyLifeCells_, kStandbyLifeColumns, kStandbyLifeRows,
-                                 kLifeGosperGliderGun,
-                                 sizeof(kLifeGosperGliderGun) / sizeof(kLifeGosperGliderGun[0]),
-                                 static_cast<int>(kStandbyLifeColumns) - 62,
-                                 static_cast<int>(kStandbyLifeRows) - 34, 36, 9);
-  clearAndStampPackedLifePattern(standbyLifeCells_, kStandbyLifeColumns, kStandbyLifeRows,
-                                 kLifePulsar, sizeof(kLifePulsar) / sizeof(kLifePulsar[0]),
-                                 static_cast<int>(kStandbyLifeColumns / 2) - 7,
-                                 static_cast<int>(kStandbyLifeRows / 2) - 7, 13, 13);
-  clearAndStampPackedLifePattern(standbyLifeCells_, kStandbyLifeColumns, kStandbyLifeRows,
-                                 kLifePentadecathlon,
-                                 sizeof(kLifePentadecathlon) / sizeof(kLifePentadecathlon[0]),
-                                 static_cast<int>(kStandbyLifeColumns / 3),
-                                 static_cast<int>(kStandbyLifeRows) - 42, 5, 10);
-  clearAndStampPackedLifePattern(standbyLifeCells_, kStandbyLifeColumns, kStandbyLifeRows,
-                                 kLifeLightweightSpaceship,
-                                 sizeof(kLifeLightweightSpaceship) /
-                                     sizeof(kLifeLightweightSpaceship[0]),
-                                 static_cast<int>((kStandbyLifeColumns * 2) / 3),
-                                 static_cast<int>(kStandbyLifeRows / 3), 5, 4);
-
-  for (uint8_t i = 0; i < 10; ++i) {
-    const int x =
-        static_cast<int>((advanceStandbyRng(standbyScreensaverRng_) >> 8) %
-                         std::max<uint16_t>(1, kStandbyLifeColumns - 6));
-    const int y =
-        static_cast<int>((advanceStandbyRng(standbyScreensaverRng_) >> 8) %
-                         std::max<uint16_t>(1, kStandbyLifeRows - 6));
-    clearAndStampPackedLifePattern(standbyLifeCells_, kStandbyLifeColumns, kStandbyLifeRows,
-                                   kLifeGlider, sizeof(kLifeGlider) / sizeof(kLifeGlider[0]), x,
-                                   y, 3, 3);
-  }
-}
-
-void App::stepStandbyLife() {
-  const size_t cellCount =
-      static_cast<size_t>(kStandbyLifeColumns) * static_cast<size_t>(kStandbyLifeRows);
-  const size_t wordCount = packedLifeWordCount(cellCount);
-  if (standbyLifeCells_.size() != wordCount || standbyLifeNextCells_.size() != wordCount) {
-    seedStandbyLife(millis());
-    return;
-  }
-
-  std::fill(standbyLifeNextCells_.begin(), standbyLifeNextCells_.end(), 0);
-  size_t aliveCount = 0;
-  for (uint16_t y = 0; y < kStandbyLifeRows; ++y) {
-    for (uint16_t x = 0; x < kStandbyLifeColumns; ++x) {
-      uint8_t neighbours = 0;
-      for (int8_t dy = -1; dy <= 1; ++dy) {
-        for (int8_t dx = -1; dx <= 1; ++dx) {
-          if (dx == 0 && dy == 0) {
-            continue;
-          }
-          const uint16_t nx =
-              static_cast<uint16_t>((static_cast<int>(x) + dx + kStandbyLifeColumns) %
-                                    kStandbyLifeColumns);
-          const uint16_t ny =
-              static_cast<uint16_t>((static_cast<int>(y) + dy + kStandbyLifeRows) %
-                                    kStandbyLifeRows);
-          neighbours += packedLifeCellAlive(
-              standbyLifeCells_, static_cast<size_t>(ny) * kStandbyLifeColumns + nx)
-                            ? 1
-                            : 0;
-        }
-      }
-
-      const size_t index = static_cast<size_t>(y) * kStandbyLifeColumns + x;
-      const bool alive = packedLifeCellAlive(standbyLifeCells_, index);
-      const bool nextAlive = alive ? (neighbours == 2 || neighbours == 3) : (neighbours == 3);
-      setPackedLifeCell(standbyLifeNextCells_, index, nextAlive);
-      if (nextAlive) {
-        ++aliveCount;
-      }
-    }
-  }
-
-  standbyLifeCells_.swap(standbyLifeNextCells_);
-  ++standbyLifeGeneration_;
-  if (aliveCount == 0 || aliveCount > (cellCount * 3) / 4) {
-    seedStandbyLife(millis());
-  }
-}
-
-void App::seedStandbyMaze(uint32_t nowMs) {
-  const size_t cellCount =
-      static_cast<size_t>(kStandbyLifeColumns) * static_cast<size_t>(kStandbyLifeRows);
-  const uint16_t mazeColumns = std::max<uint16_t>(1, (kStandbyLifeColumns - 1) / 2);
-  const uint16_t mazeRows = std::max<uint16_t>(1, (kStandbyLifeRows - 1) / 2);
-  standbyLifeCells_.assign(packedLifeWordCount(cellCount), 0);
-  standbyLifeNextCells_.assign(packedLifeWordCount(cellCount), 0);
-  standbyScreensaverDimCells_.clear();
-  standbyVoronoiX_.clear();
-  standbyVoronoiY_.clear();
-  standbyVoronoiDx_.clear();
-  standbyVoronoiDy_.clear();
-  standbyMazeVisited_.assign(static_cast<size_t>(mazeColumns) * mazeRows, 0);
-  standbyMazeStack_.clear();
-  standbyLifeGeneration_ = 0;
-  standbyScreensaverRng_ =
-      nowMs ^ micros() ^ (static_cast<uint32_t>(reader_.currentIndex() + 1) * 2246822519UL);
-
-  const uint16_t startX = static_cast<uint16_t>((advanceStandbyRng(standbyScreensaverRng_) >> 8) %
-                                               mazeColumns);
-  const uint16_t startY = static_cast<uint16_t>((advanceStandbyRng(standbyScreensaverRng_) >> 8) %
-                                               mazeRows);
-  standbyMazeVisited_[static_cast<size_t>(startY) * mazeColumns + startX] = 1;
-  standbyMazeStack_.push_back(static_cast<uint16_t>(startY * mazeColumns + startX));
-  setPackedLifeCellAt(standbyLifeCells_, kStandbyLifeColumns, kStandbyLifeRows,
-                      static_cast<int>(startX) * 2 + 1, static_cast<int>(startY) * 2 + 1, true);
-}
-
-void App::stepStandbyMaze() {
-  const uint16_t mazeColumns = std::max<uint16_t>(1, (kStandbyLifeColumns - 1) / 2);
-  const uint16_t mazeRows = std::max<uint16_t>(1, (kStandbyLifeRows - 1) / 2);
-  const size_t mazeCellCount = static_cast<size_t>(mazeColumns) * mazeRows;
-  if (standbyMazeVisited_.size() != mazeCellCount || standbyMazeStack_.empty()) {
-    if (standbyMazeStack_.empty() && standbyLifeGeneration_ < 600) {
-      ++standbyLifeGeneration_;
-      return;
-    }
-    seedStandbyMaze(millis());
-    return;
-  }
-
-  constexpr uint8_t kMazeStepsPerFrame = 32;
-  for (uint8_t step = 0; step < kMazeStepsPerFrame && !standbyMazeStack_.empty(); ++step) {
-    const uint16_t current = standbyMazeStack_.back();
-    const uint16_t cx = current % mazeColumns;
-    const uint16_t cy = current / mazeColumns;
-    uint16_t candidates[4];
-    uint8_t candidateCount = 0;
-
-    auto addCandidate = [&](int nx, int ny) {
-      if (nx < 0 || ny < 0 || nx >= static_cast<int>(mazeColumns) ||
-          ny >= static_cast<int>(mazeRows)) {
-        return;
-      }
-      const uint16_t encoded = static_cast<uint16_t>(ny * mazeColumns + nx);
-      if (standbyMazeVisited_[encoded] == 0) {
-        candidates[candidateCount++] = encoded;
-      }
-    };
-
-    addCandidate(static_cast<int>(cx) + 1, cy);
-    addCandidate(static_cast<int>(cx) - 1, cy);
-    addCandidate(cx, static_cast<int>(cy) + 1);
-    addCandidate(cx, static_cast<int>(cy) - 1);
-
-    if (candidateCount == 0) {
-      standbyMazeStack_.pop_back();
-      continue;
-    }
-
-    const uint16_t next = candidates[(advanceStandbyRng(standbyScreensaverRng_) >> 16) %
-                                     candidateCount];
-    const uint16_t nx = next % mazeColumns;
-    const uint16_t ny = next / mazeColumns;
-    standbyMazeVisited_[next] = 1;
-    standbyMazeStack_.push_back(next);
-
-    const int displayCx = static_cast<int>(cx) * 2 + 1;
-    const int displayCy = static_cast<int>(cy) * 2 + 1;
-    const int displayNx = static_cast<int>(nx) * 2 + 1;
-    const int displayNy = static_cast<int>(ny) * 2 + 1;
-    setPackedLifeCellAt(standbyLifeCells_, kStandbyLifeColumns, kStandbyLifeRows, displayNx,
-                        displayNy, true);
-    setPackedLifeCellAt(standbyLifeCells_, kStandbyLifeColumns, kStandbyLifeRows,
-                        (displayCx + displayNx) / 2, (displayCy + displayNy) / 2, true);
-  }
-
-  if (standbyMazeStack_.empty()) {
-    standbyLifeGeneration_ = 0;
-  } else {
-    ++standbyLifeGeneration_;
-  }
-}
-
-void App::seedStandbyVoronoi(uint32_t nowMs) {
-  const size_t cellCount =
-      static_cast<size_t>(kStandbyLifeColumns) * static_cast<size_t>(kStandbyLifeRows);
-  const size_t wordCount = packedLifeWordCount(cellCount);
-  standbyLifeCells_.assign(wordCount, 0);
-  standbyLifeNextCells_.assign(wordCount, 0);
-  standbyScreensaverDimCells_.assign(wordCount, 0);
-  standbyMazeVisited_.clear();
-  standbyMazeStack_.clear();
-  standbyLifeGeneration_ = 0;
-  standbyScreensaverRng_ =
-      nowMs ^ micros() ^ (static_cast<uint32_t>(reader_.currentIndex() + 1) * 3266489917UL) ^
-      0x51a7f00dUL;
-
-  constexpr size_t kVoronoiSiteCount = 15;
-  standbyVoronoiX_.assign(kVoronoiSiteCount, 0);
-  standbyVoronoiY_.assign(kVoronoiSiteCount, 0);
-  standbyVoronoiDx_.assign(kVoronoiSiteCount, 0);
-  standbyVoronoiDy_.assign(kVoronoiSiteCount, 0);
-  for (size_t i = 0; i < kVoronoiSiteCount; ++i) {
-    standbyVoronoiX_[i] = static_cast<int16_t>(
-        ((advanceStandbyRng(standbyScreensaverRng_) >> 8) % kStandbyLifeColumns) * 16);
-    standbyVoronoiY_[i] = static_cast<int16_t>(
-        ((advanceStandbyRng(standbyScreensaverRng_) >> 8) % kStandbyLifeRows) * 16);
-
-    const int16_t dx =
-        static_cast<int16_t>(4 + ((advanceStandbyRng(standbyScreensaverRng_) >> 24) % 7));
-    const int16_t dy =
-        static_cast<int16_t>(3 + ((advanceStandbyRng(standbyScreensaverRng_) >> 24) % 6));
-    standbyVoronoiDx_[i] =
-        (advanceStandbyRng(standbyScreensaverRng_) & 1U) != 0 ? dx : static_cast<int16_t>(-dx);
-    standbyVoronoiDy_[i] =
-        (advanceStandbyRng(standbyScreensaverRng_) & 1U) != 0 ? dy : static_cast<int16_t>(-dy);
-  }
-  renderStandbyVoronoi();
-}
-
-void App::renderStandbyVoronoi() {
-  const size_t cellCount =
-      static_cast<size_t>(kStandbyLifeColumns) * static_cast<size_t>(kStandbyLifeRows);
-  const size_t wordCount = packedLifeWordCount(cellCount);
-  standbyLifeCells_.assign(wordCount, 0);
-  standbyScreensaverDimCells_.assign(wordCount, 0);
-  if (standbyVoronoiX_.empty()) {
-    return;
-  }
-
-  for (uint16_t y = 0; y < kStandbyLifeRows; ++y) {
-    const int32_t cellY = static_cast<int32_t>(y) * 16 + 8;
-    for (uint16_t x = 0; x < kStandbyLifeColumns; ++x) {
-      const int32_t cellX = static_cast<int32_t>(x) * 16 + 8;
-      int32_t nearest = INT32_MAX;
-      int32_t secondNearest = INT32_MAX;
-      for (size_t i = 0; i < standbyVoronoiX_.size(); ++i) {
-        const int32_t dx = cellX - standbyVoronoiX_[i];
-        const int32_t dy = cellY - standbyVoronoiY_[i];
-        const int32_t distance = dx * dx + dy * dy;
-        if (distance < nearest) {
-          secondNearest = nearest;
-          nearest = distance;
-        } else if (distance < secondNearest) {
-          secondNearest = distance;
-        }
-      }
-
-      const size_t index = static_cast<size_t>(y) * kStandbyLifeColumns + x;
-      const int32_t gap = secondNearest - nearest;
-      if (nearest < 1200 || gap < 190) {
-        setPackedLifeCell(standbyLifeCells_, index, true);
-      } else if (gap < 580 + nearest / 180) {
-        setPackedLifeCell(standbyScreensaverDimCells_, index, true);
-      }
-    }
-  }
-}
-
-void App::stepStandbyVoronoi() {
-  constexpr size_t kVoronoiSiteCount = 15;
-  if (standbyVoronoiX_.size() != kVoronoiSiteCount ||
-      standbyVoronoiY_.size() != kVoronoiSiteCount ||
-      standbyVoronoiDx_.size() != kVoronoiSiteCount ||
-      standbyVoronoiDy_.size() != kVoronoiSiteCount) {
-    seedStandbyVoronoi(millis());
-    return;
-  }
-
-  const int16_t maxX = static_cast<int16_t>((kStandbyLifeColumns - 1) * 16);
-  const int16_t maxY = static_cast<int16_t>((kStandbyLifeRows - 1) * 16);
-  for (size_t i = 0; i < standbyVoronoiX_.size(); ++i) {
-    int16_t nextX = static_cast<int16_t>(standbyVoronoiX_[i] + standbyVoronoiDx_[i]);
-    int16_t nextY = static_cast<int16_t>(standbyVoronoiY_[i] + standbyVoronoiDy_[i]);
-    if (nextX < 0 || nextX > maxX) {
-      standbyVoronoiDx_[i] = static_cast<int16_t>(-standbyVoronoiDx_[i]);
-      nextX = std::max<int16_t>(0, std::min<int16_t>(maxX, nextX));
-    }
-    if (nextY < 0 || nextY > maxY) {
-      standbyVoronoiDy_[i] = static_cast<int16_t>(-standbyVoronoiDy_[i]);
-      nextY = std::max<int16_t>(0, std::min<int16_t>(maxY, nextY));
-    }
-    standbyVoronoiX_[i] = nextX;
-    standbyVoronoiY_[i] = nextY;
-  }
-
-  ++standbyLifeGeneration_;
-  if (standbyLifeGeneration_ > 2400) {
-    seedStandbyVoronoi(millis());
-    return;
-  }
-  renderStandbyVoronoi();
 }
 
 void App::seedStandbyScreenOff(uint32_t nowMs) {
   (void)nowMs;
-  standbyLifeCells_.clear();
-  standbyLifeNextCells_.clear();
-  standbyScreensaverDimCells_.clear();
-  standbyMazeVisited_.clear();
-  standbyMazeStack_.clear();
-  standbyVoronoiX_.clear();
-  standbyVoronoiY_.clear();
-  standbyVoronoiDx_.clear();
-  standbyVoronoiDy_.clear();
-  standbyLifeGeneration_ = 0;
+  screensaver_.reset();
   standbyScreenOffActive_ = true;
   display_.prepareForSleep();
 }
@@ -4665,15 +4236,16 @@ void App::updateStandbyScreensaver(uint32_t nowMs, bool force) {
 
   if (!force) {
     stepStandbyScreensaver(nowMs);
-  } else if (standbyLifeCells_.empty()) {
+  } else if (!screensaver_) {
     seedStandbyScreensaver(nowMs);
   }
 
   lastStandbyFrameMs_ = nowMs;
-  display_.renderLifeScreensaver(standbyLifeCells_, kStandbyLifeColumns, kStandbyLifeRows,
-                                 standbyLifeGeneration_,
-                                 standbyScreensaverDimCells_.empty() ? nullptr
-                                                                      : &standbyScreensaverDimCells_);
+  if (screensaver_) {
+    const standby::Frame frame = screensaver_->frame();
+    display_.renderLifeScreensaver(*frame.cells, kStandbyLifeColumns, kStandbyLifeRows,
+                                   frame.generation, frame.dimCells);
+  }
 }
 
 void App::enterPowerOff(uint32_t nowMs) {

--- a/src/app/App.h
+++ b/src/app/App.h
@@ -5,6 +5,7 @@
 #include <freertos/FreeRTOS.h>
 #include <freertos/queue.h>
 #include <freertos/task.h>
+#include <memory>
 #include <vector>
 
 #include "app/AppState.h"
@@ -15,6 +16,7 @@
 #include "input/TouchHandler.h"
 #include "reader/ReadingLoop.h"
 #include "rss/RssFeedManager.h"
+#include "standby/Screensaver.h"
 #include "storage/StorageManager.h"
 #include "sync/CompanionSyncManager.h"
 #include "timer/FocusTimer.h"
@@ -298,13 +300,7 @@ class App {
   void exitStandby(uint32_t nowMs);
   void seedStandbyScreensaver(uint32_t nowMs);
   void stepStandbyScreensaver(uint32_t nowMs);
-  void seedStandbyLife(uint32_t nowMs);
-  void stepStandbyLife();
-  void seedStandbyMaze(uint32_t nowMs);
-  void stepStandbyMaze();
-  void seedStandbyVoronoi(uint32_t nowMs);
-  void stepStandbyVoronoi();
-  void renderStandbyVoronoi();
+  uint32_t standbyRngSeed(uint32_t nowMs) const;
   void seedStandbyScreenOff(uint32_t nowMs);
   void updateStandbyScreensaver(uint32_t nowMs, bool force = false);
   void enterPowerOff(uint32_t nowMs);
@@ -433,8 +429,6 @@ class App {
   uint32_t standbyComboStartedMs_ = 0;
   uint32_t standbyEnteredMs_ = 0;
   uint32_t lastStandbyFrameMs_ = 0;
-  uint32_t standbyLifeGeneration_ = 0;
-  uint32_t standbyScreensaverRng_ = 1;
   uint32_t chapterTransitionUntilMs_ = 0;
   uint32_t lastLowBatteryWarningMs_ = 0;
   uint32_t batteryWarningRestoreAtMs_ = 0;
@@ -486,15 +480,7 @@ class App {
   std::vector<DisplayManager::ContextWord> contextPreviewWords_;
   std::vector<WifiNetworkInfo> wifiNetworks_;
   std::vector<TextEntryButton> textEntryButtons_;
-  std::vector<uint32_t> standbyLifeCells_;
-  std::vector<uint32_t> standbyLifeNextCells_;
-  std::vector<uint32_t> standbyScreensaverDimCells_;
-  std::vector<uint8_t> standbyMazeVisited_;
-  std::vector<uint16_t> standbyMazeStack_;
-  std::vector<int16_t> standbyVoronoiX_;
-  std::vector<int16_t> standbyVoronoiY_;
-  std::vector<int16_t> standbyVoronoiDx_;
-  std::vector<int16_t> standbyVoronoiDy_;
+  std::unique_ptr<standby::Screensaver> screensaver_;
   String currentBookPath_;
   String currentBookTitle_;
   String pendingUpdateCurrentVersion_;

--- a/src/net/WifiConnection.cpp
+++ b/src/net/WifiConnection.cpp
@@ -1,0 +1,36 @@
+#include "net/WifiConnection.h"
+
+#include <WiFi.h>
+
+namespace net {
+namespace {
+
+constexpr uint32_t kWifiConnectTimeoutMs = 15000;
+constexpr uint32_t kWifiConnectPollMs = 250;
+
+}  // namespace
+
+bool connectStation(const String &ssid, const String &password, const WifiProgress &progress) {
+  WiFi.persistent(false);
+  WiFi.setAutoReconnect(false);
+  WiFi.mode(WIFI_STA);
+  WiFi.begin(ssid.c_str(), password.c_str());
+
+  const uint32_t startMs = millis();
+  while (WiFi.status() != WL_CONNECTED && millis() - startMs < kWifiConnectTimeoutMs) {
+    if (progress) {
+      const uint32_t elapsedMs = millis() - startMs;
+      progress(5 + static_cast<int>((elapsedMs * 15) / kWifiConnectTimeoutMs));
+    }
+    delay(kWifiConnectPollMs);
+  }
+
+  return WiFi.status() == WL_CONNECTED;
+}
+
+void disconnect() {
+  WiFi.disconnect(true, false);
+  WiFi.mode(WIFI_OFF);
+}
+
+}  // namespace net

--- a/src/net/WifiConnection.h
+++ b/src/net/WifiConnection.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <Arduino.h>
+
+#include <functional>
+
+// The device's only station-mode WiFi lifecycle: bring the radio up to reach
+// the internet (RSS feed checks, OTA update checks) and tear it back down.
+// Both callers shared a byte-identical connect/poll/timeout loop before this
+// module; the timeout policy now lives here in one place.
+namespace net {
+
+// Reports association progress as a percentage in [0, 100] while connecting.
+using WifiProgress = std::function<void(int percent)>;
+
+// Brings up WIFI_STA and blocks until associated or the connect timeout
+// elapses. Returns true only when connected. progress may be null.
+bool connectStation(const String &ssid, const String &password,
+                    const WifiProgress &progress = nullptr);
+
+// Disconnects and powers the radio off (WIFI_OFF).
+void disconnect();
+
+}  // namespace net

--- a/src/rss/FeedParser.cpp
+++ b/src/rss/FeedParser.cpp
@@ -1,0 +1,539 @@
+#include "rss/FeedParser.h"
+
+#include <algorithm>
+#include <cctype>
+#include <cstring>
+
+#include "text/LatinText.h"
+
+namespace feedparser {
+namespace {
+
+constexpr size_t kMaxArticleChars = 24000;
+
+char lowerAscii(char c) {
+  return (c >= 'A' && c <= 'Z') ? static_cast<char>(c + ('a' - 'A')) : c;
+}
+
+int hexValue(char c) {
+  if (c >= '0' && c <= '9') {
+    return c - '0';
+  }
+  if (c >= 'a' && c <= 'f') {
+    return c - 'a' + 10;
+  }
+  if (c >= 'A' && c <= 'F') {
+    return c - 'A' + 10;
+  }
+  return -1;
+}
+
+bool parseNumericEntity(const String &entity, uint32_t &codepoint) {
+  if (!entity.startsWith("#")) {
+    return false;
+  }
+
+  codepoint = 0;
+  int base = 10;
+  size_t index = 1;
+  if (entity.length() > 2 && (entity[1] == 'x' || entity[1] == 'X')) {
+    base = 16;
+    index = 2;
+  }
+  if (index >= entity.length()) {
+    return false;
+  }
+
+  for (; index < entity.length(); ++index) {
+    const int digit =
+        base == 16 ? hexValue(entity[index])
+                   : (entity[index] >= '0' && entity[index] <= '9' ? entity[index] - '0' : -1);
+    if (digit < 0 || digit >= base) {
+      return false;
+    }
+    codepoint = codepoint * base + static_cast<uint32_t>(digit);
+  }
+
+  return codepoint <= 0x10FFFF && !(codepoint >= 0xD800 && codepoint <= 0xDFFF);
+}
+
+void appendText(String &target, const char *text) {
+  while (*text != '\0') {
+    target += *text;
+    ++text;
+  }
+}
+
+bool appendDecodedCodepoint(String &target, uint32_t codepoint) {
+  if (codepoint == 0x00AD || codepoint == 0x200B || codepoint == 0xFEFF) {
+    return true;
+  }
+  if (codepoint == '\t' || codepoint == '\n' || codepoint == '\r' || codepoint == 0x00A0 ||
+      codepoint == 0x1680 || codepoint == 0x180E || codepoint == 0x2028 ||
+      codepoint == 0x2029 || codepoint == 0x202F || codepoint == 0x205F ||
+      codepoint == 0x3000 || (codepoint >= 0x2000 && codepoint <= 0x200A)) {
+    target += ' ';
+    return true;
+  }
+
+  uint8_t storedByte = 0;
+  if (LatinText::storageByteForCodepoint(codepoint, storedByte)) {
+    target += static_cast<char>(storedByte);
+    return true;
+  }
+
+  if (codepoint >= 0xFF01 && codepoint <= 0xFF5E) {
+    target += static_cast<char>(codepoint - 0xFEE0);
+    return true;
+  }
+
+  switch (codepoint) {
+    case 0x00A2:
+      target += 'c';
+      return true;
+    case 0x00A3:
+      appendText(target, "GBP");
+      return true;
+    case 0x00A4:
+      target += '$';
+      return true;
+    case 0x00A5:
+      target += 'Y';
+      return true;
+    case 0x00A9:
+      appendText(target, "(c)");
+      return true;
+    case 0x00AE:
+      appendText(target, "(r)");
+      return true;
+    case 0x00B0:
+      appendText(target, "deg");
+      return true;
+    case 0x00B1:
+      appendText(target, "+/-");
+      return true;
+    case 0x00B2:
+      target += '2';
+      return true;
+    case 0x00B3:
+      target += '3';
+      return true;
+    case 0x00B9:
+      target += '1';
+      return true;
+    case 0x00BC:
+      appendText(target, "1/4");
+      return true;
+    case 0x00BD:
+      appendText(target, "1/2");
+      return true;
+    case 0x00BE:
+      appendText(target, "3/4");
+      return true;
+    case 0x00D7:
+      target += 'x';
+      return true;
+    case 0x00F7:
+      target += '/';
+      return true;
+    case 0x2010:
+    case 0x2011:
+    case 0x2212:
+      target += '-';
+      return true;
+    case 0x2012:
+    case 0x2013:
+    case 0x2014:
+    case 0x2015:
+      appendText(target, " - ");
+      return true;
+    case 0x2018:
+    case 0x2019:
+    case 0x201A:
+    case 0x201B:
+    case 0x2032:
+    case 0x2035:
+    case 0x2039:
+    case 0x203A:
+      target += '\'';
+      return true;
+    case 0x201C:
+    case 0x201D:
+    case 0x201E:
+    case 0x201F:
+    case 0x2033:
+    case 0x2036:
+    case 0x00AB:
+    case 0x00BB:
+      target += '"';
+      return true;
+    case 0x2022:
+    case 0x00B7:
+    case 0x2219:
+      target += '*';
+      return true;
+    case 0x2026:
+      appendText(target, "...");
+      return true;
+    default:
+      return false;
+  }
+}
+
+bool namedEntityCodepoint(const String &entity, uint32_t &codepoint) {
+  struct NamedEntity {
+    const char *name;
+    uint32_t codepoint;
+  };
+  static constexpr NamedEntity kNamedEntities[] = {
+      {"Agrave", 0x00C0}, {"Aacute", 0x00C1}, {"Acirc", 0x00C2},
+      {"Atilde", 0x00C3}, {"Auml", 0x00C4},   {"Aring", 0x00C5},
+      {"AElig", 0x00C6},  {"Ccedil", 0x00C7}, {"Egrave", 0x00C8},
+      {"Eacute", 0x00C9}, {"Ecirc", 0x00CA},  {"Euml", 0x00CB},
+      {"Igrave", 0x00CC}, {"Iacute", 0x00CD}, {"Icirc", 0x00CE},
+      {"Iuml", 0x00CF},   {"ETH", 0x00D0},    {"Ntilde", 0x00D1},
+      {"Ograve", 0x00D2}, {"Oacute", 0x00D3}, {"Ocirc", 0x00D4},
+      {"Otilde", 0x00D5}, {"Ouml", 0x00D6},   {"Oslash", 0x00D8},
+      {"Ugrave", 0x00D9}, {"Uacute", 0x00DA}, {"Ucirc", 0x00DB},
+      {"Uuml", 0x00DC},   {"Yacute", 0x00DD}, {"THORN", 0x00DE},
+      {"szlig", 0x00DF},  {"agrave", 0x00E0}, {"aacute", 0x00E1},
+      {"acirc", 0x00E2},  {"atilde", 0x00E3}, {"auml", 0x00E4},
+      {"aring", 0x00E5},  {"aelig", 0x00E6},  {"ccedil", 0x00E7},
+      {"egrave", 0x00E8}, {"eacute", 0x00E9}, {"ecirc", 0x00EA},
+      {"euml", 0x00EB},   {"igrave", 0x00EC}, {"iacute", 0x00ED},
+      {"icirc", 0x00EE},  {"iuml", 0x00EF},   {"eth", 0x00F0},
+      {"ntilde", 0x00F1}, {"ograve", 0x00F2}, {"oacute", 0x00F3},
+      {"ocirc", 0x00F4},  {"otilde", 0x00F5}, {"ouml", 0x00F6},
+      {"oslash", 0x00F8}, {"ugrave", 0x00F9}, {"uacute", 0x00FA},
+      {"ucirc", 0x00FB},  {"uuml", 0x00FC},   {"yacute", 0x00FD},
+      {"thorn", 0x00FE},  {"yuml", 0x00FF},   {"iexcl", 0x00A1},
+      {"iquest", 0x00BF}, {"copy", 0x00A9},   {"reg", 0x00AE},
+      {"deg", 0x00B0},    {"plusmn", 0x00B1}, {"sup2", 0x00B2},
+      {"sup3", 0x00B3},   {"sup1", 0x00B9},   {"frac14", 0x00BC},
+      {"frac12", 0x00BD}, {"frac34", 0x00BE}, {"laquo", 0x00AB},
+      {"raquo", 0x00BB},  {"middot", 0x00B7}, {"bull", 0x2022},
+      {"times", 0x00D7},  {"divide", 0x00F7},
+  };
+
+  for (const NamedEntity &entry : kNamedEntities) {
+    if (entity == entry.name) {
+      codepoint = entry.codepoint;
+      return true;
+    }
+  }
+  return false;
+}
+
+bool decodeXmlEntity(const String &entity, String &decoded) {
+  decoded = "";
+  if (entity == "amp") {
+    decoded += '&';
+    return true;
+  }
+  if (entity == "lt") {
+    decoded += '<';
+    return true;
+  }
+  if (entity == "gt") {
+    decoded += '>';
+    return true;
+  }
+  if (entity == "quot") {
+    decoded += '"';
+    return true;
+  }
+  if (entity == "apos") {
+    decoded += '\'';
+    return true;
+  }
+  if (entity == "nbsp") {
+    decoded += ' ';
+    return true;
+  }
+  if (entity == "ndash" || entity == "mdash") {
+    appendText(decoded, " - ");
+    return true;
+  }
+  if (entity == "hellip") {
+    appendText(decoded, "...");
+    return true;
+  }
+  if (entity == "rsquo" || entity == "lsquo" || entity == "sbquo") {
+    decoded += '\'';
+    return true;
+  }
+  if (entity == "rdquo" || entity == "ldquo" || entity == "bdquo") {
+    decoded += '"';
+    return true;
+  }
+
+  uint32_t codepoint = 0;
+  if ((parseNumericEntity(entity, codepoint) || namedEntityCodepoint(entity, codepoint)) &&
+      appendDecodedCodepoint(decoded, codepoint)) {
+    return true;
+  }
+
+  return false;
+}
+
+String decodeXmlEntitiesOnce(const String &value) {
+  String output;
+  output.reserve(value.length());
+
+  for (size_t i = 0; i < value.length(); ++i) {
+    const char c = value[i];
+    if (c != '&') {
+      output += c;
+      continue;
+    }
+
+    const int entityEnd = value.indexOf(';', i + 1);
+    if (entityEnd <= 0 || entityEnd - static_cast<int>(i) > 32) {
+      output += c;
+      continue;
+    }
+
+    String decoded;
+    const String entity = value.substring(i + 1, entityEnd);
+    if (!decodeXmlEntity(entity, decoded)) {
+      output += c;
+      continue;
+    }
+
+    output += decoded;
+    i = static_cast<size_t>(entityEnd);
+  }
+
+  return output;
+}
+
+bool matchesIgnoreCaseAt(const String &text, size_t index, const char *needle) {
+  for (size_t i = 0; needle[i] != '\0'; ++i) {
+    if (index + i >= text.length() || lowerAscii(text[index + i]) != lowerAscii(needle[i])) {
+      return false;
+    }
+  }
+  return true;
+}
+
+int indexOfIgnoreCase(const String &text, const char *needle, size_t start, size_t limit) {
+  const size_t needleLength = strlen(needle);
+  if (needleLength == 0 || start >= text.length()) {
+    return -1;
+  }
+  limit = std::min(limit, static_cast<size_t>(text.length()));
+  if (limit < needleLength) {
+    return -1;
+  }
+  for (size_t i = start; i + needleLength <= limit; ++i) {
+    if (matchesIgnoreCaseAt(text, i, needle)) {
+      return static_cast<int>(i);
+    }
+  }
+  return -1;
+}
+
+int tagEndIndex(const String &text, size_t start, size_t limit) {
+  limit = std::min(limit, static_cast<size_t>(text.length()));
+  for (size_t i = start; i < limit; ++i) {
+    if (text[i] == '>') {
+      return static_cast<int>(i);
+    }
+  }
+  return -1;
+}
+
+String valueBetween(const String &text, const String &openTag, const String &closeTag,
+                    size_t start, size_t end) {
+  const int open = indexOfIgnoreCase(text, openTag.c_str(), start, end);
+  if (open < 0 || static_cast<size_t>(open) >= end) {
+    return "";
+  }
+  const int valueStart = tagEndIndex(text, static_cast<size_t>(open), end);
+  if (valueStart < 0 || static_cast<size_t>(valueStart) >= end) {
+    return "";
+  }
+  const int close = indexOfIgnoreCase(text, closeTag.c_str(), valueStart + 1, end);
+  if (close < 0 || static_cast<size_t>(close) > end) {
+    return "";
+  }
+  return text.substring(valueStart + 1, close);
+}
+
+String attributeValue(const String &text, const String &tagPrefix, const String &attribute,
+                      size_t start, size_t end) {
+  int tagStart = indexOfIgnoreCase(text, tagPrefix.c_str(), start, end);
+  while (tagStart >= 0 && static_cast<size_t>(tagStart) < end) {
+    const int tagEnd = tagEndIndex(text, static_cast<size_t>(tagStart), end);
+    if (tagEnd < 0 || static_cast<size_t>(tagEnd) > end) {
+      return "";
+    }
+
+    const String needle = attribute + "=";
+    int attrIndex = indexOfIgnoreCase(text, needle.c_str(), tagStart, static_cast<size_t>(tagEnd));
+    if (attrIndex >= 0) {
+      int valueStart = attrIndex + needle.length();
+      while (valueStart < tagEnd && isspace(static_cast<unsigned char>(text[valueStart]))) {
+        ++valueStart;
+      }
+      if (valueStart < tagEnd) {
+        const char quote = text[valueStart];
+        if (quote == '"' || quote == '\'') {
+          ++valueStart;
+          for (int i = valueStart; i < tagEnd; ++i) {
+            if (text[i] == quote) {
+              return text.substring(valueStart, i);
+            }
+          }
+        } else {
+          int valueEnd = valueStart;
+          while (valueEnd < tagEnd && !isspace(static_cast<unsigned char>(text[valueEnd])) &&
+                 text[valueEnd] != '>') {
+            ++valueEnd;
+          }
+          if (valueEnd > valueStart) {
+            return text.substring(valueStart, valueEnd);
+          }
+        }
+      }
+    }
+
+    tagStart = indexOfIgnoreCase(text, tagPrefix.c_str(), static_cast<size_t>(tagEnd + 1), end);
+  }
+  return "";
+}
+
+String stripHtml(const String &html) {
+  String output;
+  output.reserve(std::min(static_cast<size_t>(html.length()), kMaxArticleChars));
+  bool inTag = false;
+  for (size_t i = 0; i < html.length(); ++i) {
+    const char c = html[i];
+    if (c == '<') {
+      inTag = true;
+      if (!output.endsWith(" ") && !output.endsWith("\n")) {
+        output += ' ';
+      }
+      continue;
+    }
+    if (c == '>') {
+      inTag = false;
+      continue;
+    }
+    if (!inTag) {
+      output += c;
+    }
+    if (output.length() >= kMaxArticleChars) {
+      break;
+    }
+  }
+  return output;
+}
+
+String xmlDecode(String value) {
+  value = decodeXmlEntitiesOnce(value);
+  if (value.indexOf('&') >= 0) {
+    value = decodeXmlEntitiesOnce(value);
+  }
+  return value;
+}
+
+String cleanText(String value) {
+  value.replace("<![CDATA[", "");
+  value.replace("]]>", "");
+  value = stripHtml(value);
+  value = xmlDecode(value);
+  value.replace("\r", "\n");
+  while (value.indexOf("\n\n\n") >= 0) {
+    value.replace("\n\n\n", "\n\n");
+  }
+  value.trim();
+  return value;
+}
+
+}  // namespace
+
+String hostLabelForUrl(const String &url) {
+  int start = url.indexOf("://");
+  start = start < 0 ? 0 : start + 3;
+  int end = url.indexOf('/', start);
+  if (end < 0) {
+    end = url.length();
+  }
+  String host = url.substring(start, end);
+  if (host.startsWith("www.")) {
+    host.remove(0, 4);
+  }
+  return host;
+}
+
+String sourceLabelForItem(const FeedItem &item) {
+  String source = item.link;
+  if (source.isEmpty()) {
+    return "RSS";
+  }
+
+  source = hostLabelForUrl(source);
+  if (source.isEmpty()) {
+    return "RSS";
+  }
+  return source;
+}
+
+bool parseNextItem(const String &feedBody, size_t &searchStart, FeedItem &item) {
+  int itemStart = indexOfIgnoreCase(feedBody, "<item", searchStart, feedBody.length());
+  bool atom = false;
+  if (itemStart < 0) {
+    itemStart = indexOfIgnoreCase(feedBody, "<entry", searchStart, feedBody.length());
+    atom = itemStart >= 0;
+  }
+  if (itemStart < 0) {
+    return false;
+  }
+
+  const String closeTag = atom ? "</entry>" : "</item>";
+  const int itemEnd = indexOfIgnoreCase(feedBody, closeTag.c_str(), itemStart, feedBody.length());
+  if (itemEnd < 0) {
+    return false;
+  }
+  searchStart = static_cast<size_t>(itemEnd + closeTag.length());
+
+  const size_t start = static_cast<size_t>(itemStart);
+  const size_t end = static_cast<size_t>(itemEnd);
+  item.title = cleanText(valueBetween(feedBody, "<title", "</title>", start, end));
+  item.link = cleanText(valueBetween(feedBody, "<link>", "</link>", start, end));
+  if (item.link.isEmpty()) {
+    item.link = cleanText(attributeValue(feedBody, "<link", "href", start, end));
+  }
+  if (item.link.isEmpty()) {
+    item.link = cleanText(valueBetween(feedBody, "<guid", "</guid>", start, end));
+  }
+  item.author = cleanText(valueBetween(feedBody, "<author", "</author>", start, end));
+  if (item.author.isEmpty()) {
+    item.author = cleanText(valueBetween(feedBody, "<dc:creator", "</dc:creator>", start, end));
+  }
+  if (item.author.isEmpty()) {
+    item.author = sourceLabelForItem(item);
+  }
+
+  item.body = cleanText(valueBetween(feedBody, "<content:encoded", "</content:encoded>", start, end));
+  if (item.body.isEmpty()) {
+    item.body = cleanText(valueBetween(feedBody, "<content", "</content>", start, end));
+  }
+  if (item.body.isEmpty()) {
+    item.body = cleanText(valueBetween(feedBody, "<description", "</description>", start, end));
+  }
+  if (item.body.isEmpty()) {
+    item.body = cleanText(valueBetween(feedBody, "<summary", "</summary>", start, end));
+  }
+  if (item.body.isEmpty()) {
+    item.body = item.link;
+  }
+
+  if (item.title.isEmpty()) {
+    item.title = item.link.isEmpty() ? "RSS Article" : item.link;
+  }
+  return !item.body.isEmpty();
+}
+
+}  // namespace feedparser

--- a/src/rss/FeedParser.h
+++ b/src/rss/FeedParser.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <Arduino.h>
+
+// Pure parsing of RSS/Atom feed bodies into article items, plus the text
+// normalization (HTML stripping, XML entity decoding, character folding) that
+// turns feed markup into reader-ready text. No networking, no SD access -- safe
+// to unit test on the host with the Arduino String shim.
+namespace feedparser {
+
+struct FeedItem {
+  String title;
+  String link;
+  String author;
+  String body;
+};
+
+// Parses the next <item> (RSS) or <entry> (Atom) starting at searchStart and
+// advances searchStart past it. Returns false when no further item is found or
+// the item has no usable body text.
+bool parseNextItem(const String &feedBody, size_t &searchStart, FeedItem &item);
+
+// The bare host of a URL: scheme and a leading "www." removed, path dropped.
+// Returns "" when no host can be found.
+String hostLabelForUrl(const String &url);
+
+// A human label for an item's origin: its link's host, or "RSS" when absent.
+String sourceLabelForItem(const FeedItem &item);
+
+}  // namespace feedparser

--- a/src/rss/RssFeedManager.cpp
+++ b/src/rss/RssFeedManager.cpp
@@ -7,7 +7,8 @@
 #include <algorithm>
 #include <vector>
 
-#include "text/LatinText.h"
+#include "net/WifiConnection.h"
+#include "rss/FeedParser.h"
 
 namespace {
 
@@ -18,8 +19,6 @@ constexpr const char *kConfigPaths[] = {
 constexpr const char *kBooksPath = "/books";
 constexpr const char *kArticleFilesPath = "/books/articles";
 constexpr const char *kStatusTitle = "RSS";
-constexpr uint32_t kWifiConnectTimeoutMs = 15000;
-constexpr uint32_t kWifiConnectPollMs = 250;
 constexpr uint32_t kFeedTotalTimeoutMs = 30000;
 constexpr uint32_t kFeedIdleTimeoutMs = 5000;
 constexpr uint32_t kFeedProgressIntervalMs = 1000;
@@ -46,353 +45,7 @@ bool isSafeFilenameChar(char c) {
          c == '-' || c == '_' || c == ' ' || c == '.';
 }
 
-char lowerAscii(char c) {
-  return (c >= 'A' && c <= 'Z') ? static_cast<char>(c + ('a' - 'A')) : c;
-}
-
-int hexValue(char c) {
-  if (c >= '0' && c <= '9') {
-    return c - '0';
-  }
-  if (c >= 'a' && c <= 'f') {
-    return c - 'a' + 10;
-  }
-  if (c >= 'A' && c <= 'F') {
-    return c - 'A' + 10;
-  }
-  return -1;
-}
-
-bool parseNumericEntity(const String &entity, uint32_t &codepoint) {
-  if (!entity.startsWith("#")) {
-    return false;
-  }
-
-  codepoint = 0;
-  int base = 10;
-  size_t index = 1;
-  if (entity.length() > 2 && (entity[1] == 'x' || entity[1] == 'X')) {
-    base = 16;
-    index = 2;
-  }
-  if (index >= entity.length()) {
-    return false;
-  }
-
-  for (; index < entity.length(); ++index) {
-    const int digit =
-        base == 16 ? hexValue(entity[index])
-                   : (entity[index] >= '0' && entity[index] <= '9' ? entity[index] - '0' : -1);
-    if (digit < 0 || digit >= base) {
-      return false;
-    }
-    codepoint = codepoint * base + static_cast<uint32_t>(digit);
-  }
-
-  return codepoint <= 0x10FFFF && !(codepoint >= 0xD800 && codepoint <= 0xDFFF);
-}
-
-void appendText(String &target, const char *text) {
-  while (*text != '\0') {
-    target += *text;
-    ++text;
-  }
-}
-
-bool appendDecodedCodepoint(String &target, uint32_t codepoint) {
-  if (codepoint == 0x00AD || codepoint == 0x200B || codepoint == 0xFEFF) {
-    return true;
-  }
-  if (codepoint == '\t' || codepoint == '\n' || codepoint == '\r' || codepoint == 0x00A0 ||
-      codepoint == 0x1680 || codepoint == 0x180E || codepoint == 0x2028 ||
-      codepoint == 0x2029 || codepoint == 0x202F || codepoint == 0x205F ||
-      codepoint == 0x3000 || (codepoint >= 0x2000 && codepoint <= 0x200A)) {
-    target += ' ';
-    return true;
-  }
-
-  uint8_t storedByte = 0;
-  if (LatinText::storageByteForCodepoint(codepoint, storedByte)) {
-    target += static_cast<char>(storedByte);
-    return true;
-  }
-
-  if (codepoint >= 0xFF01 && codepoint <= 0xFF5E) {
-    target += static_cast<char>(codepoint - 0xFEE0);
-    return true;
-  }
-
-  switch (codepoint) {
-    case 0x00A2:
-      target += 'c';
-      return true;
-    case 0x00A3:
-      appendText(target, "GBP");
-      return true;
-    case 0x00A4:
-      target += '$';
-      return true;
-    case 0x00A5:
-      target += 'Y';
-      return true;
-    case 0x00A9:
-      appendText(target, "(c)");
-      return true;
-    case 0x00AE:
-      appendText(target, "(r)");
-      return true;
-    case 0x00B0:
-      appendText(target, "deg");
-      return true;
-    case 0x00B1:
-      appendText(target, "+/-");
-      return true;
-    case 0x00B2:
-      target += '2';
-      return true;
-    case 0x00B3:
-      target += '3';
-      return true;
-    case 0x00B9:
-      target += '1';
-      return true;
-    case 0x00BC:
-      appendText(target, "1/4");
-      return true;
-    case 0x00BD:
-      appendText(target, "1/2");
-      return true;
-    case 0x00BE:
-      appendText(target, "3/4");
-      return true;
-    case 0x00D7:
-      target += 'x';
-      return true;
-    case 0x00F7:
-      target += '/';
-      return true;
-    case 0x2010:
-    case 0x2011:
-    case 0x2212:
-      target += '-';
-      return true;
-    case 0x2012:
-    case 0x2013:
-    case 0x2014:
-    case 0x2015:
-      appendText(target, " - ");
-      return true;
-    case 0x2018:
-    case 0x2019:
-    case 0x201A:
-    case 0x201B:
-    case 0x2032:
-    case 0x2035:
-    case 0x2039:
-    case 0x203A:
-      target += '\'';
-      return true;
-    case 0x201C:
-    case 0x201D:
-    case 0x201E:
-    case 0x201F:
-    case 0x2033:
-    case 0x2036:
-    case 0x00AB:
-    case 0x00BB:
-      target += '"';
-      return true;
-    case 0x2022:
-    case 0x00B7:
-    case 0x2219:
-      target += '*';
-      return true;
-    case 0x2026:
-      appendText(target, "...");
-      return true;
-    default:
-      return false;
-  }
-}
-
-bool namedEntityCodepoint(const String &entity, uint32_t &codepoint) {
-  struct NamedEntity {
-    const char *name;
-    uint32_t codepoint;
-  };
-  static constexpr NamedEntity kNamedEntities[] = {
-      {"Agrave", 0x00C0}, {"Aacute", 0x00C1}, {"Acirc", 0x00C2},
-      {"Atilde", 0x00C3}, {"Auml", 0x00C4},   {"Aring", 0x00C5},
-      {"AElig", 0x00C6},  {"Ccedil", 0x00C7}, {"Egrave", 0x00C8},
-      {"Eacute", 0x00C9}, {"Ecirc", 0x00CA},  {"Euml", 0x00CB},
-      {"Igrave", 0x00CC}, {"Iacute", 0x00CD}, {"Icirc", 0x00CE},
-      {"Iuml", 0x00CF},   {"ETH", 0x00D0},    {"Ntilde", 0x00D1},
-      {"Ograve", 0x00D2}, {"Oacute", 0x00D3}, {"Ocirc", 0x00D4},
-      {"Otilde", 0x00D5}, {"Ouml", 0x00D6},   {"Oslash", 0x00D8},
-      {"Ugrave", 0x00D9}, {"Uacute", 0x00DA}, {"Ucirc", 0x00DB},
-      {"Uuml", 0x00DC},   {"Yacute", 0x00DD}, {"THORN", 0x00DE},
-      {"szlig", 0x00DF},  {"agrave", 0x00E0}, {"aacute", 0x00E1},
-      {"acirc", 0x00E2},  {"atilde", 0x00E3}, {"auml", 0x00E4},
-      {"aring", 0x00E5},  {"aelig", 0x00E6},  {"ccedil", 0x00E7},
-      {"egrave", 0x00E8}, {"eacute", 0x00E9}, {"ecirc", 0x00EA},
-      {"euml", 0x00EB},   {"igrave", 0x00EC}, {"iacute", 0x00ED},
-      {"icirc", 0x00EE},  {"iuml", 0x00EF},   {"eth", 0x00F0},
-      {"ntilde", 0x00F1}, {"ograve", 0x00F2}, {"oacute", 0x00F3},
-      {"ocirc", 0x00F4},  {"otilde", 0x00F5}, {"ouml", 0x00F6},
-      {"oslash", 0x00F8}, {"ugrave", 0x00F9}, {"uacute", 0x00FA},
-      {"ucirc", 0x00FB},  {"uuml", 0x00FC},   {"yacute", 0x00FD},
-      {"thorn", 0x00FE},  {"yuml", 0x00FF},   {"iexcl", 0x00A1},
-      {"iquest", 0x00BF}, {"copy", 0x00A9},   {"reg", 0x00AE},
-      {"deg", 0x00B0},    {"plusmn", 0x00B1}, {"sup2", 0x00B2},
-      {"sup3", 0x00B3},   {"sup1", 0x00B9},   {"frac14", 0x00BC},
-      {"frac12", 0x00BD}, {"frac34", 0x00BE}, {"laquo", 0x00AB},
-      {"raquo", 0x00BB},  {"middot", 0x00B7}, {"bull", 0x2022},
-      {"times", 0x00D7},  {"divide", 0x00F7},
-  };
-
-  for (const NamedEntity &entry : kNamedEntities) {
-    if (entity == entry.name) {
-      codepoint = entry.codepoint;
-      return true;
-    }
-  }
-  return false;
-}
-
-bool decodeXmlEntity(const String &entity, String &decoded) {
-  decoded = "";
-  if (entity == "amp") {
-    decoded += '&';
-    return true;
-  }
-  if (entity == "lt") {
-    decoded += '<';
-    return true;
-  }
-  if (entity == "gt") {
-    decoded += '>';
-    return true;
-  }
-  if (entity == "quot") {
-    decoded += '"';
-    return true;
-  }
-  if (entity == "apos") {
-    decoded += '\'';
-    return true;
-  }
-  if (entity == "nbsp") {
-    decoded += ' ';
-    return true;
-  }
-  if (entity == "ndash" || entity == "mdash") {
-    appendText(decoded, " - ");
-    return true;
-  }
-  if (entity == "hellip") {
-    appendText(decoded, "...");
-    return true;
-  }
-  if (entity == "rsquo" || entity == "lsquo" || entity == "sbquo") {
-    decoded += '\'';
-    return true;
-  }
-  if (entity == "rdquo" || entity == "ldquo" || entity == "bdquo") {
-    decoded += '"';
-    return true;
-  }
-
-  uint32_t codepoint = 0;
-  if ((parseNumericEntity(entity, codepoint) || namedEntityCodepoint(entity, codepoint)) &&
-      appendDecodedCodepoint(decoded, codepoint)) {
-    return true;
-  }
-
-  return false;
-}
-
-String decodeXmlEntitiesOnce(const String &value) {
-  String output;
-  output.reserve(value.length());
-
-  for (size_t i = 0; i < value.length(); ++i) {
-    const char c = value[i];
-    if (c != '&') {
-      output += c;
-      continue;
-    }
-
-    const int entityEnd = value.indexOf(';', i + 1);
-    if (entityEnd <= 0 || entityEnd - static_cast<int>(i) > 32) {
-      output += c;
-      continue;
-    }
-
-    String decoded;
-    const String entity = value.substring(i + 1, entityEnd);
-    if (!decodeXmlEntity(entity, decoded)) {
-      output += c;
-      continue;
-    }
-
-    output += decoded;
-    i = static_cast<size_t>(entityEnd);
-  }
-
-  return output;
-}
-
-bool matchesIgnoreCaseAt(const String &text, size_t index, const char *needle) {
-  for (size_t i = 0; needle[i] != '\0'; ++i) {
-    if (index + i >= text.length() || lowerAscii(text[index + i]) != lowerAscii(needle[i])) {
-      return false;
-    }
-  }
-  return true;
-}
-
-int indexOfIgnoreCase(const String &text, const char *needle, size_t start, size_t limit) {
-  const size_t needleLength = strlen(needle);
-  if (needleLength == 0 || start >= text.length()) {
-    return -1;
-  }
-  limit = std::min(limit, static_cast<size_t>(text.length()));
-  if (limit < needleLength) {
-    return -1;
-  }
-  for (size_t i = start; i + needleLength <= limit; ++i) {
-    if (matchesIgnoreCaseAt(text, i, needle)) {
-      return static_cast<int>(i);
-    }
-  }
-  return -1;
-}
-
-int tagEndIndex(const String &text, size_t start, size_t limit) {
-  limit = std::min(limit, static_cast<size_t>(text.length()));
-  for (size_t i = start; i < limit; ++i) {
-    if (text[i] == '>') {
-      return static_cast<int>(i);
-    }
-  }
-  return -1;
-}
-
 String userAgent() { return String("RSVP-Nano-RSS/1.0"); }
-
-String hostLabelForUrl(const String &url) {
-  int start = url.indexOf("://");
-  start = start < 0 ? 0 : start + 3;
-  int end = url.indexOf('/', start);
-  if (end < 0) {
-    end = url.length();
-  }
-  String host = url.substring(start, end);
-  if (host.startsWith("www.")) {
-    host.remove(0, 4);
-  }
-  return host;
-}
 
 String feedProgressLabel(uint8_t feedIndex, uint8_t feedCount) {
   return "Feed " + String(feedIndex) + "/" + String(feedCount);
@@ -568,7 +221,7 @@ RssFeedManager::Result RssFeedManager::checkFeeds(const OtaUpdater::Config &wifi
     const uint8_t displayIndex = feedIndex + 1;
     const uint8_t feedCount = feeds.size();
     report(callback, context, feedProgressLabel(displayIndex, feedCount),
-           "Downloading " + hostLabelForUrl(line), 15 + displayIndex * 8);
+           "Downloading " + feedparser::hostLabelForUrl(line), 15 + displayIndex * 8);
 
     String feedBody;
     String error;
@@ -615,26 +268,12 @@ RssFeedManager::Result RssFeedManager::checkFeeds(const OtaUpdater::Config &wifi
 
 bool RssFeedManager::connectWiFi(const OtaUpdater::Config &wifiConfig, StatusCallback callback,
                                  void *context) {
-  WiFi.persistent(false);
-  WiFi.setAutoReconnect(false);
-  WiFi.mode(WIFI_STA);
-  WiFi.begin(wifiConfig.wifiSsid.c_str(), wifiConfig.wifiPassword.c_str());
-
-  const uint32_t startMs = millis();
-  while (WiFi.status() != WL_CONNECTED && millis() - startMs < kWifiConnectTimeoutMs) {
-    const uint32_t elapsedMs = millis() - startMs;
-    const int progress = 5 + static_cast<int>((elapsedMs * 12) / kWifiConnectTimeoutMs);
-    report(callback, context, "Connecting Wi-Fi", wifiConfig.wifiSsid, progress);
-    delay(kWifiConnectPollMs);
-  }
-
-  return WiFi.status() == WL_CONNECTED;
+  return net::connectStation(wifiConfig.wifiSsid, wifiConfig.wifiPassword, [&](int percent) {
+    report(callback, context, "Connecting Wi-Fi", wifiConfig.wifiSsid, percent);
+  });
 }
 
-void RssFeedManager::disconnectWiFi() {
-  WiFi.disconnect(true, false);
-  WiFi.mode(WIFI_OFF);
-}
+void RssFeedManager::disconnectWiFi() { net::disconnect(); }
 
 bool RssFeedManager::fetchUrl(const String &url, String &body, String &error,
                               uint8_t feedIndex, uint8_t feedCount,
@@ -662,7 +301,7 @@ bool RssFeedManager::fetchUrl(const String &url, String &body, String &error,
     }
 
     report(callback, context, feedProgressLabel(feedIndex, feedCount),
-           "Requesting " + hostLabelForUrl(currentUrl), 18 + feedIndex * 7);
+           "Requesting " + feedparser::hostLabelForUrl(currentUrl), 18 + feedIndex * 7);
     const int statusCode = http.GET();
     if (isRedirectStatus(statusCode)) {
       String location = http.header("Location");
@@ -677,7 +316,7 @@ bool RssFeedManager::fetchUrl(const String &url, String &body, String &error,
       Serial.printf("[rss] redirect %u url=%s\n", static_cast<unsigned int>(statusCode),
                     currentUrl.c_str());
       report(callback, context, feedProgressLabel(feedIndex, feedCount),
-             "Redirecting to " + hostLabelForUrl(currentUrl), 18 + feedIndex * 7);
+             "Redirecting to " + feedparser::hostLabelForUrl(currentUrl), 18 + feedIndex * 7);
       delay(250);
       continue;
     }
@@ -789,8 +428,8 @@ bool RssFeedManager::processFeed(const String &feedUrl, const String &feedBody,
   report(callback, context, feedProgressLabel(feedIndex, feedCount), "Parsing items",
          24 + feedIndex * 7);
   while (itemCount < kMaxItemsPerFeed && result.articlesSaved < kMaxArticlesPerCheck) {
-    FeedItem item;
-    if (!parseNextItem(feedBody, searchStart, item)) {
+    feedparser::FeedItem item;
+    if (!feedparser::parseNextItem(feedBody, searchStart, item)) {
       break;
     }
     ++itemCount;
@@ -822,63 +461,8 @@ bool RssFeedManager::processFeed(const String &feedUrl, const String &feedBody,
   return itemCount > 0;
 }
 
-bool RssFeedManager::parseNextItem(const String &feedBody, size_t &searchStart, FeedItem &item) {
-  int itemStart = indexOfIgnoreCase(feedBody, "<item", searchStart, feedBody.length());
-  bool atom = false;
-  if (itemStart < 0) {
-    itemStart = indexOfIgnoreCase(feedBody, "<entry", searchStart, feedBody.length());
-    atom = itemStart >= 0;
-  }
-  if (itemStart < 0) {
-    return false;
-  }
-
-  const String closeTag = atom ? "</entry>" : "</item>";
-  const int itemEnd = indexOfIgnoreCase(feedBody, closeTag.c_str(), itemStart, feedBody.length());
-  if (itemEnd < 0) {
-    return false;
-  }
-  searchStart = static_cast<size_t>(itemEnd + closeTag.length());
-
-  const size_t start = static_cast<size_t>(itemStart);
-  const size_t end = static_cast<size_t>(itemEnd);
-  item.title = cleanText(valueBetween(feedBody, "<title", "</title>", start, end));
-  item.link = cleanText(valueBetween(feedBody, "<link>", "</link>", start, end));
-  if (item.link.isEmpty()) {
-    item.link = cleanText(attributeValue(feedBody, "<link", "href", start, end));
-  }
-  if (item.link.isEmpty()) {
-    item.link = cleanText(valueBetween(feedBody, "<guid", "</guid>", start, end));
-  }
-  item.author = cleanText(valueBetween(feedBody, "<author", "</author>", start, end));
-  if (item.author.isEmpty()) {
-    item.author = cleanText(valueBetween(feedBody, "<dc:creator", "</dc:creator>", start, end));
-  }
-  if (item.author.isEmpty()) {
-    item.author = sourceLabelForItem(item);
-  }
-
-  item.body = cleanText(valueBetween(feedBody, "<content:encoded", "</content:encoded>", start, end));
-  if (item.body.isEmpty()) {
-    item.body = cleanText(valueBetween(feedBody, "<content", "</content>", start, end));
-  }
-  if (item.body.isEmpty()) {
-    item.body = cleanText(valueBetween(feedBody, "<description", "</description>", start, end));
-  }
-  if (item.body.isEmpty()) {
-    item.body = cleanText(valueBetween(feedBody, "<summary", "</summary>", start, end));
-  }
-  if (item.body.isEmpty()) {
-    item.body = item.link;
-  }
-
-  if (item.title.isEmpty()) {
-    item.title = item.link.isEmpty() ? "RSS Article" : item.link;
-  }
-  return !item.body.isEmpty();
-}
-
-bool RssFeedManager::saveItem(const FeedItem &item, Preferences &preferences, Result &result) {
+bool RssFeedManager::saveItem(const feedparser::FeedItem &item, Preferences &preferences,
+                              Result &result) {
   SD_MMC.mkdir(kBooksPath);
   SD_MMC.mkdir(kArticleFilesPath);
   const String finalPath = String(kArticleFilesPath) + "/" + filenameForItem(item);
@@ -895,7 +479,8 @@ bool RssFeedManager::saveItem(const FeedItem &item, Preferences &preferences, Re
   file.print("@title ");
   file.println(metadataSafe(item.title));
   file.print("@author ");
-  file.println(metadataSafe(item.author.isEmpty() ? sourceLabelForItem(item) : item.author));
+  file.println(
+      metadataSafe(item.author.isEmpty() ? feedparser::sourceLabelForItem(item) : item.author));
   if (!item.link.isEmpty()) {
     file.print("@source ");
     file.println(metadataSafe(item.link));
@@ -923,147 +508,26 @@ bool RssFeedManager::saveItem(const FeedItem &item, Preferences &preferences, Re
   return true;
 }
 
-bool RssFeedManager::itemAlreadySeen(const FeedItem &item, Preferences &preferences) {
+bool RssFeedManager::itemAlreadySeen(const feedparser::FeedItem &item, Preferences &preferences) {
   return preferences.getBool(seenKeyForItem(item).c_str(), false);
 }
 
-void RssFeedManager::markItemSeen(const FeedItem &item, Preferences &preferences) {
+void RssFeedManager::markItemSeen(const feedparser::FeedItem &item, Preferences &preferences) {
   preferences.putBool(seenKeyForItem(item).c_str(), true);
 }
 
-String RssFeedManager::seenKeyForItem(const FeedItem &item) const {
+String RssFeedManager::seenKeyForItem(const feedparser::FeedItem &item) const {
   char key[16];
   std::snprintf(key, sizeof(key), "rss%08lx", static_cast<unsigned long>(fnv1a(itemIdentity(item))));
   return String(key);
 }
 
-String RssFeedManager::itemIdentity(const FeedItem &item) const {
+String RssFeedManager::itemIdentity(const feedparser::FeedItem &item) const {
   return item.link.isEmpty() ? item.title : item.link;
 }
 
-String RssFeedManager::valueBetween(const String &text, const String &openTag,
-                                    const String &closeTag, size_t start, size_t end) const {
-  const int open = indexOfIgnoreCase(text, openTag.c_str(), start, end);
-  if (open < 0 || static_cast<size_t>(open) >= end) {
-    return "";
-  }
-  const int valueStart = tagEndIndex(text, static_cast<size_t>(open), end);
-  if (valueStart < 0 || static_cast<size_t>(valueStart) >= end) {
-    return "";
-  }
-  const int close = indexOfIgnoreCase(text, closeTag.c_str(), valueStart + 1, end);
-  if (close < 0 || static_cast<size_t>(close) > end) {
-    return "";
-  }
-  return text.substring(valueStart + 1, close);
-}
-
-String RssFeedManager::attributeValue(const String &text, const String &tagPrefix,
-                                      const String &attribute, size_t start, size_t end) const {
-  int tagStart = indexOfIgnoreCase(text, tagPrefix.c_str(), start, end);
-  while (tagStart >= 0 && static_cast<size_t>(tagStart) < end) {
-    const int tagEnd = tagEndIndex(text, static_cast<size_t>(tagStart), end);
-    if (tagEnd < 0 || static_cast<size_t>(tagEnd) > end) {
-      return "";
-    }
-
-    const String needle = attribute + "=";
-    int attrIndex = indexOfIgnoreCase(text, needle.c_str(), tagStart, static_cast<size_t>(tagEnd));
-    if (attrIndex >= 0) {
-      int valueStart = attrIndex + needle.length();
-      while (valueStart < tagEnd && isspace(static_cast<unsigned char>(text[valueStart]))) {
-        ++valueStart;
-      }
-      if (valueStart < tagEnd) {
-        const char quote = text[valueStart];
-        if (quote == '"' || quote == '\'') {
-          ++valueStart;
-          for (int i = valueStart; i < tagEnd; ++i) {
-            if (text[i] == quote) {
-              return text.substring(valueStart, i);
-            }
-          }
-        } else {
-          int valueEnd = valueStart;
-          while (valueEnd < tagEnd && !isspace(static_cast<unsigned char>(text[valueEnd])) &&
-                 text[valueEnd] != '>') {
-            ++valueEnd;
-          }
-          if (valueEnd > valueStart) {
-            return text.substring(valueStart, valueEnd);
-          }
-        }
-      }
-    }
-
-    tagStart = indexOfIgnoreCase(text, tagPrefix.c_str(), static_cast<size_t>(tagEnd + 1), end);
-  }
-  return "";
-}
-
-String RssFeedManager::cleanText(String value) const {
-  value.replace("<![CDATA[", "");
-  value.replace("]]>", "");
-  value = stripHtml(value);
-  value = xmlDecode(value);
-  value.replace("\r", "\n");
-  while (value.indexOf("\n\n\n") >= 0) {
-    value.replace("\n\n\n", "\n\n");
-  }
-  value.trim();
-  return value;
-}
-
-String RssFeedManager::stripHtml(const String &html) const {
-  String output;
-  output.reserve(std::min(static_cast<size_t>(html.length()), kMaxArticleChars));
-  bool inTag = false;
-  for (size_t i = 0; i < html.length(); ++i) {
-    const char c = html[i];
-    if (c == '<') {
-      inTag = true;
-      if (!output.endsWith(" ") && !output.endsWith("\n")) {
-        output += ' ';
-      }
-      continue;
-    }
-    if (c == '>') {
-      inTag = false;
-      continue;
-    }
-    if (!inTag) {
-      output += c;
-    }
-    if (output.length() >= kMaxArticleChars) {
-      break;
-    }
-  }
-  return output;
-}
-
-String RssFeedManager::xmlDecode(String value) const {
-  value = decodeXmlEntitiesOnce(value);
-  if (value.indexOf('&') >= 0) {
-    value = decodeXmlEntitiesOnce(value);
-  }
-  return value;
-}
-
-String RssFeedManager::sourceLabelForItem(const FeedItem &item) const {
-  String source = item.link;
-  if (source.isEmpty()) {
-    return "RSS";
-  }
-
-  source = hostLabelForUrl(source);
-  if (source.isEmpty()) {
-    return "RSS";
-  }
-  return source;
-}
-
-String RssFeedManager::filenameForItem(const FeedItem &item) const {
-  String name = xmlDecode(item.title);
+String RssFeedManager::filenameForItem(const feedparser::FeedItem &item) const {
+  String name = item.title;  // already HTML-stripped and entity-decoded by FeedParser
   String cleaned;
   cleaned.reserve(80);
   for (size_t i = 0; i < name.length() && cleaned.length() < 72; ++i) {

--- a/src/rss/RssFeedManager.h
+++ b/src/rss/RssFeedManager.h
@@ -3,6 +3,7 @@
 #include <Arduino.h>
 #include <Preferences.h>
 
+#include "rss/FeedParser.h"
 #include "update/OtaUpdater.h"
 
 class RssFeedManager {
@@ -21,13 +22,6 @@ class RssFeedManager {
                     StatusCallback callback = nullptr, void *context = nullptr);
 
  private:
-  struct FeedItem {
-    String title;
-    String link;
-    String author;
-    String body;
-  };
-
   bool connectWiFi(const OtaUpdater::Config &wifiConfig, StatusCallback callback, void *context);
   void disconnectWiFi();
   bool fetchUrl(const String &url, String &body, String &error, uint8_t feedIndex,
@@ -35,21 +29,12 @@ class RssFeedManager {
   bool processFeed(const String &feedUrl, const String &feedBody, Preferences &preferences,
                    Result &result, uint8_t feedIndex, uint8_t feedCount, StatusCallback callback,
                    void *context);
-  bool parseNextItem(const String &feedBody, size_t &searchStart, FeedItem &item);
-  bool saveItem(const FeedItem &item, Preferences &preferences, Result &result);
-  bool itemAlreadySeen(const FeedItem &item, Preferences &preferences);
-  void markItemSeen(const FeedItem &item, Preferences &preferences);
-  String seenKeyForItem(const FeedItem &item) const;
-  String itemIdentity(const FeedItem &item) const;
-  String valueBetween(const String &text, const String &openTag, const String &closeTag,
-                      size_t start, size_t end) const;
-  String attributeValue(const String &text, const String &tagPrefix, const String &attribute,
-                        size_t start, size_t end) const;
-  String cleanText(String value) const;
-  String stripHtml(const String &html) const;
-  String xmlDecode(String value) const;
-  String sourceLabelForItem(const FeedItem &item) const;
-  String filenameForItem(const FeedItem &item) const;
+  bool saveItem(const feedparser::FeedItem &item, Preferences &preferences, Result &result);
+  bool itemAlreadySeen(const feedparser::FeedItem &item, Preferences &preferences);
+  void markItemSeen(const feedparser::FeedItem &item, Preferences &preferences);
+  String seenKeyForItem(const feedparser::FeedItem &item) const;
+  String itemIdentity(const feedparser::FeedItem &item) const;
+  String filenameForItem(const feedparser::FeedItem &item) const;
   String metadataSafe(String value) const;
   uint32_t fnv1a(const String &value) const;
   void report(StatusCallback callback, void *context, const String &line1, const String &line2,

--- a/src/settings/PreferenceKeys.h
+++ b/src/settings/PreferenceKeys.h
@@ -1,0 +1,58 @@
+#pragma once
+
+// Canonical registry of device preference keys and the NVS namespace they live
+// in. App (the device UI) and CompanionSyncManager (the web companion) both
+// read and write the same stored settings; before this header each file kept
+// its own copy of these key strings, which could silently drift apart. Keys are
+// short by necessity -- the ESP32 Preferences/NVS key length limit is 15 chars.
+namespace settings {
+
+constexpr const char *kPrefsNamespace = "rsvp";
+
+// Library / reading position.
+constexpr const char *kPrefBookPath = "book";
+constexpr const char *kPrefLegacyWordIndex = "word";
+constexpr const char *kPrefRecentSeq = "seq";
+
+// Reader + display.
+constexpr const char *kPrefWpm = "wpm";
+constexpr const char *kPrefBrightness = "bright";
+constexpr const char *kPrefDarkMode = "dark";
+constexpr const char *kPrefNightMode = "night";
+constexpr const char *kPrefUiLanguage = "ui_lang";
+constexpr const char *kPrefReaderMode = "read_mode";
+constexpr const char *kPrefHandedness = "handed";
+constexpr const char *kPrefPhantomWords = "phantom_on";
+constexpr const char *kPrefFooterMetricMode = "prog_md";
+constexpr const char *kPrefBatteryLabelMode = "bat_md";
+constexpr const char *kPrefScreensaverMode = "scrn_sv";
+constexpr const char *kPrefReaderBatteryVisible = "read_bat";
+constexpr const char *kPrefReaderChapterVisible = "read_ch";
+constexpr const char *kPrefReaderProgressVisible = "read_pct";
+constexpr const char *kPrefReaderFontSize = "font_size";
+constexpr const char *kPrefReaderTypeface = "typeface";
+
+// Typography.
+constexpr const char *kPrefTypographyFocusHighlight = "type_hlt";
+constexpr const char *kPrefTypographyTracking = "type_trk";
+constexpr const char *kPrefTypographyAnchor = "type_anc";
+constexpr const char *kPrefTypographyGuideWidth = "type_wid";
+constexpr const char *kPrefTypographyGuideGap = "type_gap";
+
+// Word pacing.
+constexpr const char *kPrefLegacyPacingLong = "pace_len";
+constexpr const char *kPrefLegacyPacingComplex = "pace_cpx";
+constexpr const char *kPrefLegacyPacingPunctuation = "pace_pnc";
+constexpr const char *kPrefPacingLongMs = "pace_lms";
+constexpr const char *kPrefPacingComplexMs = "pace_cms";
+constexpr const char *kPrefPacingPunctuationMs = "pace_pms";
+constexpr const char *kPrefPauseMode = "pause_md";
+constexpr const char *kPrefAccurateTime = "time_est_a";
+
+// Wi-Fi + OTA.
+constexpr const char *kPrefWifiSsid = "wifi_ssid";
+constexpr const char *kPrefWifiPass = "wifi_pass";
+constexpr const char *kPrefOtaAuto = "ota_auto";
+constexpr const char *kPrefOtaOwner = "ota_owner";
+
+}  // namespace settings

--- a/src/standby/LifeGrid.cpp
+++ b/src/standby/LifeGrid.cpp
@@ -1,0 +1,111 @@
+#include "standby/LifeGrid.h"
+
+#include <algorithm>
+
+namespace standby {
+namespace {
+
+void clearRect(std::vector<uint32_t> &cells, uint16_t columns, uint16_t rows, int x, int y,
+               int width, int height) {
+  const int xEnd = std::min(static_cast<int>(columns), x + width);
+  const int yEnd = std::min(static_cast<int>(rows), y + height);
+  for (int cy = std::max(0, y); cy < yEnd; ++cy) {
+    for (int cx = std::max(0, x); cx < xEnd; ++cx) {
+      setCellAt(cells, columns, rows, cx, cy, false);
+    }
+  }
+}
+
+void stampPattern(std::vector<uint32_t> &cells, uint16_t columns, uint16_t rows,
+                  const LifePoint *points, size_t pointCount, int originX, int originY) {
+  for (size_t i = 0; i < pointCount; ++i) {
+    setCellAt(cells, columns, rows, originX + points[i].x, originY + points[i].y, true);
+  }
+}
+
+}  // namespace
+
+uint32_t advanceRng(uint32_t &rng) {
+  rng = (rng * 1664525UL) + 1013904223UL;
+  return rng;
+}
+
+size_t packedWordCount(size_t cellCount) { return (cellCount + 31U) / 32U; }
+
+bool cellAlive(const std::vector<uint32_t> &cells, size_t index) {
+  const size_t word = index / 32U;
+  if (word >= cells.size()) {
+    return false;
+  }
+  return (cells[word] & (1UL << (index % 32U))) != 0;
+}
+
+void setCell(std::vector<uint32_t> &cells, size_t index, bool alive) {
+  const size_t word = index / 32U;
+  if (word >= cells.size()) {
+    return;
+  }
+  const uint32_t mask = 1UL << (index % 32U);
+  if (alive) {
+    cells[word] |= mask;
+  } else {
+    cells[word] &= ~mask;
+  }
+}
+
+void setCellAt(std::vector<uint32_t> &cells, uint16_t columns, uint16_t rows, int x, int y,
+               bool alive) {
+  if (x < 0 || y < 0 || x >= static_cast<int>(columns) || y >= static_cast<int>(rows)) {
+    return;
+  }
+  setCell(cells, static_cast<size_t>(y) * columns + static_cast<size_t>(x), alive);
+}
+
+void clearAndStampPattern(std::vector<uint32_t> &cells, uint16_t columns, uint16_t rows,
+                          const LifePoint *points, size_t pointCount, int originX, int originY,
+                          int width, int height) {
+  if (originX < 0 || originY < 0 || originX + width > static_cast<int>(columns) ||
+      originY + height > static_cast<int>(rows)) {
+    return;
+  }
+  constexpr int kPatternMargin = 5;
+  clearRect(cells, columns, rows, originX - kPatternMargin, originY - kPatternMargin,
+            width + kPatternMargin * 2, height + kPatternMargin * 2);
+  stampPattern(cells, columns, rows, points, pointCount, originX, originY);
+}
+
+size_t lifeStep(const std::vector<uint32_t> &cur, std::vector<uint32_t> &next, uint16_t columns,
+                uint16_t rows) {
+  const size_t cellCount = static_cast<size_t>(columns) * static_cast<size_t>(rows);
+  next.assign(packedWordCount(cellCount), 0);
+
+  size_t aliveCount = 0;
+  for (uint16_t y = 0; y < rows; ++y) {
+    for (uint16_t x = 0; x < columns; ++x) {
+      uint8_t neighbours = 0;
+      for (int8_t dy = -1; dy <= 1; ++dy) {
+        for (int8_t dx = -1; dx <= 1; ++dx) {
+          if (dx == 0 && dy == 0) {
+            continue;
+          }
+          const uint16_t nx =
+              static_cast<uint16_t>((static_cast<int>(x) + dx + columns) % columns);
+          const uint16_t ny = static_cast<uint16_t>((static_cast<int>(y) + dy + rows) % rows);
+          neighbours +=
+              cellAlive(cur, static_cast<size_t>(ny) * columns + nx) ? 1 : 0;
+        }
+      }
+
+      const size_t index = static_cast<size_t>(y) * columns + x;
+      const bool alive = cellAlive(cur, index);
+      const bool nextAlive = alive ? (neighbours == 2 || neighbours == 3) : (neighbours == 3);
+      setCell(next, index, nextAlive);
+      if (nextAlive) {
+        ++aliveCount;
+      }
+    }
+  }
+  return aliveCount;
+}
+
+}  // namespace standby

--- a/src/standby/LifeGrid.h
+++ b/src/standby/LifeGrid.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+// Packed-bit cell grid shared by the standby screensavers. One bit per cell,
+// 32 cells per word. Pure (no Arduino, no display) so the Game-of-Life rule and
+// the bit packing can be unit tested on the host.
+namespace standby {
+
+struct LifePoint {
+  int8_t x;
+  int8_t y;
+};
+
+// Linear-congruential step; returns the new state and advances rng in place.
+uint32_t advanceRng(uint32_t &rng);
+
+size_t packedWordCount(size_t cellCount);
+bool cellAlive(const std::vector<uint32_t> &cells, size_t index);
+void setCell(std::vector<uint32_t> &cells, size_t index, bool alive);
+void setCellAt(std::vector<uint32_t> &cells, uint16_t columns, uint16_t rows, int x, int y,
+               bool alive);
+
+// Clears a margin-padded rect then stamps a pattern, but only if the pattern
+// fits within the grid. No-op when out of bounds.
+void clearAndStampPattern(std::vector<uint32_t> &cells, uint16_t columns, uint16_t rows,
+                          const LifePoint *points, size_t pointCount, int originX, int originY,
+                          int width, int height);
+
+// Advances one Conway's Game of Life generation on a toroidal grid: reads cur,
+// writes next (resized as needed). Returns the number of live cells in next.
+size_t lifeStep(const std::vector<uint32_t> &cur, std::vector<uint32_t> &next, uint16_t columns,
+                uint16_t rows);
+
+}  // namespace standby

--- a/src/standby/Screensaver.h
+++ b/src/standby/Screensaver.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+// A standby screensaver: an automaton that produces a packed-bit cell grid each
+// frame. App seeds it (with entropy it gathers), steps it on a timer, and hands
+// the resulting grid to DisplayManager::renderLifeScreensaver. Adding a new
+// screensaver means adding an adapter here, not editing App.
+namespace standby {
+
+enum class Kind {
+  Life,
+  Maze,
+  Voronoi,
+};
+
+struct Frame {
+  const std::vector<uint32_t> *cells;     // live cells (packed bits)
+  const std::vector<uint32_t> *dimCells;  // dim cells, or null
+  uint32_t generation;
+};
+
+class Screensaver {
+ public:
+  virtual ~Screensaver() = default;
+
+  // (Re)initialize from a seed. The caller supplies entropy; the screensaver
+  // owns all further randomness, so step() needs no outside state.
+  virtual void seed(uint32_t rngSeed) = 0;
+
+  // Advance one frame. May reseed itself when the pattern stagnates.
+  virtual void step() = 0;
+
+  // The current grid to render. Pointers stay valid until the next seed/step.
+  virtual Frame frame() const = 0;
+};
+
+// Builds the screensaver for a kind, sized to the given grid. Never returns null
+// for a known kind.
+std::unique_ptr<Screensaver> makeScreensaver(Kind kind, uint16_t columns, uint16_t rows);
+
+}  // namespace standby

--- a/src/standby/Screensavers.cpp
+++ b/src/standby/Screensavers.cpp
@@ -1,0 +1,329 @@
+#include "standby/Screensaver.h"
+
+#include <algorithm>
+
+#include "standby/LifeGrid.h"
+
+namespace standby {
+namespace {
+
+// ---------------------------------------------------------------------------
+// Conway's Game of Life: random soup seeded with a few classic patterns.
+// ---------------------------------------------------------------------------
+constexpr LifePoint kGlider[] = {
+    {1, 0}, {2, 1}, {0, 2}, {1, 2}, {2, 2},
+};
+constexpr LifePoint kLightweightSpaceship[] = {
+    {1, 0}, {4, 0}, {0, 1}, {0, 2}, {4, 2}, {0, 3}, {1, 3}, {2, 3}, {3, 3},
+};
+constexpr LifePoint kPentadecathlon[] = {
+    {2, 0}, {2, 1}, {1, 2}, {3, 2}, {2, 3}, {2, 4},
+    {2, 5}, {2, 6}, {1, 7}, {3, 7}, {2, 8}, {2, 9},
+};
+constexpr LifePoint kPulsar[] = {
+    {2, 0},  {3, 0},  {4, 0},  {8, 0},  {9, 0},  {10, 0}, {0, 2},  {5, 2},
+    {7, 2},  {12, 2}, {0, 3},  {5, 3},  {7, 3},  {12, 3}, {0, 4},  {5, 4},
+    {7, 4},  {12, 4}, {2, 5},  {3, 5},  {4, 5},  {8, 5},  {9, 5},  {10, 5},
+    {2, 7},  {3, 7},  {4, 7},  {8, 7},  {9, 7},  {10, 7}, {0, 8},  {5, 8},
+    {7, 8},  {12, 8}, {0, 9},  {5, 9},  {7, 9},  {12, 9}, {0, 10}, {5, 10},
+    {7, 10}, {12, 10}, {2, 12}, {3, 12}, {4, 12}, {8, 12}, {9, 12}, {10, 12},
+};
+constexpr LifePoint kGosperGliderGun[] = {
+    {24, 0}, {22, 1}, {24, 1}, {12, 2}, {13, 2}, {20, 2}, {21, 2}, {34, 2}, {35, 2},
+    {11, 3}, {15, 3}, {20, 3}, {21, 3}, {34, 3}, {35, 3}, {0, 4},  {1, 4},
+    {10, 4}, {16, 4}, {20, 4}, {21, 4}, {0, 5},  {1, 5},  {10, 5}, {14, 5},
+    {16, 5}, {17, 5}, {22, 5}, {24, 5}, {10, 6}, {16, 6}, {24, 6}, {11, 7},
+    {15, 7}, {12, 8}, {13, 8},
+};
+
+template <typename T, size_t N>
+constexpr size_t count(const T (&)[N]) {
+  return N;
+}
+
+class LifeScreensaver : public Screensaver {
+ public:
+  LifeScreensaver(uint16_t columns, uint16_t rows) : columns_(columns), rows_(rows) {}
+
+  void seed(uint32_t rngSeed) override {
+    rng_ = rngSeed;
+    const size_t cellCount = static_cast<size_t>(columns_) * rows_;
+    cells_.assign(packedWordCount(cellCount), 0);
+    generation_ = 0;
+
+    for (size_t i = 0; i < cellCount; ++i) {
+      setCell(cells_, i, (advanceRng(rng_) >> 24) < 12);
+    }
+
+    clearAndStampPattern(cells_, columns_, rows_, kGosperGliderGun, count(kGosperGliderGun), 18, 18,
+                         36, 9);
+    clearAndStampPattern(cells_, columns_, rows_, kGosperGliderGun, count(kGosperGliderGun),
+                         static_cast<int>(columns_) - 62, static_cast<int>(rows_) - 34, 36, 9);
+    clearAndStampPattern(cells_, columns_, rows_, kPulsar, count(kPulsar),
+                         static_cast<int>(columns_ / 2) - 7, static_cast<int>(rows_ / 2) - 7, 13,
+                         13);
+    clearAndStampPattern(cells_, columns_, rows_, kPentadecathlon, count(kPentadecathlon),
+                         static_cast<int>(columns_ / 3), static_cast<int>(rows_) - 42, 5, 10);
+    clearAndStampPattern(cells_, columns_, rows_, kLightweightSpaceship,
+                         count(kLightweightSpaceship), static_cast<int>((columns_ * 2) / 3),
+                         static_cast<int>(rows_ / 3), 5, 4);
+
+    for (uint8_t i = 0; i < 10; ++i) {
+      const int x = static_cast<int>((advanceRng(rng_) >> 8) % std::max<uint16_t>(1, columns_ - 6));
+      const int y = static_cast<int>((advanceRng(rng_) >> 8) % std::max<uint16_t>(1, rows_ - 6));
+      clearAndStampPattern(cells_, columns_, rows_, kGlider, count(kGlider), x, y, 3, 3);
+    }
+  }
+
+  void step() override {
+    const size_t cellCount = static_cast<size_t>(columns_) * rows_;
+    if (cells_.size() != packedWordCount(cellCount)) {
+      seed(advanceRng(rng_));
+      return;
+    }
+    const size_t aliveCount = lifeStep(cells_, next_, columns_, rows_);
+    cells_.swap(next_);
+    ++generation_;
+    if (aliveCount == 0 || aliveCount > (cellCount * 3) / 4) {
+      seed(advanceRng(rng_));
+    }
+  }
+
+  Frame frame() const override { return Frame{&cells_, nullptr, generation_}; }
+
+ private:
+  uint16_t columns_;
+  uint16_t rows_;
+  uint32_t rng_ = 1;
+  uint32_t generation_ = 0;
+  std::vector<uint32_t> cells_;
+  std::vector<uint32_t> next_;
+};
+
+// ---------------------------------------------------------------------------
+// Depth-first maze carve, rendered into the same packed grid.
+// ---------------------------------------------------------------------------
+class MazeScreensaver : public Screensaver {
+ public:
+  MazeScreensaver(uint16_t columns, uint16_t rows) : columns_(columns), rows_(rows) {}
+
+  void seed(uint32_t rngSeed) override {
+    rng_ = rngSeed;
+    const size_t cellCount = static_cast<size_t>(columns_) * rows_;
+    const uint16_t mazeColumns = std::max<uint16_t>(1, (columns_ - 1) / 2);
+    const uint16_t mazeRows = std::max<uint16_t>(1, (rows_ - 1) / 2);
+    cells_.assign(packedWordCount(cellCount), 0);
+    visited_.assign(static_cast<size_t>(mazeColumns) * mazeRows, 0);
+    stack_.clear();
+    generation_ = 0;
+
+    const uint16_t startX = static_cast<uint16_t>((advanceRng(rng_) >> 8) % mazeColumns);
+    const uint16_t startY = static_cast<uint16_t>((advanceRng(rng_) >> 8) % mazeRows);
+    visited_[static_cast<size_t>(startY) * mazeColumns + startX] = 1;
+    stack_.push_back(static_cast<uint16_t>(startY * mazeColumns + startX));
+    setCellAt(cells_, columns_, rows_, static_cast<int>(startX) * 2 + 1,
+              static_cast<int>(startY) * 2 + 1, true);
+  }
+
+  void step() override {
+    const uint16_t mazeColumns = std::max<uint16_t>(1, (columns_ - 1) / 2);
+    const uint16_t mazeRows = std::max<uint16_t>(1, (rows_ - 1) / 2);
+    const size_t mazeCellCount = static_cast<size_t>(mazeColumns) * mazeRows;
+    if (visited_.size() != mazeCellCount || stack_.empty()) {
+      if (stack_.empty() && generation_ < 600) {
+        ++generation_;
+        return;
+      }
+      seed(advanceRng(rng_));
+      return;
+    }
+
+    constexpr uint8_t kStepsPerFrame = 32;
+    for (uint8_t step = 0; step < kStepsPerFrame && !stack_.empty(); ++step) {
+      const uint16_t current = stack_.back();
+      const uint16_t cx = current % mazeColumns;
+      const uint16_t cy = current / mazeColumns;
+      uint16_t candidates[4];
+      uint8_t candidateCount = 0;
+
+      auto addCandidate = [&](int nx, int ny) {
+        if (nx < 0 || ny < 0 || nx >= static_cast<int>(mazeColumns) ||
+            ny >= static_cast<int>(mazeRows)) {
+          return;
+        }
+        const uint16_t encoded = static_cast<uint16_t>(ny * mazeColumns + nx);
+        if (visited_[encoded] == 0) {
+          candidates[candidateCount++] = encoded;
+        }
+      };
+
+      addCandidate(static_cast<int>(cx) + 1, cy);
+      addCandidate(static_cast<int>(cx) - 1, cy);
+      addCandidate(cx, static_cast<int>(cy) + 1);
+      addCandidate(cx, static_cast<int>(cy) - 1);
+
+      if (candidateCount == 0) {
+        stack_.pop_back();
+        continue;
+      }
+
+      const uint16_t next = candidates[(advanceRng(rng_) >> 16) % candidateCount];
+      const uint16_t nx = next % mazeColumns;
+      const uint16_t ny = next / mazeColumns;
+      visited_[next] = 1;
+      stack_.push_back(next);
+
+      const int displayCx = static_cast<int>(cx) * 2 + 1;
+      const int displayCy = static_cast<int>(cy) * 2 + 1;
+      const int displayNx = static_cast<int>(nx) * 2 + 1;
+      const int displayNy = static_cast<int>(ny) * 2 + 1;
+      setCellAt(cells_, columns_, rows_, displayNx, displayNy, true);
+      setCellAt(cells_, columns_, rows_, (displayCx + displayNx) / 2, (displayCy + displayNy) / 2,
+                true);
+    }
+
+    if (stack_.empty()) {
+      generation_ = 0;
+    } else {
+      ++generation_;
+    }
+  }
+
+  Frame frame() const override { return Frame{&cells_, nullptr, generation_}; }
+
+ private:
+  uint16_t columns_;
+  uint16_t rows_;
+  uint32_t rng_ = 1;
+  uint32_t generation_ = 0;
+  std::vector<uint32_t> cells_;
+  std::vector<uint8_t> visited_;
+  std::vector<uint16_t> stack_;
+};
+
+// ---------------------------------------------------------------------------
+// Moving Voronoi sites; cell edges are lit, near-edges dimmed.
+// ---------------------------------------------------------------------------
+constexpr size_t kVoronoiSiteCount = 15;
+
+class VoronoiScreensaver : public Screensaver {
+ public:
+  VoronoiScreensaver(uint16_t columns, uint16_t rows) : columns_(columns), rows_(rows) {}
+
+  void seed(uint32_t rngSeed) override {
+    rng_ = rngSeed;
+    generation_ = 0;
+    vx_.assign(kVoronoiSiteCount, 0);
+    vy_.assign(kVoronoiSiteCount, 0);
+    vdx_.assign(kVoronoiSiteCount, 0);
+    vdy_.assign(kVoronoiSiteCount, 0);
+    for (size_t i = 0; i < kVoronoiSiteCount; ++i) {
+      vx_[i] = static_cast<int16_t>(((advanceRng(rng_) >> 8) % columns_) * 16);
+      vy_[i] = static_cast<int16_t>(((advanceRng(rng_) >> 8) % rows_) * 16);
+      const int16_t dx = static_cast<int16_t>(4 + ((advanceRng(rng_) >> 24) % 7));
+      const int16_t dy = static_cast<int16_t>(3 + ((advanceRng(rng_) >> 24) % 6));
+      vdx_[i] = (advanceRng(rng_) & 1U) != 0 ? dx : static_cast<int16_t>(-dx);
+      vdy_[i] = (advanceRng(rng_) & 1U) != 0 ? dy : static_cast<int16_t>(-dy);
+    }
+    render();
+  }
+
+  void step() override {
+    if (vx_.size() != kVoronoiSiteCount) {
+      seed(advanceRng(rng_));
+      return;
+    }
+
+    const int16_t maxX = static_cast<int16_t>((columns_ - 1) * 16);
+    const int16_t maxY = static_cast<int16_t>((rows_ - 1) * 16);
+    for (size_t i = 0; i < vx_.size(); ++i) {
+      int16_t nextX = static_cast<int16_t>(vx_[i] + vdx_[i]);
+      int16_t nextY = static_cast<int16_t>(vy_[i] + vdy_[i]);
+      if (nextX < 0 || nextX > maxX) {
+        vdx_[i] = static_cast<int16_t>(-vdx_[i]);
+        nextX = std::max<int16_t>(0, std::min<int16_t>(maxX, nextX));
+      }
+      if (nextY < 0 || nextY > maxY) {
+        vdy_[i] = static_cast<int16_t>(-vdy_[i]);
+        nextY = std::max<int16_t>(0, std::min<int16_t>(maxY, nextY));
+      }
+      vx_[i] = nextX;
+      vy_[i] = nextY;
+    }
+
+    ++generation_;
+    if (generation_ > 2400) {
+      seed(advanceRng(rng_));
+      return;
+    }
+    render();
+  }
+
+  Frame frame() const override { return Frame{&cells_, &dimCells_, generation_}; }
+
+ private:
+  void render() {
+    const size_t cellCount = static_cast<size_t>(columns_) * rows_;
+    const size_t wordCount = packedWordCount(cellCount);
+    cells_.assign(wordCount, 0);
+    dimCells_.assign(wordCount, 0);
+    if (vx_.empty()) {
+      return;
+    }
+
+    for (uint16_t y = 0; y < rows_; ++y) {
+      const int32_t cellY = static_cast<int32_t>(y) * 16 + 8;
+      for (uint16_t x = 0; x < columns_; ++x) {
+        const int32_t cellX = static_cast<int32_t>(x) * 16 + 8;
+        int32_t nearest = INT32_MAX;
+        int32_t secondNearest = INT32_MAX;
+        for (size_t i = 0; i < vx_.size(); ++i) {
+          const int32_t dx = cellX - vx_[i];
+          const int32_t dy = cellY - vy_[i];
+          const int32_t distance = dx * dx + dy * dy;
+          if (distance < nearest) {
+            secondNearest = nearest;
+            nearest = distance;
+          } else if (distance < secondNearest) {
+            secondNearest = distance;
+          }
+        }
+
+        const size_t index = static_cast<size_t>(y) * columns_ + x;
+        const int32_t gap = secondNearest - nearest;
+        if (nearest < 1200 || gap < 190) {
+          setCell(cells_, index, true);
+        } else if (gap < 580 + nearest / 180) {
+          setCell(dimCells_, index, true);
+        }
+      }
+    }
+  }
+
+  uint16_t columns_;
+  uint16_t rows_;
+  uint32_t rng_ = 1;
+  uint32_t generation_ = 0;
+  std::vector<uint32_t> cells_;
+  std::vector<uint32_t> dimCells_;
+  std::vector<int16_t> vx_;
+  std::vector<int16_t> vy_;
+  std::vector<int16_t> vdx_;
+  std::vector<int16_t> vdy_;
+};
+
+}  // namespace
+
+std::unique_ptr<Screensaver> makeScreensaver(Kind kind, uint16_t columns, uint16_t rows) {
+  switch (kind) {
+    case Kind::Maze:
+      return std::unique_ptr<Screensaver>(new MazeScreensaver(columns, rows));
+    case Kind::Voronoi:
+      return std::unique_ptr<Screensaver>(new VoronoiScreensaver(columns, rows));
+    case Kind::Life:
+    default:
+      return std::unique_ptr<Screensaver>(new LifeScreensaver(columns, rows));
+  }
+}
+
+}  // namespace standby

--- a/src/sync/CompanionSyncManager.cpp
+++ b/src/sync/CompanionSyncManager.cpp
@@ -7,7 +7,13 @@
 #include <cstdio>
 #include <vector>
 
+#include "settings/PreferenceKeys.h"
+
 namespace {
+
+// Preference keys + NVS namespace are defined once in settings/PreferenceKeys.h
+// and shared with the device UI; pull them in so call sites are unchanged.
+using namespace settings;
 
 constexpr const char *kMdnsName = "rsvp-nano";
 constexpr const char *kBooksPath = "/books";
@@ -15,38 +21,10 @@ constexpr const char *kBookFilesPath = "/books/books";
 constexpr const char *kArticleFilesPath = "/books/articles";
 constexpr const char *kConfigPath = "/config";
 constexpr const char *kRssConfigPath = "/config/rss.conf";
-constexpr const char *kPrefsNamespace = "rsvp";
 constexpr size_t kMaxMetadataLineChars = 160;
 constexpr size_t kMaxSettingsPatchBytes = 2048;
 constexpr size_t kMaxRssFeedsPatchBytes = 4096;
 constexpr size_t kMaxRssFeeds = 24;
-constexpr const char *kPrefWpm = "wpm";
-constexpr const char *kPrefBrightness = "bright";
-constexpr const char *kPrefDarkMode = "dark";
-constexpr const char *kPrefNightMode = "night";
-constexpr const char *kPrefUiLanguage = "ui_lang";
-constexpr const char *kPrefReaderMode = "read_mode";
-constexpr const char *kPrefHandedness = "handed";
-constexpr const char *kPrefPhantomWords = "phantom_on";
-constexpr const char *kPrefFooterMetricMode = "prog_md";
-constexpr const char *kPrefBatteryLabelMode = "bat_md";
-constexpr const char *kPrefReaderBatteryVisible = "read_bat";
-constexpr const char *kPrefReaderChapterVisible = "read_ch";
-constexpr const char *kPrefReaderProgressVisible = "read_pct";
-constexpr const char *kPrefReaderFontSize = "font_size";
-constexpr const char *kPrefReaderTypeface = "typeface";
-constexpr const char *kPrefTypographyFocusHighlight = "type_hlt";
-constexpr const char *kPrefPacingLongMs = "pace_lms";
-constexpr const char *kPrefPacingComplexMs = "pace_cms";
-constexpr const char *kPrefPacingPunctuationMs = "pace_pms";
-constexpr const char *kPrefPauseMode = "pause_md";
-constexpr const char *kPrefAccurateTime = "time_est_a";
-constexpr const char *kPrefTypographyTracking = "type_trk";
-constexpr const char *kPrefTypographyAnchor = "type_anc";
-constexpr const char *kPrefTypographyGuideWidth = "type_wid";
-constexpr const char *kPrefTypographyGuideGap = "type_gap";
-constexpr const char *kPrefWifiSsid = "wifi_ssid";
-constexpr const char *kPrefWifiPass = "wifi_pass";
 constexpr uint16_t kDefaultWpm = 300;
 constexpr uint16_t kMinWpm = 10;
 constexpr uint16_t kMaxWpm = 1000;

--- a/src/update/OtaUpdater.cpp
+++ b/src/update/OtaUpdater.cpp
@@ -8,6 +8,9 @@
 #include <WiFi.h>
 #include <WiFiClientSecure.h>
 
+#include "net/WifiConnection.h"
+#include "update/ReleaseParser.h"
+
 #ifndef RSVP_FIRMWARE_VERSION
 #define RSVP_FIRMWARE_VERSION "dev"
 #endif
@@ -18,27 +21,11 @@ constexpr const char *kConfigPaths[] = {
     "/config/ota.conf",
     "/ota.conf",
 };
-constexpr uint32_t kWifiConnectTimeoutMs = 15000;
-constexpr uint32_t kWifiConnectPollMs = 250;
 constexpr size_t kMaxReleaseJsonBytes = 32768;
 constexpr const char *kStatusTitle = "OTA";
 const char *kRedirectHeaderKeys[] = {
     "Location",
 };
-
-bool isAsciiWhitespace(char c) {
-  switch (c) {
-    case ' ':
-    case '\t':
-    case '\n':
-    case '\r':
-    case '\f':
-    case '\v':
-      return true;
-    default:
-      return false;
-  }
-}
 
 String trimCopy(String value) {
   value.trim();
@@ -49,125 +36,6 @@ bool parseBoolValue(const String &value) {
   String lowered = trimCopy(value);
   lowered.toLowerCase();
   return lowered == "1" || lowered == "true" || lowered == "yes" || lowered == "on";
-}
-
-String jsonUnescape(const String &input) {
-  String output;
-  output.reserve(input.length());
-
-  bool escaping = false;
-  for (size_t i = 0; i < input.length(); ++i) {
-    const char c = input[i];
-    if (escaping) {
-      switch (c) {
-        case '"':
-        case '\\':
-        case '/':
-          output += c;
-          break;
-        case 'b':
-          output += '\b';
-          break;
-        case 'f':
-          output += '\f';
-          break;
-        case 'n':
-          output += '\n';
-          break;
-        case 'r':
-          output += '\r';
-          break;
-        case 't':
-          output += '\t';
-          break;
-        default:
-          output += c;
-          break;
-      }
-      escaping = false;
-      continue;
-    }
-
-    if (c == '\\') {
-      escaping = true;
-      continue;
-    }
-
-    output += c;
-  }
-
-  return output;
-}
-
-bool parseJsonStringAt(const String &json, int quoteIndex, String &value) {
-  if (quoteIndex < 0 || static_cast<size_t>(quoteIndex) >= json.length() ||
-      json[quoteIndex] != '"') {
-    return false;
-  }
-
-  String raw;
-  raw.reserve(64);
-  bool escaping = false;
-  for (size_t i = static_cast<size_t>(quoteIndex) + 1; i < json.length(); ++i) {
-    const char c = json[i];
-    if (!escaping && c == '"') {
-      value = jsonUnescape(raw);
-      return true;
-    }
-
-    raw += c;
-    if (escaping) {
-      escaping = false;
-    } else if (c == '\\') {
-      escaping = true;
-    }
-  }
-
-  return false;
-}
-
-bool extractJsonStringValue(const String &json, const char *key, size_t searchStart, String &value,
-                            int *keyPosition = nullptr) {
-  const String pattern = "\"" + String(key) + "\"";
-  const int keyIndex = json.indexOf(pattern, static_cast<unsigned int>(searchStart));
-  if (keyIndex < 0) {
-    return false;
-  }
-
-  const int colonIndex = json.indexOf(':', keyIndex + pattern.length());
-  if (colonIndex < 0) {
-    return false;
-  }
-
-  int quoteIndex = colonIndex + 1;
-  while (static_cast<size_t>(quoteIndex) < json.length() && isAsciiWhitespace(json[quoteIndex])) {
-    ++quoteIndex;
-  }
-  if (static_cast<size_t>(quoteIndex) >= json.length() || json[quoteIndex] != '"') {
-    return false;
-  }
-
-  if (keyPosition != nullptr) {
-    *keyPosition = keyIndex;
-  }
-  return parseJsonStringAt(json, quoteIndex, value);
-}
-
-bool extractAssetDownloadUrl(const String &json, const String &assetName, String &assetUrl) {
-  size_t searchStart = 0;
-  String candidateName;
-  int nameKeyIndex = -1;
-  while (extractJsonStringValue(json, "name", searchStart, candidateName, &nameKeyIndex)) {
-    if (candidateName == assetName &&
-        extractJsonStringValue(json, "browser_download_url",
-                               static_cast<size_t>(std::max(0, nameKeyIndex)), assetUrl)) {
-      return true;
-    }
-
-    searchStart = static_cast<size_t>(nameKeyIndex) + 1;
-  }
-
-  return false;
 }
 
 String readBodyLimited(HTTPClient &http, size_t maxBytes) {
@@ -297,26 +165,12 @@ bool OtaUpdater::loadConfigFromPath(const char *path, Config &config) const {
 
 bool OtaUpdater::connectWiFi(const Config &config, StatusCallback callback,
                              void *context) const {
-  WiFi.persistent(false);
-  WiFi.setAutoReconnect(false);
-  WiFi.mode(WIFI_STA);
-  WiFi.begin(config.wifiSsid.c_str(), config.wifiPassword.c_str());
-
-  const uint32_t startMs = millis();
-  while (WiFi.status() != WL_CONNECTED && millis() - startMs < kWifiConnectTimeoutMs) {
-    const uint32_t elapsedMs = millis() - startMs;
-    const int progress = 5 + static_cast<int>((elapsedMs * 15) / kWifiConnectTimeoutMs);
-    reportStatus(callback, context, kStatusTitle, "Connecting Wi-Fi", config.wifiSsid, progress);
-    delay(kWifiConnectPollMs);
-  }
-
-  return WiFi.status() == WL_CONNECTED;
+  return net::connectStation(config.wifiSsid, config.wifiPassword, [&](int percent) {
+    reportStatus(callback, context, kStatusTitle, "Connecting Wi-Fi", config.wifiSsid, percent);
+  });
 }
 
-void OtaUpdater::disconnectWiFi() const {
-  WiFi.disconnect(true, false);
-  WiFi.mode(WIFI_OFF);
-}
+void OtaUpdater::disconnectWiFi() const { net::disconnect(); }
 
 bool OtaUpdater::fetchLatestRelease(const Config &config, LatestRelease &release,
                                     String &errorDetail, StatusCallback callback,
@@ -357,13 +211,15 @@ bool OtaUpdater::fetchLatestRelease(const Config &config, LatestRelease &release
   const String body = readBodyLimited(http, kMaxReleaseJsonBytes);
   http.end();
 
-  if (!extractJsonStringValue(body, "tag_name", 0, release.tagName) || release.tagName.isEmpty()) {
+  releaseparser::ReleaseInfo parsed;
+  if (!releaseparser::parse(body, config.assetName, parsed)) {
     errorDetail = "Release tag missing";
     return false;
   }
+  release.tagName = parsed.tagName;
+  release.assetUrl = parsed.assetUrl;
 
-  if (!extractAssetDownloadUrl(body, config.assetName, release.assetUrl) ||
-      release.assetUrl.isEmpty()) {
+  if (release.assetUrl.isEmpty()) {
     errorDetail = config.assetName + " missing";
     return false;
   }

--- a/src/update/ReleaseParser.cpp
+++ b/src/update/ReleaseParser.cpp
@@ -1,0 +1,151 @@
+#include "update/ReleaseParser.h"
+
+#include <algorithm>
+
+namespace releaseparser {
+namespace {
+
+bool isAsciiWhitespace(char c) {
+  switch (c) {
+    case ' ':
+    case '\t':
+    case '\n':
+    case '\r':
+    case '\f':
+    case '\v':
+      return true;
+    default:
+      return false;
+  }
+}
+
+String jsonUnescape(const String &input) {
+  String output;
+  output.reserve(input.length());
+
+  bool escaping = false;
+  for (size_t i = 0; i < input.length(); ++i) {
+    const char c = input[i];
+    if (escaping) {
+      switch (c) {
+        case '"':
+        case '\\':
+        case '/':
+          output += c;
+          break;
+        case 'b':
+          output += '\b';
+          break;
+        case 'f':
+          output += '\f';
+          break;
+        case 'n':
+          output += '\n';
+          break;
+        case 'r':
+          output += '\r';
+          break;
+        case 't':
+          output += '\t';
+          break;
+        default:
+          output += c;
+          break;
+      }
+      escaping = false;
+      continue;
+    }
+
+    if (c == '\\') {
+      escaping = true;
+      continue;
+    }
+
+    output += c;
+  }
+
+  return output;
+}
+
+bool parseJsonStringAt(const String &json, int quoteIndex, String &value) {
+  if (quoteIndex < 0 || static_cast<size_t>(quoteIndex) >= json.length() ||
+      json[quoteIndex] != '"') {
+    return false;
+  }
+
+  String raw;
+  raw.reserve(64);
+  bool escaping = false;
+  for (size_t i = static_cast<size_t>(quoteIndex) + 1; i < json.length(); ++i) {
+    const char c = json[i];
+    if (!escaping && c == '"') {
+      value = jsonUnescape(raw);
+      return true;
+    }
+
+    raw += c;
+    if (escaping) {
+      escaping = false;
+    } else if (c == '\\') {
+      escaping = true;
+    }
+  }
+
+  return false;
+}
+
+bool extractJsonStringValue(const String &json, const char *key, size_t searchStart, String &value,
+                            int *keyPosition = nullptr) {
+  const String pattern = "\"" + String(key) + "\"";
+  const int keyIndex = json.indexOf(pattern, static_cast<unsigned int>(searchStart));
+  if (keyIndex < 0) {
+    return false;
+  }
+
+  const int colonIndex = json.indexOf(':', keyIndex + pattern.length());
+  if (colonIndex < 0) {
+    return false;
+  }
+
+  int quoteIndex = colonIndex + 1;
+  while (static_cast<size_t>(quoteIndex) < json.length() && isAsciiWhitespace(json[quoteIndex])) {
+    ++quoteIndex;
+  }
+  if (static_cast<size_t>(quoteIndex) >= json.length() || json[quoteIndex] != '"') {
+    return false;
+  }
+
+  if (keyPosition != nullptr) {
+    *keyPosition = keyIndex;
+  }
+  return parseJsonStringAt(json, quoteIndex, value);
+}
+
+bool extractAssetDownloadUrl(const String &json, const String &assetName, String &assetUrl) {
+  size_t searchStart = 0;
+  String candidateName;
+  int nameKeyIndex = -1;
+  while (extractJsonStringValue(json, "name", searchStart, candidateName, &nameKeyIndex)) {
+    if (candidateName == assetName &&
+        extractJsonStringValue(json, "browser_download_url",
+                               static_cast<size_t>(std::max(0, nameKeyIndex)), assetUrl)) {
+      return true;
+    }
+
+    searchStart = static_cast<size_t>(nameKeyIndex) + 1;
+  }
+
+  return false;
+}
+
+}  // namespace
+
+bool parse(const String &json, const String &assetName, ReleaseInfo &out) {
+  out = ReleaseInfo();
+  const bool haveTag = extractJsonStringValue(json, "tag_name", 0, out.tagName) &&
+                       !out.tagName.isEmpty();
+  extractAssetDownloadUrl(json, assetName, out.assetUrl);
+  return haveTag;
+}
+
+}  // namespace releaseparser

--- a/src/update/ReleaseParser.h
+++ b/src/update/ReleaseParser.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <Arduino.h>
+
+// Pure parsing of a GitHub "releases/latest" JSON payload. No networking, no
+// SD access -- safe to unit test on the host with the Arduino String shim.
+namespace releaseparser {
+
+struct ReleaseInfo {
+  String tagName;   // empty if the payload had no usable tag_name
+  String assetUrl;  // empty if no asset matched assetName
+};
+
+// Extracts the release tag and the browser_download_url of the asset whose
+// "name" equals assetName. Fills whatever it finds; missing fields stay empty.
+// Returns true when a non-empty tag was found.
+bool parse(const String &json, const String &assetName, ReleaseInfo &out);
+
+}  // namespace releaseparser

--- a/test/support/Arduino.h
+++ b/test/support/Arduino.h
@@ -4,6 +4,7 @@
 #include <cctype>
 #include <cstddef>
 #include <cstdint>
+#include <cstdio>
 #include <cstring>
 #include <string>
 
@@ -14,6 +15,11 @@ class String {
   String() = default;
   String(const char *cs) : s_(cs ? cs : "") {}
   String(char c) : s_(1, c) {}
+  String(const std::string &s) : s_(s) {}
+  String(int value) : s_(std::to_string(value)) {}
+  String(unsigned int value) : s_(std::to_string(value)) {}
+  String(long value) : s_(std::to_string(value)) {}
+  String(unsigned long value) : s_(std::to_string(value)) {}
   String(const String &) = default;
   String(String &&) = default;
   String &operator=(const String &) = default;
@@ -33,9 +39,31 @@ class String {
     s_ += c;
     return *this;
   }
+  String &operator+=(const char *cs) {
+    if (cs) s_ += cs;
+    return *this;
+  }
   String &operator+=(const String &o) {
     s_ += o.s_;
     return *this;
+  }
+
+  friend String operator+(String lhs, const String &rhs) {
+    lhs.s_ += rhs.s_;
+    return lhs;
+  }
+  friend String operator+(String lhs, const char *rhs) {
+    if (rhs) lhs.s_ += rhs;
+    return lhs;
+  }
+  friend String operator+(String lhs, char rhs) {
+    lhs.s_ += rhs;
+    return lhs;
+  }
+  friend String operator+(const char *lhs, const String &rhs) {
+    String out(lhs);
+    out.s_ += rhs.s_;
+    return out;
   }
 
   bool operator==(const char *cs) const { return s_ == (cs ? cs : ""); }
@@ -45,6 +73,14 @@ class String {
 
   void reserve(size_t n) { s_.reserve(n); }
 
+  bool startsWith(const char *prefix) const {
+    if (!prefix) return false;
+    const size_t pl = std::strlen(prefix);
+    if (pl > s_.size()) return false;
+    return s_.compare(0, pl, prefix) == 0;
+  }
+  bool startsWith(const String &prefix) const { return startsWith(prefix.s_.c_str()); }
+
   bool endsWith(const char *suffix) const {
     if (!suffix) return false;
     const size_t sl = std::strlen(suffix);
@@ -53,8 +89,70 @@ class String {
   }
   bool endsWith(const String &suffix) const { return endsWith(suffix.s_.c_str()); }
 
+  int indexOf(char c, unsigned int from = 0) const {
+    const size_t pos = s_.find(c, from);
+    return pos == std::string::npos ? -1 : static_cast<int>(pos);
+  }
+  int indexOf(const char *needle, unsigned int from = 0) const {
+    if (!needle) return -1;
+    const size_t pos = s_.find(needle, from);
+    return pos == std::string::npos ? -1 : static_cast<int>(pos);
+  }
+  int indexOf(const String &needle, unsigned int from = 0) const {
+    return indexOf(needle.s_.c_str(), from);
+  }
+  int lastIndexOf(char c) const {
+    const size_t pos = s_.rfind(c);
+    return pos == std::string::npos ? -1 : static_cast<int>(pos);
+  }
+
+  String substring(unsigned int beginIndex) const {
+    if (beginIndex >= s_.size()) return String();
+    return String(s_.substr(beginIndex));
+  }
+  String substring(unsigned int beginIndex, unsigned int endIndex) const {
+    if (beginIndex > endIndex) std::swap(beginIndex, endIndex);
+    if (beginIndex >= s_.size()) return String();
+    endIndex = std::min(endIndex, static_cast<unsigned int>(s_.size()));
+    return String(s_.substr(beginIndex, endIndex - beginIndex));
+  }
+
+  void replace(const char *find, const char *repl) {
+    if (!find || !*find) return;
+    const std::string f(find);
+    const std::string r(repl ? repl : "");
+    size_t pos = 0;
+    while ((pos = s_.find(f, pos)) != std::string::npos) {
+      s_.replace(pos, f.size(), r);
+      pos += r.size();
+    }
+  }
+  void replace(const String &find, const String &repl) {
+    replace(find.s_.c_str(), repl.s_.c_str());
+  }
+
+  void remove(unsigned int index, unsigned int count) {
+    if (index >= s_.size()) return;
+    s_.erase(index, count);
+  }
+  void remove(unsigned int index) {
+    if (index >= s_.size()) return;
+    s_.erase(index);
+  }
+
+  void trim() {
+    size_t begin = 0;
+    while (begin < s_.size() && std::isspace(static_cast<unsigned char>(s_[begin]))) ++begin;
+    size_t end = s_.size();
+    while (end > begin && std::isspace(static_cast<unsigned char>(s_[end - 1]))) --end;
+    s_ = s_.substr(begin, end - begin);
+  }
+
   void toLowerCase() {
     for (char &c : s_) c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+  }
+  void toUpperCase() {
+    for (char &c : s_) c = static_cast<char>(std::toupper(static_cast<unsigned char>(c)));
   }
 
   const char *c_str() const { return s_.c_str(); }

--- a/test/test_feed_parser/test_main.cpp
+++ b/test/test_feed_parser/test_main.cpp
@@ -1,0 +1,127 @@
+#include <unity.h>
+
+#include "rss/FeedParser.h"
+
+namespace {
+
+feedparser::FeedItem firstItem(const String &feed) {
+  size_t cursor = 0;
+  feedparser::FeedItem item;
+  feedparser::parseNextItem(feed, cursor, item);
+  return item;
+}
+
+}  // namespace
+
+void test_parses_rss_item_fields() {
+  const String feed =
+      "<rss><channel>"
+      "<item>"
+      "<title>Hello World</title>"
+      "<link>https://example.com/a</link>"
+      "<description>Body text here.</description>"
+      "</item>"
+      "</channel></rss>";
+  const feedparser::FeedItem item = firstItem(feed);
+  TEST_ASSERT_EQUAL_STRING("Hello World", item.title.c_str());
+  TEST_ASSERT_EQUAL_STRING("https://example.com/a", item.link.c_str());
+  TEST_ASSERT_EQUAL_STRING("Body text here.", item.body.c_str());
+}
+
+void test_parses_atom_entry_with_href_link() {
+  const String feed =
+      "<feed>"
+      "<entry>"
+      "<title>Atom Title</title>"
+      "<link href=\"https://example.com/atom\"/>"
+      "<summary>Summary body.</summary>"
+      "</entry>"
+      "</feed>";
+  const feedparser::FeedItem item = firstItem(feed);
+  TEST_ASSERT_EQUAL_STRING("Atom Title", item.title.c_str());
+  TEST_ASSERT_EQUAL_STRING("https://example.com/atom", item.link.c_str());
+  TEST_ASSERT_EQUAL_STRING("Summary body.", item.body.c_str());
+}
+
+void test_decodes_entities_and_strips_html() {
+  // stripHtml runs before entity decoding, so real markup tags become spaces
+  // and named entities decode to their character.
+  const String feed =
+      "<rss><channel><item>"
+      "<title>Tom &amp; Jerry</title>"
+      "<link>https://example.com/x</link>"
+      "<description><p>Hello <b>there</b></p></description>"
+      "</item></channel></rss>";
+  const feedparser::FeedItem item = firstItem(feed);
+  TEST_ASSERT_EQUAL_STRING("Tom & Jerry", item.title.c_str());
+  TEST_ASSERT_EQUAL_STRING("Hello there", item.body.c_str());
+}
+
+void test_unwraps_cdata_in_body() {
+  const String feed =
+      "<rss><channel><item>"
+      "<title>T</title>"
+      "<link>https://example.com/y</link>"
+      "<description><![CDATA[Plain cdata text]]></description>"
+      "</item></channel></rss>";
+  const feedparser::FeedItem item = firstItem(feed);
+  TEST_ASSERT_EQUAL_STRING("Plain cdata text", item.body.c_str());
+}
+
+void test_falls_back_to_host_for_author() {
+  const String feed =
+      "<rss><channel><item>"
+      "<title>No Author</title>"
+      "<link>https://www.example.com/post</link>"
+      "<description>Body.</description>"
+      "</item></channel></rss>";
+  const feedparser::FeedItem item = firstItem(feed);
+  TEST_ASSERT_EQUAL_STRING("example.com", item.author.c_str());
+}
+
+void test_prefers_dc_creator_author() {
+  const String feed =
+      "<rss><channel><item>"
+      "<title>T</title>"
+      "<link>https://example.com/z</link>"
+      "<dc:creator>Jane Doe</dc:creator>"
+      "<description>Body.</description>"
+      "</item></channel></rss>";
+  const feedparser::FeedItem item = firstItem(feed);
+  TEST_ASSERT_EQUAL_STRING("Jane Doe", item.author.c_str());
+}
+
+void test_iterates_multiple_items_then_stops() {
+  const String feed =
+      "<rss><channel>"
+      "<item><title>One</title><link>https://e.com/1</link><description>b1</description></item>"
+      "<item><title>Two</title><link>https://e.com/2</link><description>b2</description></item>"
+      "</channel></rss>";
+  size_t cursor = 0;
+  feedparser::FeedItem a;
+  feedparser::FeedItem b;
+  feedparser::FeedItem c;
+  TEST_ASSERT_TRUE(feedparser::parseNextItem(feed, cursor, a));
+  TEST_ASSERT_TRUE(feedparser::parseNextItem(feed, cursor, b));
+  TEST_ASSERT_FALSE(feedparser::parseNextItem(feed, cursor, c));
+  TEST_ASSERT_EQUAL_STRING("One", a.title.c_str());
+  TEST_ASSERT_EQUAL_STRING("Two", b.title.c_str());
+}
+
+void test_host_label_strips_scheme_and_www() {
+  TEST_ASSERT_EQUAL_STRING("example.com",
+                           feedparser::hostLabelForUrl("https://www.example.com/path?x=1").c_str());
+}
+
+int main(void) {
+  UNITY_BEGIN();
+  RUN_TEST(test_parses_rss_item_fields);
+  RUN_TEST(test_parses_atom_entry_with_href_link);
+  RUN_TEST(test_decodes_entities_and_strips_html);
+  RUN_TEST(test_unwraps_cdata_in_body);
+  RUN_TEST(test_falls_back_to_host_for_author);
+  RUN_TEST(test_prefers_dc_creator_author);
+  RUN_TEST(test_iterates_multiple_items_then_stops);
+  RUN_TEST(test_host_label_strips_scheme_and_www);
+  return UNITY_END();
+}

--- a/test/test_life_grid/test_main.cpp
+++ b/test/test_life_grid/test_main.cpp
@@ -1,0 +1,88 @@
+#include <unity.h>
+
+#include <vector>
+
+#include "standby/LifeGrid.h"
+
+namespace {
+
+// Builds an empty packed grid sized for columns x rows.
+std::vector<uint32_t> emptyGrid(uint16_t columns, uint16_t rows) {
+  return std::vector<uint32_t>(
+      standby::packedWordCount(static_cast<size_t>(columns) * rows), 0);
+}
+
+}  // namespace
+
+void test_set_and_read_cell_roundtrips() {
+  std::vector<uint32_t> grid = emptyGrid(8, 8);
+  TEST_ASSERT_FALSE(standby::cellAlive(grid, 35));
+  standby::setCell(grid, 35, true);
+  TEST_ASSERT_TRUE(standby::cellAlive(grid, 35));
+  standby::setCell(grid, 35, false);
+  TEST_ASSERT_FALSE(standby::cellAlive(grid, 35));
+}
+
+void test_set_cell_at_clips_out_of_bounds() {
+  std::vector<uint32_t> grid = emptyGrid(8, 8);
+  standby::setCellAt(grid, 8, 8, -1, 4, true);  // off-grid, no-op
+  standby::setCellAt(grid, 8, 8, 8, 4, true);   // off-grid, no-op
+  for (uint32_t word : grid) {
+    TEST_ASSERT_EQUAL_UINT32(0, word);
+  }
+  standby::setCellAt(grid, 8, 8, 3, 2, true);
+  TEST_ASSERT_TRUE(standby::cellAlive(grid, 2 * 8 + 3));
+}
+
+void test_blinker_oscillates_period_two() {
+  // A vertical 3-cell blinker becomes horizontal after one step, then vertical
+  // again after the next -- the canonical Game-of-Life period-2 oscillator.
+  const uint16_t cols = 8;
+  const uint16_t rows = 8;
+  std::vector<uint32_t> grid = emptyGrid(cols, rows);
+  standby::setCellAt(grid, cols, rows, 4, 3, true);
+  standby::setCellAt(grid, cols, rows, 4, 4, true);
+  standby::setCellAt(grid, cols, rows, 4, 5, true);
+
+  std::vector<uint32_t> next;
+  const size_t aliveAfterOne = standby::lifeStep(grid, next, cols, rows);
+  TEST_ASSERT_EQUAL_UINT32(3, aliveAfterOne);
+  // Now horizontal: (3,4) (4,4) (5,4).
+  TEST_ASSERT_TRUE(standby::cellAlive(next, 4 * cols + 3));
+  TEST_ASSERT_TRUE(standby::cellAlive(next, 4 * cols + 4));
+  TEST_ASSERT_TRUE(standby::cellAlive(next, 4 * cols + 5));
+  TEST_ASSERT_FALSE(standby::cellAlive(next, 3 * cols + 4));
+  TEST_ASSERT_FALSE(standby::cellAlive(next, 5 * cols + 4));
+
+  std::vector<uint32_t> back;
+  standby::lifeStep(next, back, cols, rows);
+  // Back to the original vertical blinker.
+  TEST_ASSERT_TRUE(standby::cellAlive(back, 3 * cols + 4));
+  TEST_ASSERT_TRUE(standby::cellAlive(back, 4 * cols + 4));
+  TEST_ASSERT_TRUE(standby::cellAlive(back, 5 * cols + 4));
+}
+
+void test_empty_grid_stays_empty() {
+  const uint16_t cols = 8;
+  const uint16_t rows = 8;
+  std::vector<uint32_t> grid = emptyGrid(cols, rows);
+  std::vector<uint32_t> next;
+  TEST_ASSERT_EQUAL_UINT32(0, standby::lifeStep(grid, next, cols, rows));
+}
+
+void test_advance_rng_is_deterministic() {
+  uint32_t a = 12345;
+  uint32_t b = 12345;
+  TEST_ASSERT_EQUAL_UINT32(standby::advanceRng(a), standby::advanceRng(b));
+  TEST_ASSERT_EQUAL_UINT32(a, b);
+}
+
+int main(void) {
+  UNITY_BEGIN();
+  RUN_TEST(test_set_and_read_cell_roundtrips);
+  RUN_TEST(test_set_cell_at_clips_out_of_bounds);
+  RUN_TEST(test_blinker_oscillates_period_two);
+  RUN_TEST(test_empty_grid_stays_empty);
+  RUN_TEST(test_advance_rng_is_deterministic);
+  return UNITY_END();
+}

--- a/test/test_release_parser/test_main.cpp
+++ b/test/test_release_parser/test_main.cpp
@@ -1,0 +1,80 @@
+#include <unity.h>
+
+#include "update/ReleaseParser.h"
+
+namespace {
+
+const char *kAsset = "rsvp-nano-ota.bin";
+
+releaseparser::ReleaseInfo parseJson(const String &json) {
+  releaseparser::ReleaseInfo out;
+  releaseparser::parse(json, kAsset, out);
+  return out;
+}
+
+}  // namespace
+
+void test_extracts_tag_and_matching_asset_url() {
+  const String json =
+      "{\"tag_name\":\"v0.0.6\",\"assets\":["
+      "{\"name\":\"other.bin\",\"browser_download_url\":\"https://example.com/other.bin\"},"
+      "{\"name\":\"rsvp-nano-ota.bin\",\"browser_download_url\":\"https://example.com/ota.bin\"}"
+      "]}";
+  releaseparser::ReleaseInfo out;
+  TEST_ASSERT_TRUE(releaseparser::parse(json, kAsset, out));
+  TEST_ASSERT_EQUAL_STRING("v0.0.6", out.tagName.c_str());
+  TEST_ASSERT_EQUAL_STRING("https://example.com/ota.bin", out.assetUrl.c_str());
+}
+
+void test_returns_false_when_tag_missing() {
+  const String json = "{\"assets\":[]}";
+  releaseparser::ReleaseInfo out;
+  TEST_ASSERT_FALSE(releaseparser::parse(json, kAsset, out));
+  TEST_ASSERT_TRUE(out.tagName.isEmpty());
+}
+
+void test_asset_url_empty_when_no_asset_matches() {
+  const String json =
+      "{\"tag_name\":\"v1.2.3\",\"assets\":["
+      "{\"name\":\"wrong.bin\",\"browser_download_url\":\"https://example.com/wrong.bin\"}]}";
+  const releaseparser::ReleaseInfo out = parseJson(json);
+  TEST_ASSERT_EQUAL_STRING("v1.2.3", out.tagName.c_str());
+  TEST_ASSERT_TRUE(out.assetUrl.isEmpty());
+}
+
+void test_handles_whitespace_after_colon() {
+  const String json = "{ \"tag_name\" :   \"v9\" }";
+  const releaseparser::ReleaseInfo out = parseJson(json);
+  TEST_ASSERT_EQUAL_STRING("v9", out.tagName.c_str());
+}
+
+void test_unescapes_forward_slashes_in_url() {
+  const String json =
+      "{\"tag_name\":\"v2\",\"assets\":["
+      "{\"name\":\"rsvp-nano-ota.bin\","
+      "\"browser_download_url\":\"https:\\/\\/example.com\\/path\\/ota.bin\"}]}";
+  const releaseparser::ReleaseInfo out = parseJson(json);
+  TEST_ASSERT_EQUAL_STRING("https://example.com/path/ota.bin", out.assetUrl.c_str());
+}
+
+void test_picks_url_after_matching_name_not_a_neighbor() {
+  // The matching asset is the second entry; its url must come from after its name.
+  const String json =
+      "{\"tag_name\":\"v3\",\"assets\":["
+      "{\"name\":\"a.bin\",\"browser_download_url\":\"https://example.com/a.bin\"},"
+      "{\"name\":\"rsvp-nano-ota.bin\",\"browser_download_url\":\"https://example.com/correct.bin\"}"
+      "]}";
+  const releaseparser::ReleaseInfo out = parseJson(json);
+  TEST_ASSERT_EQUAL_STRING("https://example.com/correct.bin", out.assetUrl.c_str());
+}
+
+int main(void) {
+  UNITY_BEGIN();
+  RUN_TEST(test_extracts_tag_and_matching_asset_url);
+  RUN_TEST(test_returns_false_when_tag_missing);
+  RUN_TEST(test_asset_url_empty_when_no_asset_matches);
+  RUN_TEST(test_handles_whitespace_after_colon);
+  RUN_TEST(test_unescapes_forward_slashes_in_url);
+  RUN_TEST(test_picks_url_after_matching_name_not_a_neighbor);
+  return UNITY_END();
+}


### PR DESCRIPTION
A focused architecture pass that pulls self-contained logic out of the two largest files (`App.cpp` ~6.1k lines, the network managers) into small, well-named modules — several now unit-tested on the host, where before only `ReadingLoop` was. No feature or behavior changes intended; the device UI, web companion, and stored settings all work exactly as before.

Three independent commits, each building on its own:

### 1. Pure feed/release parsers; dedupe station-WiFi setup
`RssFeedManager` and `OtaUpdater` mixed transport, parsing, and orchestration; their WiFi connect loop was byte-for-byte identical.
- **`rss/FeedParser`** — RSS/Atom parsing + HTML strip + XML entity decode + char folding. `String` in → `FeedItem` out.
- **`update/ReleaseParser`** — GitHub `releases/latest` JSON → tag + asset URL.
- **`net/WifiConnection`** — the single `WIFI_STA` connect/poll/timeout loop, deduped.
- Managers shrink **−737 / +147**, public interfaces unchanged.

### 2. Standby screensavers → a `Screensaver` module
The Life/Maze/Voronoi animations were ~310 lines + 9 member vectors inline in `App`.
- **`standby/Screensaver`** — interface (seed/step/frame) + `Kind` + factory.
- **`standby/LifeGrid`** — pure packed-bit grid + Conway rule (`lifeStep`), host-testable.
- **`standby/Screensavers`** — the three adapters.
- `App` keeps one `unique_ptr<Screensaver>`, supplies seed entropy, renders the frame. Adding a screensaver is now an adapter, not an `App` edit.

### 3. One shared preference-key registry
`App` and `CompanionSyncManager` each kept their own copy of the NVS namespace + ~28 key strings — two copies that can silently drift.
- **`settings/PreferenceKeys.h`** — the canonical registry both include. Call sites unchanged; stored keys byte-identical.
- This is the safe first layer of a Settings module. The deeper change (typed accessors + validation behind the seam, migrating ~170 call sites off raw `Preferences`) is intentionally **left for a pass that can be exercised on hardware** — it is behavior-sensitive and not host-testable.

## Tests & build

`FeedParser`, `ReleaseParser`, and `LifeGrid` gain host-side unit tests, joining `ReadingLoop`. The `test/support/Arduino.h` `String` shim was extended to support them.

- ✅ `pio test -e native_test` — **78 cases pass** (pacing 59, feed 8, release 6, life-grid 5)
- ✅ `pio run -e waveshare_esp32s3_usb_msc` — `[SUCCESS]`
- ✅ `pio run -e waveshare_esp32s3` — `[SUCCESS]`

## Behavior notes
- No intended behavior changes. Two cosmetic ones: the RSS WiFi-connect progress ramp is unified with OTA's; screensaver reseed-on-stagnation now draws from the saver's own RNG instead of re-reading `millis()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)