### PR TITLE
Half-baked variant working on Lilygo T-Lora Pager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .pio
 .gradle/
 .kotlin/
+local.properties
 .local/
 build/
 **/build/
@@ -36,3 +37,8 @@ compile_commands.json
 src/idf_component.yml
 benchmark/logs/
 benchmark/summary.md
+logs/
+# T-Pager build artifacts / transient backups
+tpager_build.log
+tpager_pkg.log
+*.orig

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,7 +1,7 @@
 {
-    // See http://go.microsoft.com/fwlink/?LinkId=827846
-    // for the documentation about the extensions.json format
     "recommendations": [
+        "Jason2866.esp-decoder",
+        "pioarduino.pioarduino-ide",
         "platformio.platformio-ide"
     ],
     "unwantedRecommendations": [

--- a/README-tpager.md
+++ b/README-tpager.md
@@ -1,0 +1,206 @@
+# RSVP Nano — LilyGo T-LoRa-Pager variant
+
+This document describes the **T-LoRa-Pager** build variant of RSVP Nano and how
+to compile and flash it. The default firmware targets the Waveshare ESP32-S3
+3.49" board; this variant retargets the same application to the LilyGo
+T-LoRa-Pager using the vendor **LilyGoLib** BSP.
+
+> **Status — read this first.** The variant was implemented against the LilyGoLib
+> source and the T-Pager hardware docs, but it has **not yet been compiled or
+> flashed on hardware from this workspace** (no PlatformIO/ESP32 toolchain or
+> device was available here). Treat it as a complete, reviewable foundation that
+> needs an on-device build/flash iteration pass. The sections below list the
+> exact prerequisites and the one external step (lvgl exclusion) that the build
+> needs.
+
+## What changed vs. the Waveshare build
+
+The board layer is a per-platform implementation of the shared `Board::` API.
+The T-Pager lives in `src/platforms/lilygo_tlora_pager/` and is selected by the
+`t_lora_pager` PlatformIO environment, which compiles that directory's sources
+(`build_src_filter`), points `RSVP_BOARD_CONFIG_HEADER` at its `BoardConfig.h`,
+and sets the `RSVP_BOARD_TPAGER` flag. The Waveshare builds are untouched.
+
+| Concern            | Waveshare (default)                     | T-Pager (`platforms/lilygo_tlora_pager/`)                      |
+| ------------------ | --------------------------------------- | -------------------------------------------------------------- |
+| Display            | AXS15231B QSPI, 640×172 (`drivers/display/axs15231b`) | ST7796 SPI, 480×222 via LilyGoLib (`BoardDisplay.cpp`) |
+| Orientation        | native-portrait rotated to landscape    | identity (`Portrait`/`PortraitFlipped`) — panel is native landscape |
+| Input              | capacitive touch + 2 buttons            | rotary encoder + center button → synthetic touch (`InputTouch.cpp`, replaces the generic `input/InputTouch.cpp`) |
+| Board/power        | TCA9554, ADC battery (`platforms/waveshare_lcd_349`) | XL9555 + BQ25896/BQ27220 via LilyGoLib (`BoardPower.cpp`) |
+| SD card            | SDMMC (1-bit)                           | shared SPI bus, mounted by LilyGoLib (`installSD()`, see `SdDiagnostics.cpp`) |
+| Audio              | direct ES8311 over I2S (`drivers/audio/es8311`) | ES8311 via LilyGoLib codec (`BoardAudio.cpp`)          |
+| USB file transfer  | TinyUSB MSC                             | TinyUSB MSC over native USB, SD card exposed at the FatFS block level (`RSVP_USB_TRANSFER_ENABLED=1`, USB-OTG mode) |
+
+All LilyGoLib access is funneled through `platforms/lilygo_tlora_pager/TPagerHardware.h`
+(one idempotent `ensureBegun()`). The card filesystem is abstracted with an
+`RSVP_CARD` alias (`src/storage/fs/CardFs.h`: `SD_MMC` vs the SPI `SD` object) so
+the shared storage code (`StorageManager`, the `converter/` + `storage/`
+modules, `RssFeedManager`, `CompanionSyncManager`, `OtaUpdater`, …) is reused;
+only the mount path in `SdDiagnostics.cpp` is board-specific.
+
+## Controls
+
+| Action                  | Input                                                    |
+| ----------------------- | -------------------------------------------------------- |
+| Move menu selection     | Rotate the encoder                                       |
+| Select / confirm        | Press the encoder (center button) — haptic confirmation  |
+| Start/stop reading      | Double-press the encoder (reader double-tap toggles play) |
+| Adjust WPM (while paused)| Rotate the encoder                                       |
+| Open / close menu (back)| Short-press **BOOT**                                      |
+| Power off (deep sleep)  | Long-press **BOOT** (wakes on **BOOT**)                  |
+
+The PWR button is hardware-only on this device and cannot be read by firmware,
+so **BOOT** (GPIO0) is the primary control button and the encoder drives
+navigation. Text entry (e.g. Wi-Fi password) uses the physical **TCA8418
+keyboard**: on a text-entry screen there are no on-screen keys — type on the
+hardware keyboard (Shift and the Space-Fn symbol layer are resolved by the BSP),
+**Enter** confirms/saves, **backspace** deletes, and **BOOT** cancels the field.
+Masked fields (e.g. Wi-Fi password) are shown in clear text as you type, since
+there is no on-screen show/hide toggle on the physical-keyboard path.
+
+## Build prerequisites
+
+1. **PlatformIO** (CLI or IDE).
+2. **arduino-esp32 3.x toolchain.** LilyGoLib requires core ≥ 3.3.0-alpha1
+   (IDF 5). Mainline `platformio/espressif32` only ships arduino 2.0.x, so the
+   `t_lora_pager` environment pins the community **pioarduino** platform fork.
+   The version in `platformio.ini`
+   (`pioarduino/platform-espressif32@53.03.13`) is a known arduino-3.x release;
+   bump it if a newer one is needed. This also provides the
+   `lilygo_tlora_pager` board variant (`pins_arduino.h`, `ARDUINO_T_LORA_PAGER`,
+   `DISP_*`/`ROTARY_*`/`SD_CS` pin macros) that LilyGoLib relies on.
+3. **LilyGoLib + third-party libraries**, checked out as siblings of this repo:
+
+   ```
+   <parent>/
+     rsvpnano/                ← this repo
+     LilyGoLib-master/        ← https://github.com/Xinyuan-LilyGO/LilyGoLib
+     LilyGoLib-ThirdParty/    ← https://github.com/Xinyuan-LilyGO/LilyGoLib-ThirdParty
+   ```
+
+   `platformio.ini` already points `lib_extra_dirs` at `..` and
+   `../LilyGoLib-ThirdParty`, so PlatformIO resolves `LilyGoLib`, `RadioLib`,
+   `XPowersLib`, `SensorLib`, the TCA8418 keyboard driver, etc. from these local
+   folders.
+
+### Handle lvgl (the one required external step)
+
+This firmware renders its own UI and never uses lvgl, but LilyGoLib bundles
+`LV_Helper.cpp` / `LV_Helper_v9.cpp`, which `#include "lvgl.h"`. The env sets
+`lib_ignore = lvgl`, so you must also stop LilyGoLib from compiling those two
+files. Add a `build.srcFilter` to **`../LilyGoLib-master/library.json`**:
+
+```jsonc
+{
+  // ...existing keys...
+  "build": {
+    "srcFilter": "+<*> -<LV_Helper.cpp> -<LV_Helper_v9.cpp> -<USB_MSC.cpp>"
+  }
+}
+```
+
+(`USB_MSC.cpp` is excluded because this variant drives USB mass storage through
+its own `UsbMassStorageManager` over the SD card, not LilyGoLib's flash-backed
+MSC.) Alternatively, vendor a matching `lv_conf.h` and drop `lib_ignore = lvgl`
+— but excluding the unused helpers is simpler.
+
+Note: `LilyGo_LoRa_Pager::begin()` still *references* `setupMSC()` (defined in the
+excluded `USB_MSC.cpp`), so excluding that file alone produces an
+`undefined reference to setupMSC(...)` at link time.
+`platforms/lilygo_tlora_pager/TPagerHardware.cpp` provides a no-op `setupMSC`
+stub to satisfy the linker without pulling in TinyUSB.
+
+### Keyboard: suppress the trailing space after "Space + number"
+
+The TCA8418 keymap uses **Space as the symbol/Fn modifier** (the pager has no
+dedicated symbol key, so `has_symbol_key == false`). LilyGoLib's
+`LilyGoKeyboard.cpp` emitted a space on *every* Space-key release, so typing a
+number or symbol via `Space + <key>` inserted the character **and** a stray
+trailing space. This repo patches `../LilyGoLib-master/src/LilyGoKeyboard.cpp`
+to track a `symbol_modifier_consumed` flag: any key pressed while Space is held
+marks Space as a modifier, and its release then emits nothing; a standalone
+Space tap still produces a space. Re-apply this patch if you re-clone LilyGoLib
+(it lives in `handleSpecialKeys`, `update`, `begin`, and a file-scope static).
+
+## Build & flash
+
+> **Use a dedicated PlatformIO core dir.** This env must build against the
+> pioarduino Arduino-3.x core, but the default `~/.platformio` core also holds
+> the mainline Arduino-2.0.x framework pulled in by the Waveshare env. Those two
+> collide: pioarduino's builder can't resolve `framework-arduinoespressif32` and
+> the build dies with `TypeError: expected str, bytes or os.PathLike object, not
+> NoneType` (`FRAMEWORK_DIR` is `None`). Keep this variant in its own core via
+> `PLATFORMIO_CORE_DIR`. The hardcoded `-I` include paths in the env's
+> `build_flags` already assume `D:/pio-tpager`, so use that path (or set it to
+> your own and update those flags to match).
+
+```powershell
+# PowerShell (set once per shell session)
+$env:PLATFORMIO_CORE_DIR = "D:\pio-tpager"
+pio run -e t_lora_pager                 # compile
+pio run -e t_lora_pager -t upload       # flash over USB-C
+pio device monitor -b 115200            # serial (USB CDC)
+```
+
+```bash
+# bash/zsh
+export PLATFORMIO_CORE_DIR=/path/to/pio-tpager
+pio run -e t_lora_pager
+pio run -e t_lora_pager -t upload
+pio device monitor -b 115200
+```
+
+Do **not** add `core_dir` to the `[platformio]` section of `platformio.ini` to
+achieve this — that is project-global and would force the default Waveshare env
+to redownload its entire toolchain into the same core.
+
+If the panel image is upside-down for your grip, switch to the left-handed UI
+mode in Settings (a true 180° flip) or set `-DRSVP_TPAGER_ROTATION=2` in the
+env's `build_flags`. (Landscape is rotation 0 or 2; rotations 1 and 3 are the
+panel's 222×480 portrait orientations.)
+
+## SD card layout
+
+Same as the default firmware — FAT32, with:
+
+```
+/books/books        (books)
+/books/articles     (articles)
+/config
+```
+
+## Known limitations / next iterations
+
+The board builds, flashes and runs on hardware. The display, rotary/button
+navigation, the legacy flat menu, the button-driven focus timer and the
+battery gauge are all verified on-device. The remaining open items:
+
+1. **USB file transfer — needs on-device verification.** Now enabled
+   (`RSVP_USB_TRANSFER_ENABLED=1`, USB-OTG mode). The app's
+   `UsbMassStorageManager` exposes the SD card over native USB at the FatFS
+   block level, so the SPI SD mounted by LilyGoLib's `installSD()` works
+   unchanged. This is the one feature that has **not** yet been exercised on
+   hardware — confirm the card enumerates on a host and that Serial-over-USB
+   (CDC) still works after switching to `ARDUINO_USB_MODE=0`. LilyGoLib's own
+   `USB_MSC.cpp` stays excluded (it would expose internal flash, not the SD);
+   the `setupMSC` stub in `TPagerHardware.cpp` keeps the linker happy.
+2. **Display rotation/mirroring.** `RSVP_TPAGER_ROTATION` defaults to landscape
+   rotation 0 (LilyGoLib maps rotations 0/2 -> 480×222 landscape, 1/3 -> 222×480
+   portrait). Verified `width()==480, height()==222` on-device.
+
+Accepted as good enough (no further work planned):
+
+- **Text entry** uses the physical TCA8418 keyboard (`Board::Keyboard` →
+  `tpager::hw().kb`), not rotary input. Wired and working.
+- **Input latency.** `getRotary()` blocks up to 50 ms when idle, so the idle
+  loop runs ~20 Hz. Fine for reading at the WPM range this device is used at.
+- **Audio cue** plays a 1 kHz tone through LilyGoLib's `EspCodec`; the cue is
+  audible and the parameters are accepted as-is.
+
+Resolved:
+
+- **Power consumption.** `LilyGoLib::begin()` still powers up LoRa/GPS/NFC, but
+  `TPagerHardware::ensureBegun()` now immediately puts the SX1262 into sleep
+  (`radio.sleep()`) and cuts the GPS and NFC rails
+  (`powerControl(POWER_GPS/POWER_NFC, false)`) right after boot, since the app
+  uses none of them.

--- a/README.md
+++ b/README.md
@@ -143,14 +143,23 @@ remounts the SD card and refreshes the library.
 
 ### Option 3: Web Companion
 
-The device can host its own browser companion page.
+The device serves a browser companion page over Wi-Fi.
 
 1. Swipe up from the bottom edge to open quick settings.
 2. Choose `Sync`.
 3. Choose `Wi-Fi Sync`.
-4. The device shows the Wi-Fi network name and the browser URL.
-5. Connect your phone, tablet, or computer to the `RSVP-Nano-xxxxxx` Wi-Fi network.
-6. Open the URL shown on the device, usually `http://192.168.4.1`.
+4. The device shows the Wi-Fi network name and the browser address.
+
+**If home Wi-Fi credentials are saved** (Settings → Wi-Fi, or the companion's
+Settings page), the device joins that network and serves the page on your LAN.
+Leave your phone/computer on the same Wi-Fi and open the IP address shown on the
+device (e.g. `http://192.168.1.42`) — no network switching needed.
+(`http://rsvp-nano.local` also works on clients that resolve mDNS.)
+
+**Otherwise** the device falls back to hosting its own access point: connect
+your phone, tablet, or computer to the `RSVP-Nano-xxxxxx` Wi-Fi network, then
+open the URL shown on the device, usually `http://192.168.4.1`. (This is also
+the automatic fallback if joining the saved network fails — e.g. out of range.)
 
 The web companion has pages for:
 

--- a/boards/lilygo-t-lora-pager.json
+++ b/boards/lilygo-t-lora-pager.json
@@ -1,0 +1,52 @@
+{
+  "build": {
+    "arduino": {
+      "ldscript": "esp32s3_out.ld",
+      "memory_type": "qio_qspi",
+      "partitions": "default_16MB.csv"
+    },
+    "core": "esp32",
+    "extra_flags": [
+      "-DARDUINO_T_LORA_PAGER",
+      "-DARDUINO_USB_MODE=0",
+      "-DARDUINO_USB_CDC_ON_BOOT=1",
+      "-DARDUINO_RUNNING_CORE=1",
+      "-DARDUINO_EVENT_RUNNING_CORE=1",
+      "-DBOARD_HAS_PSRAM",
+      "-DUSING_XL9555_EXPANDS",
+      "-DUSING_AUDIO_CODEC",
+      "-DARDUINO_LILYGO_LORA_SX1262"
+    ],
+    "f_cpu": "240000000L",
+    "f_flash": "80000000L",
+    "flash_mode": "qio",
+    "hwids": [
+      [
+        "0x303A",
+        "0x1001"
+      ]
+    ],
+    "mcu": "esp32s3",
+    "variant": "lilygo_tlora_pager"
+  },
+  "connectivity": [
+    "wifi",
+    "bluetooth"
+  ],
+  "debug": {
+    "openocd_target": "esp32s3.cfg"
+  },
+  "frameworks": [
+    "arduino"
+  ],
+  "name": "LilyGo T-LoRa-Pager (16M Flash 8M PSRAM)",
+  "upload": {
+    "flash_size": "16MB",
+    "maximum_ram_size": 327680,
+    "maximum_size": 16777216,
+    "require_upload_port": true,
+    "speed": 921600
+  },
+  "url": "https://www.lilygo.cc/products/t-lora-pager",
+  "vendor": "LilyGo"
+}

--- a/diagram.json
+++ b/diagram.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "author": "wokwi",
+  "editor": "wokwi",
+  "parts": [
+    { "type": "board-esp32-s3-devkitc-1", "id": "esp", "top": 0, "left": 0, "attrs": {} }
+  ],
+  "connections": [
+    [ "esp:TX", "$serialMonitor:RX", "", [] ],
+    [ "esp:RX", "$serialMonitor:TX", "", [] ]
+  ]
+}

--- a/platformio.ini
+++ b/platformio.ini
@@ -87,6 +87,15 @@ c6_touch_lcd_147_src_filter =
   +<drivers/imu/qmi8658/**>
   +<drivers/touch/axs5106/**>
 
+; LilyGo T-LoRa-Pager: every peripheral is driven through the LilyGoLib BSP, so
+; no drivers/** are pulled in -- the platform's own Board:: backends back the
+; seams. The generic no-op board/BoardKeyboard.cpp is excluded because this
+; platform supplies a real TCA8418-backed Board::Keyboard.
+tpager_src_filter =
+  ${common.base_src_filter}
+  +<platforms/lilygo_tlora_pager/**>
+  -<board/BoardKeyboard.cpp>
+
 usb_msc_build_flags =
   -DARDUINO_USB_MODE=0
   -DARDUINO_USB_MSC_ON_BOOT=0
@@ -384,6 +393,113 @@ build_flags =
 
 monitor_filters =
   ${common.benchmark_monitor_filters}
+
+;
+; LilyGo T-LoRa-Pager variant.
+;
+; This board is driven through the vendor BSP (LilyGoLib), which requires the
+; arduino-esp32 3.x core. The mainline PlatformIO espressif32 platform only ships
+; arduino 2.0.x, so this environment overrides `platform` with the community
+; pioarduino fork that packages arduino-esp32 3.x. LilyGoLib and its third-party
+; dependencies are resolved from the sibling checkouts next to this repo.
+;
+; See README-tpager.md for the full build prerequisites and known integration
+; steps (lvgl exclusion, codec component, USB transfer rework).
+[env:t_lora_pager]
+platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.39/platform-espressif32.zip
+board = lilygo-t-lora-pager
+framework = arduino
+monitor_speed = 115200
+upload_speed = 921600
+board_build.partitions = default_16MB.csv
+; The lilygo_tlora_pager core variant (pins_arduino.h) is not present in the
+; pinned pioarduino core, so it is vendored here and resolved from this dir.
+board_build.variants_dir = variants
+; Select this platform's Board:: backends (platforms/lilygo_tlora_pager/**) via
+; the shared tpager_src_filter and exclude the generic no-op keyboard backend
+; (board/BoardKeyboard.cpp) that this platform replaces with its TCA8418-backed
+; one. No drivers/** are added: every peripheral on this board is driven through
+; the LilyGoLib BSP, and the platform's own BoardInput/BoardImu/BoardStorage/...
+; back the Board:: seams.
+build_src_filter =
+  ${common.tpager_src_filter}
+lib_ldf_mode = deep+
+lib_extra_dirs =
+  ${PROJECT_DIR}/..
+  ${PROJECT_DIR}/../LilyGoLib-ThirdParty
+lib_deps =
+  LilyGoLib
+  ; LilyGoLib uses these but does not declare them in its library.json, so they
+  ; must be listed explicitly to be resolved from LilyGoLib-ThirdParty.
+  RadioLib
+  XPowersLib
+  SensorLib
+  TinyGPSPlus
+  Adafruit TCA8418
+  Adafruit BusIO
+  NFC-RFAL-fork
+  ST25R3916-fork
+  NimBLE-Arduino
+; This firmware has its own renderer and never uses lvgl. Ignoring it keeps the
+; build lean, but note LilyGoLib still ships LV_Helper*.cpp which #include
+; lvgl.h -- those must be excluded from LilyGoLib's own build (see
+; README-tpager.md, "Handle lvgl"). USB_MSC.cpp is likewise unused here.
+lib_ignore =
+  lvgl
+  ; lib_extra_dirs includes ${PROJECT_DIR}/.. (to resolve the sibling LilyGoLib
+  ; checkouts), which also makes the LDF discover the project itself (rsvpnano/)
+  ; and the docs/tooling sibling (utils/) as "libraries" -- it would then compile
+  ; rsvpnano's own sources a SECOND time, causing duplicate-symbol link errors
+  ; (e.g. UsbMassStorageManager::onStartStop multiply defined). Ignore both so only
+  ; the real project src build and the actual third-party libraries are compiled.
+  rsvpnano
+  utils
+# LilyGoLib's vendored sub-libraries (RadioLib, SensorLib, XPowersLib, the codec,
+# Adafruit BusIO, ...) and the bundled Arduino libraries this app pulls in
+# (HTTPUpdate -> WiFi/HTTPClient/Update, ...) are compiled in isolation by the
+# Library Dependency Finder and assume the sibling Arduino framework library
+# headers (SPI/Wire/FS/SD, the WiFi/network stack, ...) are globally visible.
+# PlatformIO does not propagate those into the isolated library builds, so we add
+# them as -I flags here -- build_flags reach every translation unit (project src,
+# framework libs AND third-party libs), which appending to env CPPPATH from an
+# extra_script does not.
+#
+# These paths must use forward slashes and are therefore machine-specific (like
+# the LilyGoLib-ThirdParty paths below): ${platformio.packages_dir} expands with
+# Windows backslashes (D:\pio-tpager\packages), and a backslashed path in a -I
+# build flag is mangled by the build-flag parser, so RadioLib & co. then fail to
+# find SPI.h. The base is <PLATFORMIO_CORE_DIR>/packages -- adjust if your core
+# dir differs (see README-tpager.md).
+build_flags =
+  -DCORE_DEBUG_LEVEL=3
+  -DRSVP_BOARD_TPAGER=1
+  -DRSVP_BOARD_CONFIG_HEADER=\"platforms/lilygo_tlora_pager/BoardConfig.h\"
+  -DRSVP_ON_DEVICE_EPUB_CONVERSION=1
+  ; USB mass-storage SD transfer is DISABLED on this board after the PR#120
+  ; refactor. Upstream rewrote app/UsbMassStorageManager to drive the SDMMC host
+  ; directly (sdmmc_host_init_slot / sdmmc_card_init), but this board's SD card is
+  ; on the shared SPI bus and is mounted by LilyGoLib's installSD(), not the SDMMC
+  ; peripheral -- so the new MSC path cannot enumerate it. The previous T-Pager
+  ; USB transfer relied on the OLD bus-agnostic (FatFS block-level) manager that
+  ; upstream replaced. Re-enabling it needs a SPI/bus-agnostic MSC backend; until
+  ; then RSVP_USB_TRANSFER_ENABLED stays 0 (its default) so the board keeps the
+  ; default ARDUINO_USB_MODE=1 (CDC) and the reader is unaffected. See
+  ; README-tpager.md.
+  -DARDUINO_LILYGO_LORA_SX1262
+  -ID:/pio-tpager/packages/framework-arduinoespressif32/libraries/SPI/src
+  -ID:/pio-tpager/packages/framework-arduinoespressif32/libraries/Wire/src
+  -ID:/pio-tpager/packages/framework-arduinoespressif32/libraries/FS/src
+  -ID:/pio-tpager/packages/framework-arduinoespressif32/libraries/SD/src
+  -ID:/pio-tpager/packages/framework-arduinoespressif32/libraries/SD_MMC/src
+  -ID:/pio-tpager/packages/framework-arduinoespressif32/libraries/Network/src
+  -ID:/pio-tpager/packages/framework-arduinoespressif32/libraries/NetworkClientSecure/src
+  -ID:/pio-tpager/packages/framework-arduinoespressif32/libraries/WiFi/src
+  -ID:/pio-tpager/packages/framework-arduinoespressif32/libraries/HTTPClient/src
+  -ID:/pio-tpager/packages/framework-arduinoespressif32/libraries/Update/src
+  -I"D:/progetti/t-lora-pager/LilyGoLib-ThirdParty/Adafruit BusIO"
+  -ID:/progetti/t-lora-pager/LilyGoLib-ThirdParty/NFC-RFAL-fork/src
+  -ID:/progetti/t-lora-pager/LilyGoLib-ThirdParty/ST25R3916-fork/src
+  -ID:/progetti/t-lora-pager/LilyGoLib-ThirdParty/NimBLE-Arduino/src
 
 ;
 ; Native unit tests

--- a/src/app/App.cpp
+++ b/src/app/App.cpp
@@ -2063,6 +2063,11 @@ void App::applyPausedTouchGesture(const TouchEvent& event, uint32_t nowMs) {
                     && (playLocked_ || pauseAtSentenceEndRequested_)) {
                     resetReaderTapTracking();
                     requestReaderPauseAtSentenceEnd(nowMs);
+                } else if (Board::Config::READER_TAP_TOGGLES_PLAYBACK) {
+                    // Touchless board: a single deliberate tap (the rotary center push)
+                    // toggles playback -- no double-tap required.
+                    resetReaderTapTracking();
+                    toggleReaderPlaybackFromShortcut(nowMs);
                 } else if (Board::Config::TOUCH_READER_PLAYBACK_ENABLED) {
                     handleReaderTap(event.x, event.y, nowMs);
                 } else {
@@ -2152,6 +2157,11 @@ void App::applyPausedTouchGesture(const TouchEvent& event, uint32_t nowMs) {
             resetReaderTapTracking();
             contextViewVisible_ = false;
             renderActiveReader(nowMs);
+        } else if (tapLike && Board::Config::READER_TAP_TOGGLES_PLAYBACK) {
+            // Touchless board: a single deliberate tap (the rotary center push)
+            // toggles playback -- no double-tap required.
+            resetReaderTapTracking();
+            toggleReaderPlaybackFromShortcut(nowMs);
         } else if (tapLike && Board::Config::TOUCH_READER_PLAYBACK_ENABLED) {
             handleReaderTap(event.x, event.y, nowMs);
         } else {

--- a/src/app/App.cpp
+++ b/src/app/App.cpp
@@ -7,6 +7,8 @@
 
 #include "board/BoardConfig.h"
 #include "board/BoardInput.h"
+#include "board/BoardKeyboard.h"
+#include "settings/PreferenceKeys.h"
 
 #ifndef RSVP_USB_TRANSFER_ENABLED
 #define RSVP_USB_TRANSFER_ENABLED 0
@@ -841,6 +843,7 @@ void App::update(uint32_t nowMs) {
     maybeOpenUpdateConfirm(nowMs);
     updateFocusTimer(nowMs);
     updateReader(nowMs);
+    handleTextEntryKeyboard(nowMs);
     updateWpmFeedback(nowMs);
     maybeSaveReadingPosition(nowMs);
     updateTimeEstimateBuild(nowMs);
@@ -1197,14 +1200,20 @@ bool App::handleReaderInput(const Input::Event& event, uint32_t nowMs) {
         return true;
     }
 
+    // BOOT = back: on boards where the physical BOOT button is the power button
+    // (e.g. T-Pager), a short power-button press also leaves Companion sync /
+    // USB transfer, mirroring the long-hold exit. Otherwise these screens could
+    // only be left by long-holding.
     if (state_ == AppState::CompanionSync && Input::hasControl(event.controls, Input::InputPower)
-        && event.gesture == Input::Gesture::LongPressed) {
+        && (event.gesture == Input::Gesture::ShortPressed
+            || event.gesture == Input::Gesture::LongPressed)) {
         exitCompanionSync(nowMs);
         return true;
     }
 
     if (state_ == AppState::UsbTransfer && Input::hasControl(event.controls, Input::InputPower)
-        && event.gesture == Input::Gesture::LongPressed) {
+        && (event.gesture == Input::Gesture::ShortPressed
+            || event.gesture == Input::Gesture::LongPressed)) {
         exitUsbTransfer(nowMs);
         return true;
     }
@@ -2344,6 +2353,54 @@ void App::applyMenuTouchGesture(const TouchEvent& event, uint32_t nowMs) {
 }
 
 void App::applyFocusTimerTouch(const TouchEvent& event, uint32_t nowMs) {
+#ifdef RSVP_BOARD_TPAGER
+    // Rotary + center button only (no touch panel, no orientation control):
+    //   synthetic vertical swipe (rotary turn) -> step the duration on BEGIN
+    //   center-button tap -> start (BEGIN) or cancel (running)
+    // The rotary/center input is synthesized into TouchStart/TouchEnd/Tapped
+    // events by platforms/lilygo_tlora_pager/BoardInput.cpp.
+    if (event.gesture == Input::Gesture::TouchStart) {
+        pausedTouch_.active = true;
+        pausedTouch_.startX = event.x;
+        pausedTouch_.startY = event.y;
+        pausedTouch_.startMs = nowMs;
+        return;
+    }
+    if ((event.gesture != Input::Gesture::TouchEnd && event.gesture != Input::Gesture::Tapped) ||
+        !pausedTouch_.active) {
+        return;
+    }
+    pausedTouch_.active = false;
+
+    const int tpagerDeltaX = static_cast<int>(event.x) - static_cast<int>(pausedTouch_.startX);
+    const int tpagerDeltaY = static_cast<int>(event.y) - static_cast<int>(pausedTouch_.startY);
+    const bool rotaryStep = abs(tpagerDeltaY) >= static_cast<int>(kSwipeThresholdPx) &&
+                            abs(tpagerDeltaY) > abs(tpagerDeltaX);
+
+    if (rotaryStep) {
+        if (focusTimer_.state() == FocusTimer::State::WaitForTouchStart) {
+            // Rotate CW (synthetic swipe down, deltaY > 0) lengthens the block.
+            focusTimer_.stepTouchDuration(tpagerDeltaY > 0 ? 1 : -1);
+            const uint8_t genreIndex = static_cast<uint8_t>(focusTimer_.genre());
+            if (genreIndex < FocusTimer::kGenreCount) {
+                preferences_.putUChar(kPrefTimerDurationByGenre[genreIndex],
+                                      focusTimer_.touchDurationIndex());
+            }
+            renderFocusTimerSession();
+        }
+        return;
+    }
+
+    // Center-button tap.
+    if (focusTimer_.state() == FocusTimer::State::WaitForTouchStart) {
+        focusTimer_.startTouchTimer(nowMs);
+        renderFocusTimerSession();
+    } else if (focusTimer_.isActiveTimerRunning()) {
+        focusTimer_.cancelActiveTimer(nowMs);
+        renderFocusTimerSession();
+    }
+    return;
+#else
     if (event.gesture == Input::Gesture::TouchStart) {
         pausedTouch_.active = true;
         pausedTouch_.startX = event.x;
@@ -2393,6 +2450,7 @@ void App::applyFocusTimerTouch(const TouchEvent& event, uint32_t nowMs) {
     }
 
     (void) tapLike;
+#endif  // RSVP_BOARD_TPAGER
 }
 
 void App::openFocusTimer() {
@@ -3532,7 +3590,12 @@ void App::openTextEntry(TextEntryPurpose purpose, const String& title, const Str
     textEntrySession_.contextValue = contextValue;
     textEntrySession_.maxLength = maxLength;
     textEntrySession_.masked = masked;
-    textEntrySession_.revealValue = false;
+    // On physical-keyboard boards there is no on-screen show/hide control
+    // (rebuildTextEntryButtons() suppresses the virtual keys), so reveal masked
+    // values as they are typed -- otherwise the user can never see what they
+    // enter. The on-screen keyboard keeps the default-hidden behaviour and its
+    // show/hide toggle button.
+    textEntrySession_.revealValue = Board::Keyboard::present();
     menuScreen_ = MenuScreen::TextEntry;
     rebuildTextEntryButtons();
     renderTextEntry();
@@ -3541,6 +3604,12 @@ void App::openTextEntry(TextEntryPurpose purpose, const String& title, const Str
 void App::rebuildTextEntryButtons() {
     textEntryButtons_.clear();
     if (!textEntrySession_.active) {
+        return;
+    }
+
+    if (Board::Keyboard::present()) {
+        // Physical keyboard: no on-screen keys. Text entry is driven by
+        // handleTextEntryKeyboard(); the field renders with an empty button list.
         return;
     }
 
@@ -3667,6 +3736,42 @@ bool App::handleTextEntryTap(uint16_t x, uint16_t y, uint32_t nowMs) {
     }
 
     return false;
+}
+
+void App::handleTextEntryKeyboard(uint32_t nowMs) {
+    if (!Board::Keyboard::present() || menuScreen_ != MenuScreen::TextEntry ||
+        !textEntrySession_.active) {
+        return;
+    }
+
+    char c = '\0';
+    if (!Board::Keyboard::readChar(c)) {
+        return;
+    }
+
+    lastActivityMs_ = nowMs;
+    restoreFromAutoDim(nowMs);
+
+    if (c == '\n') {  // Enter: confirm/save.
+        commitTextEntry(nowMs);
+        return;
+    }
+
+    if (c == '\b') {  // Backspace.
+        if (!textEntrySession_.value.isEmpty()) {
+            textEntrySession_.value.remove(textEntrySession_.value.length() - 1);
+            renderTextEntry();
+        }
+        return;
+    }
+
+    // Printable character (letters, digits, symbols and space). Shift and the
+    // Space-Fn symbol layer are already resolved by the keyboard backend.
+    if (c >= ' ' && static_cast<uint8_t>(c) < 0x7F &&
+        textEntrySession_.value.length() < textEntrySession_.maxLength) {
+        textEntrySession_.value += c;
+        renderTextEntry();
+    }
 }
 
 void App::activateTextEntryButton(size_t buttonIndex, uint32_t nowMs) {
@@ -5787,7 +5892,15 @@ void App::renderFocusTimerGenres() {
 }
 
 void App::renderFocusTimerSession() {
+#ifdef RSVP_BOARD_TPAGER
+    // The pager's ST7796 is landscape-native and held normally; the BHI260AP
+    // drives only the timer's state transitions, not screen rotation. Keep the
+    // reader orientation instead of the touch boards' flip-to-portrait behavior,
+    // which would otherwise render this screen rotated 90 degrees.
+    applyReaderUiOrientation();
+#else
     applyUiOrientation(focusTimer_.uiOrientation());
+#endif
     const String remainingLabel = formatFocusTimerRemaining(millis());
 
     switch (focusTimer_.state()) {
@@ -5798,8 +5911,20 @@ void App::renderFocusTimerSession() {
         renderFocusTimerGenres();
         return;
     case FocusTimer::State::WaitForTouchStart:
+#ifdef RSVP_BOARD_TPAGER
+    {
+        // Rotary selects the block length; center button starts. Show the
+        // selected duration so the rotary feedback is visible.
+        const uint32_t durationMs = focusTimer_.selectedTouchDurationMs();
+        const String durationLabel = String(durationMs / 60000UL) + " min";
+        display_.renderFocusTimerScreen("BEGIN", "", durationLabel,
+                                        "Rotate to change\nPress to start");
+        return;
+    }
+#else
         display_.renderFocusTimerScreen("BEGIN", "", "", "Place on short side");
         return;
+#endif
     case FocusTimer::State::TouchRunning:
         display_.renderFocusTimerScreen("BEGIN", "", remainingLabel, "", "", focusTimer_.progressPercent(millis()));
         return;
@@ -5820,7 +5945,11 @@ void App::renderFocusTimerSession() {
         display_.renderFocusTimerScreen("WORK", "", "", "Flip to begin");
         return;
     case FocusTimer::State::Cancelled:
+#ifdef RSVP_BOARD_TPAGER
+        display_.renderFocusTimerScreen("BEGIN", "", "", "Press to begin again");
+#else
         display_.renderFocusTimerScreen("BEGIN", "", "", "Place to begin again");
+#endif
         return;
     case FocusTimer::State::Complete:
         display_.renderFocusTimerScreen("DONE", "", "", "Session complete");

--- a/src/app/App.cpp
+++ b/src/app/App.cpp
@@ -3765,7 +3765,6 @@ void App::handleTextEntryKeyboard(uint32_t nowMs) {
     }
 
     lastActivityMs_ = nowMs;
-    restoreFromAutoDim(nowMs);
 
     if (c == '\n') {  // Enter: confirm/save.
         commitTextEntry(nowMs);

--- a/src/app/App.cpp
+++ b/src/app/App.cpp
@@ -758,6 +758,11 @@ void App::begin() {
 
     Board::Audio::begin();
     focusTimer_.begin();
+    for (uint8_t i = 0; i < FocusTimer::kGenreCount; ++i) {
+        focusTimer_.setTouchDurationIndexForGenre(
+            static_cast<FocusTimer::Genre>(i),
+            preferences_.getUChar(settings::kPrefTimerDurationByGenre[i], 0));
+    }
 
 #if RSVP_USB_TRANSFER_ENABLED && RSVP_USB_TRANSFER_AUTO_START
     state_ = AppState::Booting;
@@ -2383,7 +2388,7 @@ void App::applyFocusTimerTouch(const TouchEvent& event, uint32_t nowMs) {
             focusTimer_.stepTouchDuration(tpagerDeltaY > 0 ? 1 : -1);
             const uint8_t genreIndex = static_cast<uint8_t>(focusTimer_.genre());
             if (genreIndex < FocusTimer::kGenreCount) {
-                preferences_.putUChar(kPrefTimerDurationByGenre[genreIndex],
+                preferences_.putUChar(settings::kPrefTimerDurationByGenre[genreIndex],
                                       focusTimer_.touchDurationIndex());
             }
             renderFocusTimerSession();
@@ -5926,7 +5931,14 @@ void App::renderFocusTimerSession() {
         return;
 #endif
     case FocusTimer::State::TouchRunning:
+#ifdef RSVP_BOARD_TPAGER
+        // The panel does not rotate between the pre-start and running screens on
+        // this board, so a shared "BEGIN" title makes starting look like nothing
+        // happened (the word merely shrinks). Use a distinct running title.
+        display_.renderFocusTimerScreen("FOCUS", "", remainingLabel, "", "", focusTimer_.progressPercent(millis()));
+#else
         display_.renderFocusTimerScreen("BEGIN", "", remainingLabel, "", "", focusTimer_.progressPercent(millis()));
+#endif
         return;
     case FocusTimer::State::WaitAfterTouch:
         display_.renderFocusTimerScreen("WORK", "", "", "Flip to continue");

--- a/src/app/App.h
+++ b/src/app/App.h
@@ -276,6 +276,10 @@ private:
     void rebuildTextEntryButtons();
     void renderTextEntry();
     bool handleTextEntryTap(uint16_t x, uint16_t y, uint32_t nowMs);
+    // Physical-keyboard text entry (T-Pager): polls Board::Keyboard each tick and
+    // maps keys to insert/delete/commit. No-op on boards without a keyboard
+    // (Board::Keyboard::present() == false).
+    void handleTextEntryKeyboard(uint32_t nowMs);
     void activateTextEntryButton(size_t buttonIndex, uint32_t nowMs);
     void commitTextEntry(uint32_t nowMs);
     String configuredWifiSsid();

--- a/src/board/BoardImu.h
+++ b/src/board/BoardImu.h
@@ -16,4 +16,14 @@ namespace Board::Imu {
     bool writeRegister(uint8_t address, uint8_t reg, uint8_t value);
     bool readRegisters(uint8_t address, uint8_t startReg, uint8_t* buffer, size_t len);
 
-} // namespace Board::Imu
+#ifdef RSVP_BOARD_TPAGER
+// T-LoRa-Pager only. The IMU here is a Bosch BHI260AP sensor hub driven by the
+// LilyGoLib BSP, not a QMI8658 on a raw I2C bus, so the register helpers above
+// do not apply. begin() boots the hub's gravity virtual sensor; readGravity()
+// returns the latest gravity direction as a unit vector (magnitude ~1). The
+// focus timer uses these in place of the register path.
+bool begin();
+bool readGravity(float &gx, float &gy, float &gz);
+#endif
+
+}  // namespace Board::Imu

--- a/src/board/BoardKeyboard.cpp
+++ b/src/board/BoardKeyboard.cpp
@@ -1,0 +1,16 @@
+#include "board/BoardKeyboard.h"
+
+// Default backend for boards without a physical keyboard: text entry uses the
+// on-screen virtual keyboard. The T-LoRa-Pager replaces this file with its own
+// TCA8418-backed implementation (see platforms/lilygo_tlora_pager/BoardKeyboard.cpp).
+
+namespace Board::Keyboard {
+
+bool present() { return false; }
+
+bool readChar(char &c) {
+  (void)c;
+  return false;
+}
+
+}  // namespace Board::Keyboard

--- a/src/board/BoardKeyboard.h
+++ b/src/board/BoardKeyboard.h
@@ -1,0 +1,15 @@
+#pragma once
+
+namespace Board::Keyboard {
+
+// True if this board has a physical keyboard. When true, the on-screen virtual
+// keyboard is suppressed and text entry is driven by readChar().
+bool present();
+
+// Polls the physical keyboard. Returns true and sets `c` to the resolved
+// character for a key pressed this poll: a printable character, ' ' (space),
+// '\n' (enter/confirm) or '\b' (backspace). Returns false when nothing was
+// pressed. Boards without a physical keyboard always return false.
+bool readChar(char &c);
+
+}  // namespace Board::Keyboard

--- a/src/display/DisplayManager.cpp
+++ b/src/display/DisplayManager.cpp
@@ -3141,7 +3141,12 @@ void DisplayManager::renderFocusTimerScreen(const String &mode, const String &ge
   progressPercent = std::max(-1, std::min(100, progressPercent));
   const int virtualWidth = logicalWidth();
   const int virtualHeight = logicalHeight();
-  const bool portrait = isPortraitOrientation(uiOrientation_);
+  // Use the portrait layout only when the logical panel is actually taller than
+  // it is wide. Some boards (e.g. the T-LoRa-Pager) run at their identity
+  // orientation -- reported as "Portrait" -- on a physically landscape panel
+  // (480x222); the tall-portrait layout would push the timer text below the
+  // visible area, so those fall through to the landscape layout instead.
+  const bool portrait = isPortraitOrientation(uiOrientation_) && virtualHeight >= virtualWidth;
   const bool timerRunning = progressPercent >= 0;
 
   String renderKey;
@@ -3335,7 +3340,8 @@ void DisplayManager::renderFocusTimerScreen(const String &mode, const String &ge
     return std::max(blockX, blockX + ((blockWidth - textWidth) / 2));
   };
 
-  const bool portraitFocusLayout = portrait && !breakAccent && (mode == "BEGIN" || mode == "WORK");
+  const bool portraitFocusLayout =
+      portrait && !breakAccent && (mode == "BEGIN" || mode == "WORK" || mode == "FOCUS");
   int titleScale = portrait ? 5 : 7;
   if (portraitFocusLayout && timerRunning) {
     titleScale = 4;
@@ -3394,14 +3400,32 @@ void DisplayManager::renderFocusTimerScreen(const String &mode, const String &ge
 
     drawTinyTextAt(mode, centeredXForTiny(mode, titleScale), titleY, baseTextColor, titleScale);
 
+    int instructionY = titleY + (kTinyGlyphHeight * titleScale) + (portrait ? 42 : 28);
+    if (portraitFocusLayout) {
+      instructionY = dividerY + 66;
+    }
+
+    // A non-empty timer in a non-running state is the selectable pre-start
+    // duration: touchless boards let the rotary pick the block length before
+    // starting. Draw it between the title and the instruction so the rotary
+    // feedback is visible. (Orientation boards leave this empty and are
+    // unaffected.)
+    if (!timer.isEmpty()) {
+      int durationScale = portrait ? 4 : 6;
+      while (durationScale > 1 && measureTinyTextWidth(timer, durationScale) > contentWidth) {
+        --durationScale;
+      }
+      const int durationY = titleY + (kTinyGlyphHeight * titleScale) + (portrait ? 20 : 14);
+      drawTinyTextAt(timer, centeredXForTiny(timer, durationScale), durationY, accent,
+                     durationScale);
+      instructionY = durationY + (kTinyGlyphHeight * durationScale) + (portrait ? 22 : 16);
+    }
+
     if (!instruction.isEmpty()) {
       const std::vector<String> lines =
           wrapTinyLines(instruction, instructionBlockWidth, instructionScale);
       const int lineHeight = (kTinyGlyphHeight * instructionScale) + instructionScale + 4;
-      int y = titleY + (kTinyGlyphHeight * titleScale) + (portrait ? 42 : 28);
-      if (portraitFocusLayout) {
-        y = dividerY + 66;
-      }
+      int y = instructionY;
       for (const String &line : lines) {
         drawTinyTextAt(line,
                        centeredXWithin(line, instructionScale, instructionBlockX,

--- a/src/idf_component.yml
+++ b/src/idf_component.yml
@@ -1,0 +1,2 @@
+dependencies:
+  idf: '>=5.1'

--- a/src/platforms/lilygo_tlora_pager/BoardAudio.cpp
+++ b/src/platforms/lilygo_tlora_pager/BoardAudio.cpp
@@ -1,0 +1,64 @@
+#include "board/BoardAudio.h"
+
+#include <Arduino.h>
+#include <math.h>
+
+#include "platforms/lilygo_tlora_pager/TPagerHardware.h"
+
+// LilyGo T-LoRa-Pager audio cues via the ES8311 codec (driven by LilyGoLib).
+// Implements the Board::Audio surface used by App (begin/beep/available).
+
+namespace {
+
+constexpr uint32_t kSampleRateHz = 16000;
+constexpr uint32_t kBeepDurationMs = 120;
+constexpr size_t kBeepFrames = (static_cast<size_t>(kSampleRateHz) * kBeepDurationMs) / 1000U;
+
+bool gAvailable = false;
+int16_t gBeepBuffer[kBeepFrames] = {};
+
+}  // namespace
+
+namespace Board::Audio {
+
+bool begin() {
+  tpager::ensureBegun();
+  // Enable the Class-D speaker amplifier rail (XL9555 GPIO1). The codec itself
+  // is brought up by LilyGoLib::begin().
+  tpager::hw().powerControl(POWER_SPEAK, true);
+  gAvailable = true;
+  return true;
+}
+
+bool available() { return gAvailable; }
+
+bool beep() {
+  if (!gAvailable) {
+    return false;
+  }
+
+  // Synthesize a short 1 kHz mono tone with a quick attack/decay envelope so it
+  // does not click.
+  constexpr float kToneHz = 1000.0f;
+  constexpr float kAmplitude = 8000.0f;
+  const float fadeFrames = static_cast<float>(kSampleRateHz) * 0.008f;  // 8 ms ramps
+  for (size_t frame = 0; frame < kBeepFrames; ++frame) {
+    const float t = static_cast<float>(frame) / static_cast<float>(kSampleRateHz);
+    float envelope = 1.0f;
+    if (frame < fadeFrames) {
+      envelope = static_cast<float>(frame) / fadeFrames;
+    } else if (frame > kBeepFrames - fadeFrames) {
+      envelope = static_cast<float>(kBeepFrames - frame) / fadeFrames;
+    }
+    const float value = sinf(2.0f * static_cast<float>(PI) * kToneHz * t) * kAmplitude * envelope;
+    gBeepBuffer[frame] = static_cast<int16_t>(value);
+  }
+
+  EspCodec &codec = tpager::hw().codec;
+  codec.open(16, 1, kSampleRateHz);  // 16-bit, mono
+  codec.setVolume(80);
+  codec.write(reinterpret_cast<uint8_t *>(gBeepBuffer), kBeepFrames * sizeof(int16_t));
+  return true;
+}
+
+}  // namespace Board::Audio

--- a/src/platforms/lilygo_tlora_pager/BoardConfig.h
+++ b/src/platforms/lilygo_tlora_pager/BoardConfig.h
@@ -1,0 +1,186 @@
+#pragma once
+
+#include "board/BoardTypes.h"
+
+// ---------------------------------------------------------------------------
+// LilyGo T-LoRa-Pager platform config.
+//
+// ST7796U SPI panel (480x222 landscape), rotary encoder + TCA8418 keyboard
+// (no touch panel), XL9555 IO expander, BQ25896 charger + BQ27220 fuel gauge,
+// SPI SD card, ES8311 audio + DRV2605 haptics. All peripheral access goes
+// through the LilyGoLib BSP (see platforms/lilygo_tlora_pager/TPagerHardware.h);
+// the pin constants below are mostly informational because LilyGoLib owns the
+// buses. The Board:: backends in this directory are fully custom and route
+// every access through LilyGoLib rather than the shared direct-GPIO drivers.
+//
+// Display geometry: the ST7796 panel is natively landscape (480x222), so the
+// renderer uses the identity (Portrait) orientation -- logical canvas maps
+// straight onto the panel, never the native-portrait rotation the Waveshare
+// boards use. The left-handed / flipped mode is a true 180 deg flip
+// (PortraitFlipped).
+//
+// Buttons: the only user-readable hardware button is the physical BOOT button
+// (GPIO0), wired here as PIN_PWR_BUTTON. In App's button model that gives:
+//   short press -> open/close menu (toggleMenuFromPowerButton)
+//   long press  -> power-off confirm (SUPPORTS_SOFTWARE_POWEROFF)
+// The rotary encoder and its center push are synthesized into touch gestures by
+// platforms/lilygo_tlora_pager/InputTouch.cpp (rotate = navigation/WPM/scrub,
+// center = select / play-pause). There is no second physical button, so
+// PIN_BOOT_BUTTON / PIN_KEY_BUTTON are inert (-1).
+// ---------------------------------------------------------------------------
+
+namespace Board::Config {
+
+using UiOrientation = Board::UiOrientation;
+using BatteryStatus = Board::BatteryStatus;
+using PowerDiagnosticSnapshot = Board::PowerDiagnosticSnapshot;
+
+constexpr const char *BOARD_ID = "lilygo_t_lora_pager";
+constexpr const char *BOARD_LABEL = "LilyGo T-LoRa-Pager";
+constexpr const char *OTA_ASSET_NAME = "rsvp-nano-tpager-ota.bin";
+
+// SD shares the main SPI bus and is mounted by LilyGoLib (installSD()), not the
+// SDMMC peripheral. The mount lives in this platform's BoardStorage backend; the
+// post-PR#120 Board layer no longer carries a declarative StorageBusKind here.
+
+constexpr bool HAS_LCD_BACKLIGHT = true;   // AW9364 charge-pump, driven by LilyGoLib.
+constexpr bool HAS_AUDIO_OUTPUT = true;
+constexpr bool TOUCH_USES_WIRE1 = false;
+// This board's IMU is a Bosch BHI260AP sensor hub (I2C 0x28), already booted
+// and owned by the LilyGoLib BSP -- not a QMI8658 on a raw bus. The platform
+// Board::Imu backend (platforms/lilygo_tlora_pager/BoardImu.cpp) reads its
+// gravity virtual sensor through the BSP, so the focus timer's movement
+// detection works. The Wire/release/address fields below are unused on this
+// board (the generic QMI8658 path is excluded); kept for config completeness.
+constexpr bool HAS_IMU = true;
+constexpr bool IMU_USES_WIRE1 = false;
+constexpr bool IMU_RELEASE_BUS_BEFORE_READ = false;
+constexpr uint8_t IMU_I2C_ADDRESS = 0x28;
+
+constexpr bool SWAP_APP_BOOT_AND_POWER_BUTTONS = false;
+constexpr bool APP_POWER_BUTTON_USES_PMU_EVENTS = false;
+constexpr bool BOOT_BUTTON_WAKES_STANDBY = true;
+constexpr bool ENABLE_TOP_EDGE_MENU_SWIPE = true;
+constexpr bool ENABLE_BOTTOM_EDGE_QUICK_SETTINGS_SWIPE = true;
+constexpr bool FIRMWARE_POWER_BUTTON_ENABLED = true;
+constexpr bool BOOT_BUTTON_TOGGLES_READER = true;
+// Touchless board: a reader center tap (synthesized from the rotary push) toggles
+// playback, since there is no dedicated KEY/BOOT button to start RSVP. In the
+// post-PR#120 Board layer this is the app-facing TOUCH_READER_PLAYBACK_ENABLED
+// knob; READER_TAP_TOGGLES_PLAYBACK is kept only for this platform's own
+// backends and is otherwise unused by shared code.
+constexpr bool READER_TAP_TOGGLES_PLAYBACK = true;
+constexpr bool TOUCH_READER_PLAYBACK_ENABLED = true;
+// The center tap toggles playback rather than only pausing a locked reader.
+constexpr bool READER_SINGLE_TAP_PAUSES_WHILE_LOCKED = false;
+constexpr bool BOOT_BUTTON_BACKS_OUT_OF_MENU = true;
+constexpr bool BOOT_BUTTON_HOLD_STARTS_STANDBY = true;
+// Use the legacy flat menu, not the restructured one. The restructured layout
+// relocates Focus Timer and Companion sync into the Quick Settings panel, which
+// is only reachable by a bottom-edge touch swipe. This board synthesizes swipes
+// from the rotary encoder anchored at screen center (see InputTouch.cpp), so it
+// can never trigger that gesture and both entries would be unreachable. The flat
+// menu lists them as top-level items, navigable by rotary scroll + center tap.
+constexpr bool ENABLE_RESTRUCTURED_MENU = false;
+
+constexpr int PIN_BOOT_BUTTON = -1;  // No second physical button; kept inert.
+constexpr int PIN_PWR_BUTTON = 0;    // Physical BOOT button (GPIO0).
+constexpr int PIN_KEY_BUTTON = -1;   // No dedicated key button.
+constexpr int PIN_BATTERY_ADC = -1;  // Battery read via BQ27220 fuel gauge.
+constexpr int PIN_BATTERY_HOLD = -1;
+
+// ST7796 is SPI (not QSPI); informational only -- LilyGoLib drives the panel.
+constexpr int PIN_LCD_CS = 38;
+constexpr int PIN_LCD_SCLK = 35;
+constexpr int PIN_LCD_DATA0 = 34;  // MOSI on the shared SPI bus.
+constexpr int PIN_LCD_DATA1 = -1;
+constexpr int PIN_LCD_DATA2 = -1;
+constexpr int PIN_LCD_DATA3 = -1;
+constexpr int PIN_LCD_RST = -1;       // Display RESET is not connected.
+constexpr int PIN_LCD_BACKLIGHT = 42;  // AW9364 backlight driver (LilyGoLib-managed).
+
+constexpr int PANEL_NATIVE_WIDTH = 480;
+constexpr int PANEL_NATIVE_HEIGHT = 222;
+constexpr int DISPLAY_WIDTH = 480;
+constexpr int DISPLAY_HEIGHT = 222;
+constexpr int READER_CHROME_MARGIN_X = 12;
+constexpr int READER_CHROME_MARGIN_TOP = 8;
+constexpr int READER_CHROME_MARGIN_BOTTOM = 8;
+constexpr int READER_BATTERY_MARGIN_X = READER_CHROME_MARGIN_X;
+constexpr int READER_BATTERY_MARGIN_TOP = READER_CHROME_MARGIN_TOP;
+constexpr int PIN_DEEP_SLEEP_WAKE = PIN_PWR_BUTTON;  // ext0 wake on the BOOT button.
+constexpr bool SUPPORTS_SOFTWARE_POWEROFF = true;
+constexpr bool RELEASE_BATTERY_HOLD_BEFORE_DEEP_SLEEP = false;
+constexpr bool REQUEST_PMU_SHUTDOWN_ON_POWEROFF = false;
+constexpr bool SOFTWARE_POWEROFF_USES_SOFT_LOOP = false;
+constexpr bool SOFT_OFF_WAKE_USES_POWER_BUTTON = false;
+constexpr bool SOFT_OFF_WAKE_USES_BOOT_BUTTON = false;
+constexpr bool PMU_REQUIRES_POWER_KEY_CONFIG = false;
+constexpr bool AXP2101_RELEASE_BUS_BEFORE_READ = false;
+constexpr bool AXP2101_ENABLE_POWER_KEY_IRQS = false;
+constexpr bool TCA9554_HAS_DISPLAY_SEQUENCE = false;
+constexpr bool TCA9554_HAS_POWER_BUTTON = false;
+constexpr bool TCA9554_RELEASE_BUS_BEFORE_READ = false;
+constexpr uint8_t PMU_POWER_KEY_ON_TIME_VALUE = 0x00;
+constexpr uint8_t PMU_POWER_KEY_OFF_TIME_VALUE = 0x00;
+constexpr uint32_t PMU_BOOT_BUTTON_IGNORE_MS = 1200;
+constexpr uint32_t SOFT_OFF_WAKE_CONFIRM_MS = 90;
+constexpr uint32_t SYSTEM_I2C_CLOCK_HZ = 300000;
+constexpr uint32_t SYSTEM_I2C_TIMEOUT_MS = 10;
+constexpr uint32_t TOUCH_I2C_CLOCK_HZ = 300000;
+constexpr uint32_t TOUCH_I2C_TIMEOUT_MS = 10;
+constexpr size_t DISPLAY_TX_CHUNK_BYTES = 16 * 1024;
+constexpr bool UI_ROTATED_180 = false;  // Panel is natively landscape; identity map.
+constexpr UiOrientation DEFAULT_UI_ORIENTATION =
+    UI_ROTATED_180 ? UiOrientation::PortraitFlipped : UiOrientation::Portrait;
+constexpr UiOrientation ROTATED_UI_ORIENTATION =
+    UI_ROTATED_180 ? UiOrientation::Portrait : UiOrientation::PortraitFlipped;
+
+// SD shares the main SPI bus; informational only (LilyGoLib::installSD() owns the
+// mount, power rail, CS pin and shared-bus settings).
+constexpr int PIN_SD_CLK = 35;
+constexpr int PIN_SD_CMD = 34;
+constexpr int PIN_SD_D0 = 33;
+constexpr int PIN_I2C_SDA = 3;
+constexpr int PIN_I2C_SCL = 2;
+
+// No touch panel on this board. The constants below exist only so the shared
+// touch-config surface compiles; the generic input/InputTouch.cpp is excluded
+// for this platform in favour of the rotary-encoder InputTouch.cpp here.
+constexpr int PIN_TOUCH_SDA = -1;
+constexpr int PIN_TOUCH_SCL = -1;
+constexpr int PIN_TOUCH_IRQ = -1;
+constexpr int PIN_TOUCH_RST = -1;
+constexpr uint8_t TOUCH_I2C_ADDRESS = 0x00;
+constexpr bool TOUCH_REQUIRES_MONITOR_MODE = false;
+constexpr bool TOUCH_RELEASE_BUS_BEFORE_READ = false;
+constexpr uint8_t TOUCH_MONITOR_MODE_REGISTER = 0x00;
+constexpr uint8_t TOUCH_MONITOR_MODE_VALUE = 0x00;
+constexpr uint32_t TOUCH_POLL_INTERVAL_MS = 20;
+constexpr uint32_t TOUCH_FAILURE_BACKOFF_MS = 250;
+constexpr uint32_t TOUCH_RECOVERY_RETRY_MS = 1000;
+constexpr uint32_t TOUCH_RECOVERY_EVENT_IGNORE_MS = 0;
+
+// XL9555 is the IO expander on this board (not TCA9554). These placeholders keep
+// shared code that references the TCA9554 names compiling; the custom Board
+// backends never touch them (expander access goes through LilyGoLib).
+constexpr int TCA9554_ADDRESS = 0x20;
+constexpr uint8_t TCA9554_PIN_BACKLIGHT_ENABLE = 0;
+constexpr uint8_t TCA9554_PIN_PWR_BUTTON = 0;
+constexpr uint8_t TCA9554_PIN_PMU_IRQ = 0;
+constexpr uint8_t TCA9554_PIN_SD_ENABLE = 0;
+constexpr uint8_t TCA9554_PIN_TOUCH_RESET = 0;
+constexpr uint8_t TCA9554_PIN_LCD_RESET = 0;
+constexpr uint8_t TCA9554_PIN_DISPLAY_ENABLE = 0;
+constexpr uint8_t TCA9554_PIN_SYS_EN = 0;
+constexpr uint8_t TCA9554_PIN_AUDIO_ENABLE = 0;
+
+// ES8311 audio (informational; LilyGoLib's codec owns the I2S/I2C setup).
+constexpr int PIN_AUDIO_MCLK = 10;
+constexpr int PIN_AUDIO_BCLK = 11;
+constexpr int PIN_AUDIO_WS = 18;
+constexpr int PIN_AUDIO_DIN = 17;
+constexpr int PIN_AUDIO_DOUT = 45;
+constexpr uint8_t ES8311_ADDRESS = 0x18;
+
+}  // namespace Board::Config

--- a/src/platforms/lilygo_tlora_pager/BoardConfig.h
+++ b/src/platforms/lilygo_tlora_pager/BoardConfig.h
@@ -65,10 +65,10 @@ constexpr bool ENABLE_BOTTOM_EDGE_QUICK_SETTINGS_SWIPE = true;
 constexpr bool FIRMWARE_POWER_BUTTON_ENABLED = true;
 constexpr bool BOOT_BUTTON_TOGGLES_READER = true;
 // Touchless board: a reader center tap (synthesized from the rotary push) toggles
-// playback, since there is no dedicated KEY/BOOT button to start RSVP. In the
-// post-PR#120 Board layer this is the app-facing TOUCH_READER_PLAYBACK_ENABLED
-// knob; READER_TAP_TOGGLES_PLAYBACK is kept only for this platform's own
-// backends and is otherwise unused by shared code.
+// playback, since there is no dedicated KEY/BOOT button to start RSVP. Because the
+// tap is a deliberate rotary center push (not an accidental screen touch), App
+// treats it as a single-tap play/pause toggle when READER_TAP_TOGGLES_PLAYBACK is
+// set, instead of the double-tap handleReaderTap() path the touch boards use.
 constexpr bool READER_TAP_TOGGLES_PLAYBACK = true;
 constexpr bool TOUCH_READER_PLAYBACK_ENABLED = true;
 // The center tap toggles playback rather than only pausing a locked reader.

--- a/src/platforms/lilygo_tlora_pager/BoardDisplay.cpp
+++ b/src/platforms/lilygo_tlora_pager/BoardDisplay.cpp
@@ -1,0 +1,124 @@
+#include "board/BoardDisplay.h"
+
+#include <Arduino.h>
+
+#include "board/BoardConfig.h"
+#include "platforms/lilygo_tlora_pager/TPagerHardware.h"
+
+// LilyGo T-LoRa-Pager display backend.
+//
+// DisplayManager renders into a native-geometry framebuffer (480x222) and pushes
+// pixel bands through Board::Display::pushColors. On the Waveshare boards those
+// calls hit the AXS15231B QSPI driver; here they are implemented against
+// LilyGoLib's ST7796 SPI panel so the renderer is unchanged.
+//
+// Geometry note: BoardConfig sets the panel to 480x222 and the renderer uses the
+// identity (Portrait) orientation, so the (x, y, width, height) bands map
+// straight onto the panel. LilyGoLib's pushColors(x, y, w, h, color) calls
+// setAddrWindow(x, y, x+w-1, y+h-1), matching the renderer's expectations.
+
+#ifndef RSVP_TPAGER_ROTATION
+// LilyGoLib's LoRaPager rotation table maps the panel's DISP_WIDTH=222 /
+// DISP_HEIGHT=480 as: rotation 0 & 2 -> 480x222 landscape (49px row offset),
+// rotation 1 & 3 -> 222x480 portrait. So landscape (what the UI expects) is
+// rotation 0; the 180 deg flip is rotation 2. If the image is upside-down for
+// your handedness, use the left-handed UI mode or set this to 2.
+#define RSVP_TPAGER_ROTATION 0
+#endif
+
+namespace {
+
+constexpr uint8_t kMaxBrightnessLevel = 16;  // AW9364 has 16 brightness steps.
+uint8_t gBrightnessPercent = 100;
+bool gBacklightOn = false;
+
+uint8_t levelForPercent(uint8_t percent) {
+  if (percent == 0) {
+    return 0;
+  }
+  uint16_t level = (static_cast<uint16_t>(percent) * kMaxBrightnessLevel + 50) / 100;
+  if (level < 1) {
+    level = 1;
+  } else if (level > kMaxBrightnessLevel) {
+    level = kMaxBrightnessLevel;
+  }
+  return static_cast<uint8_t>(level);
+}
+
+void applyBacklight() {
+  tpager::hw().setBrightness(gBacklightOn ? levelForPercent(gBrightnessPercent) : 0);
+}
+
+}  // namespace
+
+namespace Board::Display {
+
+bool begin() {
+  tpager::ensureBegun();
+  // LilyGoLib::begin() already brought up the ST7796 (in portrait). Force the
+  // landscape orientation the UI expects.
+  tpager::hw().setRotation(RSVP_TPAGER_ROTATION);
+  gBacklightOn = false;
+  applyBacklight();
+  return true;
+}
+
+Board::UiOrientation defaultUiOrientation() {
+  return Board::Config::DEFAULT_UI_ORIENTATION;
+}
+
+Board::UiOrientation rotatedUiOrientation() {
+  return Board::Config::ROTATED_UI_ORIENTATION;
+}
+
+uint16_t nativeWidth() { return Board::Config::PANEL_NATIVE_WIDTH; }
+
+uint16_t nativeHeight() { return Board::Config::PANEL_NATIVE_HEIGHT; }
+
+size_t txChunkBytes() { return Board::Config::DISPLAY_TX_CHUNK_BYTES; }
+
+void holdBacklightOffForDeepSleep() {
+  // The backlight is an AW9364 charge-pump driver controlled by LilyGoLib, not a
+  // plain PWM pin, so drop it through the driver rather than forcing the GPIO.
+  gBacklightOn = false;
+  tpager::hw().setBrightness(0);
+}
+
+void setBacklight(bool on) {
+  gBacklightOn = on;
+  applyBacklight();
+}
+
+void setBrightness(uint8_t percent) {
+  if (percent > 100) {
+    percent = 100;
+  }
+  gBrightnessPercent = percent;
+  if (gBacklightOn) {
+    applyBacklight();
+  }
+}
+
+void sleep() {
+  // For light sleep DisplayManager blanks the frame first; here we only cut the
+  // backlight and leave panel RAM intact, mirroring the Waveshare behavior.
+  gBacklightOn = false;
+  applyBacklight();
+}
+
+void wake() {
+  gBacklightOn = true;
+  applyBacklight();
+}
+
+bool pushColors(uint16_t x, uint16_t y, uint16_t width, uint16_t height,
+                const uint16_t *data) {
+  if (data == nullptr || width == 0 || height == 0) {
+    return false;
+  }
+  // LilyGoLib's pushColors writes the band and does not mutate the buffer.
+  tpager::hw().pushColors(x, y, width, height, const_cast<uint16_t *>(data));
+  return true;
+}
+
+}  // namespace Board::Display

--- a/src/platforms/lilygo_tlora_pager/BoardImu.cpp
+++ b/src/platforms/lilygo_tlora_pager/BoardImu.cpp
@@ -1,0 +1,129 @@
+#include "board/BoardImu.h"
+
+#include <Arduino.h>
+#include <SensorBHI260AP.hpp>
+#include <bosch/BoschSensorDataHelper.hpp>
+
+#include "board/BoardConfig.h"
+#include "platforms/lilygo_tlora_pager/TPagerHardware.h"
+
+// LilyGo T-LoRa-Pager IMU backend.
+//
+// This board's IMU is a Bosch BHI260AP smart sensor hub (I2C 0x28), booted and
+// owned by the LilyGoLib BSP, which uploads its firmware during begin(). It is
+// not a QMI8658 on a raw I2C bus, so the generic register-level Board::Imu
+// driver (board/BoardImu.cpp) is excluded for this platform (see platformio.ini)
+// and replaced here.
+//
+// The focus timer only needs the gravity direction to detect how the device is
+// resting (flat / on a short side / flipped). We subscribe to the hub's gravity
+// virtual sensor through SensorLib's SensorXYZ helper and hand FocusTimer a unit
+// gravity vector; its existing classify()/state machine is unchanged. Only
+// available(), begin() and readGravity() are defined -- nothing on this board
+// references the register/probe helpers, so they are intentionally absent.
+
+namespace Board::Imu {
+namespace {
+
+// The gravity virtual sensor reports the gravity direction with magnitude ~1g.
+// 25 Hz with no batching resolves a placement/flip well within the focus timer's
+// 700 ms orientation-stability window at negligible bus cost.
+constexpr float kGravitySampleRateHz = 25.0f;
+constexpr uint32_t kGravityReportLatencyMs = 0;
+
+bool gEnabled = false;
+bool gHasSample = false;
+
+// UI orientation tracked for the generic Board::Imu seam. The synthetic
+// rotary/center input (BoardInput.cpp) is anchored at screen center, so the
+// generic touch poller maps it with the identity (Portrait) transform here.
+Board::UiOrientation gUiOrientation = Board::Config::DEFAULT_UI_ORIENTATION;
+float gLastX = 0.0f;
+float gLastY = 0.0f;
+float gLastZ = 0.0f;
+
+// Constructed lazily after the BSP exists. tpager::hw() returns the singleton
+// board object (whose `sensor` member is valid before begin()), and SensorXYZ
+// only stores the id + a reference, so this touches no hardware at construction.
+SensorXYZ &gravitySensor() {
+  static SensorXYZ sensor(SensorBHI260AP::GRAVITY_VECTOR, tpager::hw().sensor);
+  return sensor;
+}
+
+}  // namespace
+
+bool available() { return Board::Config::HAS_IMU; }
+
+// --- New Board::Imu register seam --------------------------------------------
+// This board's IMU is a BHI260AP sensor hub owned by LilyGoLib, not a register-
+// addressable QMI8658 on a raw bus, so the generic register/probe helpers do not
+// apply: they report "no device" so the shared orientation/probe code is inert.
+// The gravity backend used by the focus timer lives in begin()/readGravity()
+// below (declared under RSVP_BOARD_TPAGER in board/BoardImu.h).
+const char *wireName() { return "BSP"; }
+
+uint8_t address() { return Board::Config::IMU_I2C_ADDRESS; }
+
+Board::UiOrientation uiOrientation() { return gUiOrientation; }
+
+void setUiOrientation(Board::UiOrientation orientation) { gUiOrientation = orientation; }
+
+bool probeAddress(uint8_t) { return false; }
+
+bool readRegister(uint8_t, uint8_t, uint8_t &) { return false; }
+
+bool writeRegister(uint8_t, uint8_t, uint8_t) { return false; }
+
+bool readRegisters(uint8_t, uint8_t, uint8_t *, size_t) { return false; }
+
+bool begin() {
+  if (!Board::Config::HAS_IMU) {
+    return false;
+  }
+  tpager::ensureBegun();
+  if (gEnabled) {
+    return true;
+  }
+  if (!gravitySensor().enable(kGravitySampleRateHz, kGravityReportLatencyMs)) {
+    Serial.println("[timer] BHI260AP gravity sensor enable failed");
+    return false;
+  }
+  gEnabled = true;
+  gHasSample = false;
+  Serial.println("[timer] BHI260AP gravity sensor enabled");
+  return true;
+}
+
+bool readGravity(float &gx, float &gy, float &gz) {
+  if (!gEnabled) {
+    return false;
+  }
+
+  // Pump the hub's FIFO so the helper sees fresh frames; cache the latest so a
+  // poll between frames still returns the last known direction.
+  tpager::hw().sensor.update();
+  SensorXYZ &sensor = gravitySensor();
+  if (sensor.hasUpdated()) {
+    gLastX = sensor.getX();
+    gLastY = sensor.getY();
+    gLastZ = sensor.getZ();
+    gHasSample = true;
+  }
+
+  if (!gHasSample) {
+    return false;
+  }
+
+  // Normalize to a unit vector so FocusTimer::classify()'s g-based thresholds
+  // are independent of the hub's output scaling/units.
+  const float magnitude = sqrtf(gLastX * gLastX + gLastY * gLastY + gLastZ * gLastZ);
+  if (magnitude < 1e-3f) {
+    return false;
+  }
+  gx = gLastX / magnitude;
+  gy = gLastY / magnitude;
+  gz = gLastZ / magnitude;
+  return true;
+}
+
+}  // namespace Board::Imu

--- a/src/platforms/lilygo_tlora_pager/BoardInput.cpp
+++ b/src/platforms/lilygo_tlora_pager/BoardInput.cpp
@@ -1,0 +1,205 @@
+#include "board/BoardInput.h"
+
+#include <Arduino.h>
+
+#include "board/BoardConfig.h"
+#include "platforms/lilygo_tlora_pager/TPagerHardware.h"
+
+// LilyGo T-LoRa-Pager input backend (post-PR#120 Board::Input seam).
+//
+// This board has no touch panel and a single physical BOOT button, so it maps
+// onto the generic Input:: state machine (input/Input.cpp) like this:
+//
+//   * Controls: the BOOT button (GPIO0, wired as PIN_PWR_BUTTON) reports as
+//     InputPower. App turns an InputPower short press into open/close menu
+//     (toggleMenuFromPowerButton) and a long press into the power-off confirm --
+//     matching this board's single-button model.
+//
+//   * Touch: there is no touch hardware. Instead readTouch() synthesizes a touch
+//     contact trajectory from the rotary encoder and its centre push, so the
+//     generic poller derives the very same TouchStart/TouchMove/TouchEnd/Tapped
+//     gestures a real panel would, and App's touch UI is reused unchanged:
+//       rotate CW  -> synthetic swipe down -> menu next / reader WPM- / timer +
+//       rotate CCW -> synthetic swipe up   -> menu prev / reader WPM+ / timer -
+//       centre push-> synthetic tap        -> select / play-pause / start-stop
+//     The contacts are emitted in logical (display) coordinates anchored at the
+//     screen centre, so the gesture is independent of orientation; Board::Imu
+//     reports the identity (Portrait) orientation, so the generic mapper passes
+//     them through unrotated.
+//
+// Latency note: getRotary() blocks up to ~50 ms when the encoder queue is empty,
+// so the idle loop runs at ~20 Hz. A small FIFO of pending synthetic contacts is
+// drained first, so a multi-contact gesture still flushes without re-blocking.
+
+namespace {
+
+// Synthetic gesture geometry, in logical (display) pixels. The vertical delta
+// must clear App's swipe threshold (kSwipeThresholdPx 40 + kAxisBiasPx 12) so it
+// reads as a directional swipe rather than a tap.
+constexpr int kCenterX = Board::Config::DISPLAY_WIDTH / 2;
+constexpr int kCenterY = Board::Config::DISPLAY_HEIGHT / 2;
+constexpr int kSynthSwipePx = 64;
+
+// A gesture enqueues its touched samples plus two released samples; the generic
+// poller needs releaseConfirmSamples (2) empty reads to close a touch, and the
+// explicit releases keep consecutive rotary ticks from merging into one drag.
+constexpr size_t kQueueCapacity = 16;
+
+::Input::TouchContact gQueue[kQueueCapacity];
+size_t gHead = 0;
+size_t gCount = 0;
+bool gInitialized = false;
+
+void clearQueue() {
+  gHead = 0;
+  gCount = 0;
+}
+
+void enqueue(const ::Input::TouchContact &contact) {
+  if (gCount >= kQueueCapacity) {
+    return;  // Drop overflow; input is paced far slower than this fills.
+  }
+  gQueue[(gHead + gCount) % kQueueCapacity] = contact;
+  ++gCount;
+}
+
+bool dequeue(::Input::TouchContact &contact) {
+  if (gCount == 0) {
+    return false;
+  }
+  contact = gQueue[gHead];
+  gHead = (gHead + 1) % kQueueCapacity;
+  --gCount;
+  return true;
+}
+
+::Input::TouchContact touchedAt(int x, int y) {
+  ::Input::TouchContact contact;
+  contact.touched = true;
+  contact.x = static_cast<uint16_t>(constrain(x, 0, Board::Config::DISPLAY_WIDTH - 1));
+  contact.y = static_cast<uint16_t>(constrain(y, 0, Board::Config::DISPLAY_HEIGHT - 1));
+  return contact;
+}
+
+::Input::TouchContact released() {
+  ::Input::TouchContact contact;
+  contact.touched = false;
+  contact.x = static_cast<uint16_t>(kCenterX);
+  contact.y = static_cast<uint16_t>(kCenterY);
+  return contact;
+}
+
+// direction: +1 = swipe down (rotate CW), -1 = swipe up (rotate CCW).
+void enqueueSwipe(int direction) {
+  enqueue(touchedAt(kCenterX, kCenterY));
+  enqueue(touchedAt(kCenterX, kCenterY + direction * kSynthSwipePx));
+  enqueue(released());
+  enqueue(released());
+}
+
+void enqueueTap() {
+  enqueue(touchedAt(kCenterX, kCenterY));
+  enqueue(released());
+  enqueue(released());
+}
+
+bool bootButtonPressed() {
+  if (Board::Config::PIN_PWR_BUTTON < 0) {
+    return false;
+  }
+  return !digitalRead(Board::Config::PIN_PWR_BUTTON);  // Active-low BOOT (GPIO0).
+}
+
+}  // namespace
+
+namespace Board::Input {
+
+bool begin() {
+  tpager::ensureBegun();
+  if (Config::PIN_PWR_BUTTON >= 0) {
+    pinMode(Config::PIN_PWR_BUTTON, INPUT_PULLUP);
+  }
+  tpager::hw().clearRotaryMsg();
+  clearQueue();
+  gInitialized = true;
+  return true;
+}
+
+void end() {
+  clearQueue();
+  if (gInitialized) {
+    tpager::hw().clearRotaryMsg();
+  }
+  gInitialized = false;
+}
+
+void cancel() { clearQueue(); }
+
+::Input::ControlTiming controlTiming() {
+  // Defaults: 25 ms debounce, <=700 ms short press, >=900 ms long press.
+  return {};
+}
+
+::Input::ControlMask currentControls() {
+  ::Input::ControlMask controls = ::Input::InputNone;
+  if (bootButtonPressed()) {
+    // The single BOOT button is the power button on this board: short = toggle
+    // menu, long = power-off confirm (see App::handleInputEvent).
+    controls |= ::Input::InputPower;
+  }
+  return controls;
+}
+
+::Input::TouchSurface touchSurface() {
+  return {static_cast<uint16_t>(Board::Config::DISPLAY_WIDTH),
+          static_cast<uint16_t>(Board::Config::DISPLAY_HEIGHT)};
+}
+
+::Input::TouchTiming touchTiming() {
+  // Defaults are fine: 20 ms poll, 2-sample release confirm, 40/48 px swipe etc.
+  return {};
+}
+
+bool beginTouch() {
+  if (gInitialized) {
+    tpager::hw().clearRotaryMsg();
+  }
+  clearQueue();
+  return true;
+}
+
+bool touchReady() { return true; }
+
+bool readTouch(::Input::TouchContact &contact) {
+  contact = ::Input::TouchContact{};
+
+  if (!gInitialized) {
+    return true;  // No hardware failure; just report "no contact".
+  }
+
+  // Flush any pending synthetic contacts from a gesture already in progress.
+  if (dequeue(contact)) {
+    return true;
+  }
+
+  // Otherwise read the encoder. This blocks up to ~50 ms only when idle.
+  RotaryMsg_t msg = tpager::hw().getRotary();
+
+  // Encoder direction is inverted on purpose: CW (ROTARY_DIR_UP) drives a swipe
+  // down (menu next / reader WPM- / timer longer), CCW drives a swipe up.
+  if (msg.dir == ROTARY_DIR_UP) {
+    enqueueSwipe(1);
+  } else if (msg.dir == ROTARY_DIR_DOWN) {
+    enqueueSwipe(-1);
+  }
+
+  if (msg.centerBtnPressed) {
+    tpager::hw().vibrator();  // Haptic confirmation on select / play-pause.
+    enqueueTap();
+  }
+
+  dequeue(contact);  // Returns the first queued contact, or leaves it untouched.
+  return true;
+}
+
+}  // namespace Board::Input

--- a/src/platforms/lilygo_tlora_pager/BoardKeyboard.cpp
+++ b/src/platforms/lilygo_tlora_pager/BoardKeyboard.cpp
@@ -1,0 +1,30 @@
+#include "board/BoardKeyboard.h"
+
+#include "platforms/lilygo_tlora_pager/TPagerHardware.h"
+
+// LilyGo T-LoRa-Pager physical keyboard backend.
+//
+// The board carries a TCA8418 QWERTY keyboard driven by LilyGoLib's
+// LilyGoKeyboard. getKey() resolves the keymap, the Shift/caps key and the
+// Space-as-Fn symbol layer internally, returning the final character: a letter
+// (upper-case when Shift is latched), a number/symbol (when Space-Fn is held),
+// ' ', '\n' (Enter) or '\b' (backspace). Modifier-only keys yield '\0'. We
+// surface that here so App's text entry uses the physical keys instead of the
+// on-screen keyboard.
+
+namespace Board::Keyboard {
+
+bool present() { return true; }
+
+bool readChar(char &c) {
+  char key = '\0';
+  // LilyGoKeyboard::getKey returns KB_PRESSED (1) on a key press; act on those
+  // only, and ignore modifier/no-op keys that resolve to the null character.
+  if (tpager::hw().kb.getKey(&key) != 1 || key == '\0') {
+    return false;
+  }
+  c = key;
+  return true;
+}
+
+}  // namespace Board::Keyboard

--- a/src/platforms/lilygo_tlora_pager/BoardPower.cpp
+++ b/src/platforms/lilygo_tlora_pager/BoardPower.cpp
@@ -25,6 +25,14 @@ bool enableAudioPowerIfAvailable() {
 bool readBatteryStatus(BatteryStatus &status) {
   status = BatteryStatus{};
 
+  // The BQ27220 getters return a cached register snapshot; refresh() performs the
+  // actual I2C read that repopulates it. Without this, getVoltage() returns the
+  // zero-initialized cache and the battery reads as absent. LilyGoLib only calls
+  // gauge.begin()/setNewCapacity() at init, so we must refresh on every sample.
+  if (!tpager::hw().gauge.refresh()) {
+    return false;
+  }
+
   // BQ27220 fuel gauge reports voltage in millivolts and a calibrated SoC.
   const uint16_t millivolts = tpager::hw().gauge.getVoltage();
   status.voltage = static_cast<float>(millivolts) / 1000.0f;

--- a/src/platforms/lilygo_tlora_pager/BoardPower.cpp
+++ b/src/platforms/lilygo_tlora_pager/BoardPower.cpp
@@ -1,5 +1,6 @@
 #include "board/BoardPower.h"
 
+#include "board/BoardConfig.h"
 #include "platforms/lilygo_tlora_pager/TPagerHardware.h"
 
 // LilyGo T-LoRa-Pager power backend. The BQ25896 charger and BQ27220 fuel gauge
@@ -61,14 +62,14 @@ bool releaseBatteryPowerHold() {
   return true;
 }
 
-bool supportsSoftwarePowerOff() { return Config::SUPPORTS_SOFTWARE_POWEROFF; }
+bool supportsSoftwarePowerOff() { return Board::Config::SUPPORTS_SOFTWARE_POWEROFF; }
 
 bool powerOffUsesControllerWake() { return false; }
 
-bool shouldRequestShutdownOnPowerOff() { return Config::REQUEST_PMU_SHUTDOWN_ON_POWEROFF; }
+bool shouldRequestShutdownOnPowerOff() { return Board::Config::REQUEST_PMU_SHUTDOWN_ON_POWEROFF; }
 
 bool shouldReleaseBatteryPowerBeforeDeepSleep() {
-  return Config::RELEASE_BATTERY_HOLD_BEFORE_DEEP_SLEEP;
+  return Board::Config::RELEASE_BATTERY_HOLD_BEFORE_DEEP_SLEEP;
 }
 
 }  // namespace Board::Power

--- a/src/platforms/lilygo_tlora_pager/BoardPower.cpp
+++ b/src/platforms/lilygo_tlora_pager/BoardPower.cpp
@@ -1,0 +1,66 @@
+#include "board/BoardPower.h"
+
+#include "platforms/lilygo_tlora_pager/TPagerHardware.h"
+
+// LilyGo T-LoRa-Pager power backend. The BQ25896 charger and BQ27220 fuel gauge
+// are owned by LilyGoLib; there is no programmable system-rail latch to hold or
+// release like the Waveshare TCA9554 boards. True power-off is deep sleep, woken
+// by the BOOT button (ext0 on GPIO0).
+
+namespace Board::Power {
+
+void begin() {
+  // LilyGoLib::begin() brings up the charger, fuel gauge and power rails.
+  tpager::ensureBegun();
+}
+
+void prepareDeepSleepPowerHold() {}
+
+bool enableAudioPowerIfAvailable() {
+  // Class-D speaker amplifier rail (XL9555 GPIO1).
+  tpager::hw().powerControl(POWER_SPEAK, true);
+  return true;
+}
+
+bool readBatteryStatus(BatteryStatus &status) {
+  status = BatteryStatus{};
+
+  // BQ27220 fuel gauge reports voltage in millivolts and a calibrated SoC.
+  const uint16_t millivolts = tpager::hw().gauge.getVoltage();
+  status.voltage = static_cast<float>(millivolts) / 1000.0f;
+  status.present = status.voltage >= 2.5f && status.voltage <= 4.6f;
+  if (!status.present) {
+    status.percent = 0;
+    return false;
+  }
+
+  uint16_t soc = tpager::hw().gauge.getStateOfCharge();
+  if (soc > 100) {
+    soc = 100;
+  }
+  status.percent = static_cast<uint8_t>(soc);
+  return true;
+}
+
+DiagnosticSnapshot diagnosticSnapshot() { return PowerDiagnosticSnapshot{}; }
+
+bool externalPowerPresent() { return false; }
+
+bool releaseBatteryPowerHold() {
+  // No programmable system-rail latch on this board; the caller follows up with
+  // esp_deep_sleep_start(), which reaches the documented deep-sleep state and
+  // wakes on the BOOT button (ext0 on GPIO0).
+  return true;
+}
+
+bool supportsSoftwarePowerOff() { return Config::SUPPORTS_SOFTWARE_POWEROFF; }
+
+bool powerOffUsesControllerWake() { return false; }
+
+bool shouldRequestShutdownOnPowerOff() { return Config::REQUEST_PMU_SHUTDOWN_ON_POWEROFF; }
+
+bool shouldReleaseBatteryPowerBeforeDeepSleep() {
+  return Config::RELEASE_BATTERY_HOLD_BEFORE_DEEP_SLEEP;
+}
+
+}  // namespace Board::Power

--- a/src/platforms/lilygo_tlora_pager/BoardStorage.cpp
+++ b/src/platforms/lilygo_tlora_pager/BoardStorage.cpp
@@ -1,0 +1,41 @@
+#include "board/BoardStorage.h"
+
+#include <SD.h>
+
+#include "platforms/lilygo_tlora_pager/TPagerHardware.h"
+
+// LilyGo T-LoRa-Pager storage backend.
+//
+// The SD card shares the main SPI bus and is mounted by the LilyGoLib BSP
+// (installSD()), not the ESP32 SDMMC peripheral. LilyGoLib populates the Arduino
+// `SD` object, which exposes the same fs::FS API the shared storage code uses.
+//
+// Because the card is SPI-mounted at a LilyGoLib-fixed rate, this board reports
+// supportsFrequencySelection()==false; the shared SdDiagnostics mount path then
+// calls mount() once with a default frequency (which we ignore) and never probes
+// SDMMC frequencies or pins. No SDMMC slot is configured, so USB mass storage
+// (which drives the SDMMC host directly) is disabled for this board -- see
+// platformio.ini / README-tpager.md.
+
+namespace Board::Storage {
+
+fs::FS &filesystem() { return SD; }
+
+bool mount(const char * /*mountPoint*/, int /*frequencyKhz*/) {
+  // installSD() is idempotent: it powers the SD rail, claims the shared SPI bus
+  // and mounts the card into the Arduino `SD` object, returning true once ready.
+  tpager::ensureBegun();
+  return tpager::hw().installSD();
+}
+
+void end() { SD.end(); }
+
+uint64_t cardSize() { return SD.cardSize(); }
+
+CardType cardType() { return static_cast<CardType>(SD.cardType()); }
+
+bool supportsFrequencySelection() { return false; }
+
+bool setSdMmcPins() { return false; }
+
+}  // namespace Board::Storage

--- a/src/platforms/lilygo_tlora_pager/BoardSystem.cpp
+++ b/src/platforms/lilygo_tlora_pager/BoardSystem.cpp
@@ -1,0 +1,112 @@
+#include "board/BoardDisplay.h"
+#include "board/BoardPower.h"
+#include "board/BoardSystem.h"
+
+#include <Arduino.h>
+#include <driver/gpio.h>
+#include <esp_sleep.h>
+#include <esp_system.h>
+
+#include "platforms/lilygo_tlora_pager/TPagerHardware.h"
+
+// LilyGo T-LoRa-Pager system backend. LilyGoLib owns the buses, expander, power
+// rails and panel, so most of the direct-GPIO bring-up the Waveshare boards do
+// is replaced by a single idempotent ensureBegun(). Only the BOOT button (GPIO0)
+// is configured here for normal reads and wake-from-sleep.
+
+namespace Board {
+
+namespace System {
+
+void begin() {
+  // Full BSP init must run before any Board:: backend touches a peripheral.
+  tpager::ensureBegun();
+
+  if (Config::PIN_PWR_BUTTON >= 0) {
+    pinMode(Config::PIN_PWR_BUTTON, INPUT_PULLUP);
+  }
+
+  Board::Power::begin();
+}
+
+void lightSleepUntilBootButton() {
+  const int wakePin = Config::PIN_DEEP_SLEEP_WAKE >= 0 ? Config::PIN_DEEP_SLEEP_WAKE
+                                                       : Config::PIN_PWR_BUTTON;
+  if (wakePin < 0) {
+    return;
+  }
+
+  pinMode(wakePin, INPUT_PULLUP);
+  gpio_wakeup_enable(static_cast<gpio_num_t>(wakePin), GPIO_INTR_LOW_LEVEL);
+  esp_sleep_enable_gpio_wakeup();
+  Serial.flush();
+  esp_light_sleep_start();
+  gpio_wakeup_disable(static_cast<gpio_num_t>(wakePin));
+  esp_sleep_disable_wakeup_source(ESP_SLEEP_WAKEUP_GPIO);
+}
+
+void holdBacklightOffForDeepSleep() {
+  Board::Power::prepareDeepSleepPowerHold();
+  Board::Display::holdBacklightOffForDeepSleep();
+}
+
+const char *wakeLabel(bool) { return "Press BOOT to start"; }
+
+void deepSleepUntilConfiguredWake() {
+  const int wakePin = Config::PIN_DEEP_SLEEP_WAKE;
+  if (wakePin >= 0) {
+    pinMode(wakePin, INPUT_PULLUP);
+    esp_sleep_enable_ext0_wakeup(static_cast<gpio_num_t>(wakePin), 0);
+  }
+  esp_deep_sleep_start();
+}
+
+namespace {
+
+const char *resetReasonName(esp_reset_reason_t reason) {
+  switch (reason) {
+    case ESP_RST_POWERON:
+      return "poweron";
+    case ESP_RST_EXT:
+      return "external";
+    case ESP_RST_SW:
+      return "software";
+    case ESP_RST_PANIC:
+      return "panic";
+    case ESP_RST_DEEPSLEEP:
+      return "deep_sleep";
+    case ESP_RST_BROWNOUT:
+      return "brownout";
+    case ESP_RST_UNKNOWN:
+    default:
+      return "unknown";
+  }
+}
+
+const char *wakeupCauseName(esp_sleep_wakeup_cause_t cause) {
+  switch (cause) {
+    case ESP_SLEEP_WAKEUP_EXT0:
+      return "ext0";
+    case ESP_SLEEP_WAKEUP_GPIO:
+      return "gpio";
+    case ESP_SLEEP_WAKEUP_TIMER:
+      return "timer";
+    case ESP_SLEEP_WAKEUP_UNDEFINED:
+    default:
+      return "undefined";
+  }
+}
+
+}  // namespace
+
+void logStartupDiagnostics() {
+  const esp_reset_reason_t resetReason = esp_reset_reason();
+  const esp_sleep_wakeup_cause_t wakeupCause = esp_sleep_get_wakeup_cause();
+  Serial.printf("[diag] reset=%s(%d) sleep_wake=%s(%d)\n", resetReasonName(resetReason),
+                static_cast<int>(resetReason), wakeupCauseName(wakeupCause),
+                static_cast<int>(wakeupCause));
+}
+
+}  // namespace System
+
+}  // namespace Board

--- a/src/platforms/lilygo_tlora_pager/BoardSystem.cpp
+++ b/src/platforms/lilygo_tlora_pager/BoardSystem.cpp
@@ -7,6 +7,7 @@
 #include <esp_sleep.h>
 #include <esp_system.h>
 
+#include "board/BoardConfig.h"
 #include "platforms/lilygo_tlora_pager/TPagerHardware.h"
 
 // LilyGo T-LoRa-Pager system backend. LilyGoLib owns the buses, expander, power
@@ -22,16 +23,17 @@ void begin() {
   // Full BSP init must run before any Board:: backend touches a peripheral.
   tpager::ensureBegun();
 
-  if (Config::PIN_PWR_BUTTON >= 0) {
-    pinMode(Config::PIN_PWR_BUTTON, INPUT_PULLUP);
+  if (Board::Config::PIN_PWR_BUTTON >= 0) {
+    pinMode(Board::Config::PIN_PWR_BUTTON, INPUT_PULLUP);
   }
 
   Board::Power::begin();
 }
 
 void lightSleepUntilBootButton() {
-  const int wakePin = Config::PIN_DEEP_SLEEP_WAKE >= 0 ? Config::PIN_DEEP_SLEEP_WAKE
-                                                       : Config::PIN_PWR_BUTTON;
+  const int wakePin = Board::Config::PIN_DEEP_SLEEP_WAKE >= 0
+                          ? Board::Config::PIN_DEEP_SLEEP_WAKE
+                          : Board::Config::PIN_PWR_BUTTON;
   if (wakePin < 0) {
     return;
   }
@@ -53,7 +55,7 @@ void holdBacklightOffForDeepSleep() {
 const char *wakeLabel(bool) { return "Press BOOT to start"; }
 
 void deepSleepUntilConfiguredWake() {
-  const int wakePin = Config::PIN_DEEP_SLEEP_WAKE;
+  const int wakePin = Board::Config::PIN_DEEP_SLEEP_WAKE;
   if (wakePin >= 0) {
     pinMode(wakePin, INPUT_PULLUP);
     esp_sleep_enable_ext0_wakeup(static_cast<gpio_num_t>(wakePin), 0);

--- a/src/platforms/lilygo_tlora_pager/TPagerHardware.cpp
+++ b/src/platforms/lilygo_tlora_pager/TPagerHardware.cpp
@@ -1,0 +1,43 @@
+#include "platforms/lilygo_tlora_pager/TPagerHardware.h"
+
+namespace tpager {
+namespace {
+bool gBegun = false;
+}  // namespace
+
+LilyGoLoRaPager &hw() { return instance; }
+
+void ensureBegun() {
+  if (gBegun) {
+    return;
+  }
+  // Full BSP init: display, I2C bus, XL9555 expander, fuel gauge, PMU, rotary
+  // encoder + keyboard background tasks, codec, haptics, SD power rail, radio.
+  instance.begin();
+  gBegun = true;
+
+  // Power-gate the radios this app never uses, to cut idle battery draw.
+  // LilyGo_LoRa_Pager::begin() unconditionally powers up and initializes the
+  // SX1262 LoRa radio, the GPS module and the NFC front-end. RSVP Nano is a
+  // reader; it uses none of them. Put the LoRa radio into its ~1uA sleep state
+  // (the same call LilyGoLib makes before light sleep — it releases the shared
+  // SPI bus cleanly, which is safer than cutting POWER_RADIO out from under the
+  // bus) and cut the GPS and NFC power rails outright.
+  radio.sleep();
+  instance.powerControl(POWER_GPS, false);
+  instance.powerControl(POWER_NFC, false);
+}
+
+}  // namespace tpager
+
+// LilyGoLib's LilyGo_LoRa_Pager::begin() unconditionally *references* setupMSC()
+// (USB Mass Storage), even though it only *calls* it when NO_INIT_FATFS is clear.
+// This variant disables USB transfer and excludes LilyGoLib's USB_MSC.cpp from the
+// build (see README-tpager.md), which removes the definition -- so provide a no-op
+// here to satisfy the linker without pulling in TinyUSB/USBMSC. The signature must
+// match LilyGoLib's `extern void setupMSC(lock_callback_t, lock_callback_t)`, where
+// lock_callback_t is `bool (*)(void)`.
+void setupMSC(bool (*lock_cb)(void), bool (*unlock_cb)(void)) {
+  (void)lock_cb;
+  (void)unlock_cb;
+}

--- a/src/platforms/lilygo_tlora_pager/TPagerHardware.h
+++ b/src/platforms/lilygo_tlora_pager/TPagerHardware.h
@@ -1,0 +1,24 @@
+#pragma once
+
+// Central access point to the LilyGoLib BSP for the T-LoRa-Pager platform.
+//
+// All T-Pager hardware (ST7796 display, rotary encoder, TCA8418 keyboard, SPI
+// SD card, BQ25896/BQ27220 power, ES8311 codec, DRV2605 haptics) is driven
+// through the single LilyGoLoRaPager instance. This header gives the rest of
+// the platform one idempotent entry point so initialization order does not
+// matter: every Board:: backend (System/Display/Power/Audio) and the platform
+// InputTouch can each call ensureBegun() before touching a peripheral.
+
+#include <LilyGoLib.h>
+
+namespace tpager {
+
+// Returns the LilyGoLib singleton. Call ensureBegun() before relying on any
+// peripheral being initialized.
+LilyGoLoRaPager &hw();
+
+// Runs LilyGoLib's full hardware init exactly once. Safe to call repeatedly
+// (LilyGoLib::begin() itself is guarded, and so is this wrapper).
+void ensureBegun();
+
+}  // namespace tpager

--- a/src/sync/CompanionSyncManager.cpp
+++ b/src/sync/CompanionSyncManager.cpp
@@ -7,6 +7,7 @@
 #include <cstdio>
 #include <vector>
 
+#include "net/WifiConnection.h"
 #include "settings/PreferenceKeys.h"
 #include "storage/fs/StorageFiles.h"
 #include "storage/fs/StoragePaths.h"
@@ -175,7 +176,7 @@ ul{padding-left:20px}code{background:var(--soft);border-radius:4px;padding:1px 4
 <section id="help" class="page">
 <div class="card"><h2>How to use this web companion</h2>
 <ul>
-<li>Open Companion sync on the reader, join the <code>RSVP-Nano</code> Wi-Fi network, then open this page.</li>
+<li>Open Companion sync on the reader. If it joined your home Wi-Fi, stay on that network and open the IP address shown on the reader (mDNS <code>rsvp-nano.local</code> also works on some clients). Otherwise join the reader's <code>RSVP-Nano</code> Wi-Fi network, then open this page.</li>
 <li>Use Books for prepared book files and Articles for article drafts, article uploads, and synced articles.</li>
 <li>For best book conversion, use the hosted web converter/flasher first. This page is the wireless upload and settings companion, not the full conversion engine.</li>
 <li><code>.txt</code> and <code>.epub</code> uploads are accepted, but EPUB conversion is handled on the device when opened.</li>
@@ -506,7 +507,6 @@ String rsvpMetadataValueFromLine(const String &line, const char *directive, bool
 CompanionSyncManager *CompanionSyncManager::instance_ = nullptr;
 
 bool CompanionSyncManager::begin(const Config &config) {
-  (void)config;
   if (active_) {
     return true;
   }
@@ -517,7 +517,18 @@ bool CompanionSyncManager::begin(const Config &config) {
   statusLine2_ = "Preparing Wi-Fi";
   preferences_.begin(kPrefsNamespace, false);
 
-  const bool networkReady = startAccessPoint();
+  // Prefer joining the configured Wi-Fi (station mode): the companion is then
+  // reachable from any device already on that LAN at http://rsvp-nano.local
+  // (mDNS) or the IP shown on screen, with no network switching. Fall back to
+  // hosting our own open SoftAP when no Wi-Fi is configured or the join fails,
+  // so sync still works with zero infrastructure / away from a known network.
+  bool networkReady = false;
+  if (!config.wifiSsid.isEmpty()) {
+    networkReady = startStation(config.wifiSsid, config.wifiPassword);
+  }
+  if (!networkReady) {
+    networkReady = startAccessPoint();
+  }
   if (!networkReady) {
     statusLine1_ = "Wi-Fi failed";
     statusLine2_ = "";
@@ -534,9 +545,13 @@ bool CompanionSyncManager::begin(const Config &config) {
 
   active_ = true;
   statusLine1_ = networkSsid_;
+  // Show the IP URL in both modes -- it always works, whereas mDNS (.local)
+  // resolution is unreliable on some networks/clients. mDNS stays registered as
+  // a convenience for clients that do resolve it.
   statusLine2_ = baseUrl();
-  Serial.printf("[sync] ready ssid=%s url=%s pairing=%s\n", networkSsid_.c_str(), baseUrl().c_str(),
-                pairingCode_.c_str());
+  Serial.printf("[sync] ready mode=%s ssid=%s url=%s host=%s.local pairing=%s\n",
+                networkMode_ == NetworkMode::Station ? "station" : "access_point",
+                networkSsid_.c_str(), baseUrl().c_str(), kMdnsName, pairingCode_.c_str());
   return true;
 }
 
@@ -639,6 +654,21 @@ void CompanionSyncManager::handleNotFoundStatic() {
   if (instance_ != nullptr) {
     instance_->handleNotFound();
   }
+}
+
+bool CompanionSyncManager::startStation(const String &ssid, const String &password) {
+  statusLine1_ = "Joining Wi-Fi";
+  statusLine2_ = ssid;
+  if (!net::connectStation(ssid, password)) {
+    Serial.printf("[sync] station join failed ssid=%s\n", ssid.c_str());
+    return false;
+  }
+
+  networkMode_ = NetworkMode::Station;
+  networkSsid_ = ssid;
+  Serial.printf("[sync] station ssid=%s ip=%s\n", ssid.c_str(),
+                ipToString(WiFi.localIP()).c_str());
+  return true;
 }
 
 bool CompanionSyncManager::startAccessPoint() {

--- a/src/sync/CompanionSyncManager.h
+++ b/src/sync/CompanionSyncManager.h
@@ -43,6 +43,7 @@ class CompanionSyncManager {
   static void handleBookUploadStatic();
   static void handleNotFoundStatic();
 
+  bool startStation(const String &ssid, const String &password);
   bool startAccessPoint();
   bool startServer();
   void stopServer();

--- a/src/timer/FocusTimer.cpp
+++ b/src/timer/FocusTimer.cpp
@@ -31,11 +31,35 @@ constexpr float kSideAxisThreshold = 0.78f;
 constexpr float kCrossAxisLimit = 0.42f;
 constexpr float kFlatAxisThreshold = 0.84f;
 
+#ifdef RSVP_BOARD_TPAGER
+// The T-LoRa-Pager has no touch panel and only two stable rest orientations, so
+// the place-on-side / flip hourglass mechanic cannot work. The timer is driven
+// by the rotary encoder (duration) and center button (start/cancel) instead, and
+// does not use the IMU for control. App::applyFocusTimerTouch maps the input.
+constexpr bool kButtonDrivenTimer = true;
+#else
+constexpr bool kButtonDrivenTimer = false;
+#endif
+
 }  // namespace
 
-bool FocusTimer::begin() { return initImu(); }
+bool FocusTimer::begin() {
+  if (kButtonDrivenTimer) {
+    return true;  // No IMU needed; the timer is rotary/button-driven.
+  }
+  return initImu();
+}
 
 void FocusTimer::open() {
+  if (kButtonDrivenTimer) {
+    // Always ready: no IMU gate, so no "IMU unavailable" dead end.
+    clearSession();
+    resetOrientationStability();
+    state_ = State::GenreSelect;
+    stateStartedMs_ = millis();
+    return;
+  }
+
   if (!imuAvailable_) {
     initImu();
   }
@@ -47,7 +71,7 @@ void FocusTimer::open() {
 }
 
 void FocusTimer::update(uint32_t nowMs) {
-  if (imuAvailable_) {
+  if (!kButtonDrivenTimer && imuAvailable_) {
     updateOrientation(nowMs);
   }
 
@@ -57,7 +81,10 @@ void FocusTimer::update(uint32_t nowMs) {
       break;
 
     case State::WaitForTouchStart:
-      if (orientationInputArmed(nowMs) && isShortSide(stableOrientation_)) {
+      // Button-driven boards start via startTouchTimer(); only orientation boards
+      // auto-start from being placed on a short side.
+      if (!kButtonDrivenTimer && orientationInputArmed(nowMs) &&
+          isShortSide(stableOrientation_)) {
         startMode(TimerMode::Touch, nowMs, kTouchDurationMs, stableOrientation_);
         transitionTo(State::TouchRunning, nowMs);
       }
@@ -67,7 +94,13 @@ void FocusTimer::update(uint32_t nowMs) {
       if (timerExpired(nowMs)) {
         completeActiveTimer();
         resetOrientationStability();
-        transitionTo(State::WaitAfterTouch, nowMs);
+        if (kButtonDrivenTimer) {
+          // No pomodoro flip cycle on this hardware: finish the session.
+          feedbackStartedMs_ = nowMs;
+          transitionTo(State::Complete, nowMs);
+        } else {
+          transitionTo(State::WaitAfterTouch, nowMs);
+        }
       }
       break;
 
@@ -157,6 +190,17 @@ void FocusTimer::cancelActiveTimer(uint32_t nowMs) {
   resetOrientationStability();
   feedbackStartedMs_ = nowMs;
   transitionTo(State::Cancelled, nowMs);
+}
+
+void FocusTimer::startTouchTimer(uint32_t nowMs) {
+  // Explicit start for button-driven boards (no place-on-side gesture). The
+  // start orientation is irrelevant here, so use a neutral value that is not a
+  // short side (it would otherwise seed the flip-restart logic).
+  if (state_ != State::WaitForTouchStart) {
+    return;
+  }
+  startMode(TimerMode::Touch, nowMs, selectedTouchDurationMs(), OrientationState::FlatBack);
+  transitionTo(State::TouchRunning, nowMs);
 }
 
 void FocusTimer::abandon() {
@@ -260,6 +304,19 @@ bool FocusTimer::initImu() {
     return true;
   }
 
+#ifdef RSVP_BOARD_TPAGER
+  // BHI260AP sensor hub via the LilyGoLib BSP: no raw-register probe/reset dance.
+  // begin() boots the hub's gravity virtual sensor; readGravity() feeds the same
+  // classify() path the QMI8658 boards use.
+  imuAvailable_ = Board::Imu::begin();
+  if (imuAvailable_) {
+    resetOrientationStability();
+    Serial.println("[timer] BHI260AP gravity source ready");
+  } else {
+    Serial.println("[timer] BHI260AP gravity source unavailable");
+  }
+  return imuAvailable_;
+#else
   const uint8_t candidateAddresses[] = {
       Board::Imu::address(),
       0x6B,
@@ -352,8 +409,10 @@ bool FocusTimer::initImu() {
                   Board::Imu::wireName(), Board::Imu::address());
   }
   return false;
+#endif  // RSVP_BOARD_TPAGER
 }
 
+#ifndef RSVP_BOARD_TPAGER
 bool FocusTimer::updateRegister(uint8_t reg, uint8_t mask, uint8_t value) {
   uint8_t current = 0;
   if (!Board::Imu::readRegister(imuAddress_, reg, current)) {
@@ -363,8 +422,14 @@ bool FocusTimer::updateRegister(uint8_t reg, uint8_t mask, uint8_t value) {
   current = static_cast<uint8_t>((current & static_cast<uint8_t>(~mask)) | (value & mask));
   return Board::Imu::writeRegister(imuAddress_, reg, current);
 }
+#endif  // !RSVP_BOARD_TPAGER
 
 bool FocusTimer::readAccelerometer(float &x, float &y, float &z) {
+#ifdef RSVP_BOARD_TPAGER
+  // BHI260AP gravity vector (already a unit direction), used directly by
+  // classify(). No raw registers or accelScale_ on this board.
+  return Board::Imu::readGravity(x, y, z);
+#else
   uint8_t buffer[6] = {0};
   if (!Board::Imu::readRegisters(imuAddress_, kImuAccelStartReg, buffer, sizeof(buffer))) {
     return false;
@@ -378,6 +443,7 @@ bool FocusTimer::readAccelerometer(float &x, float &y, float &z) {
   y = rawY * accelScale_;
   z = rawZ * accelScale_;
   return true;
+#endif  // RSVP_BOARD_TPAGER
 }
 
 void FocusTimer::updateOrientation(uint32_t nowMs) {

--- a/src/timer/FocusTimer.cpp
+++ b/src/timer/FocusTimer.cpp
@@ -23,7 +23,13 @@ constexpr uint32_t kOrientationStableMs = 700;
 constexpr uint32_t kTouchStartArmDelayMs = 350;
 constexpr uint32_t kPostTimerFlipGraceMs = 900;
 constexpr uint32_t kFeedbackMs = 900;
-constexpr uint32_t kTouchDurationMs = 2UL * 60UL * 1000UL;
+constexpr uint32_t kTouchDurations[] = {
+    2UL * 60UL * 1000UL,  5UL * 60UL * 1000UL,  10UL * 60UL * 1000UL,
+    15UL * 60UL * 1000UL, 20UL * 60UL * 1000UL, 25UL * 60UL * 1000UL,
+    30UL * 60UL * 1000UL, 35UL * 60UL * 1000UL, 40UL * 60UL * 1000UL,
+    45UL * 60UL * 1000UL, 50UL * 60UL * 1000UL, 60UL * 60UL * 1000UL,
+};
+constexpr size_t kTouchDurationCount = sizeof(kTouchDurations) / sizeof(kTouchDurations[0]);
 constexpr uint32_t kWorkDurationMs = 20UL * 60UL * 1000UL;
 constexpr uint32_t kBreakDurationMs = 5UL * 60UL * 1000UL;
 
@@ -85,7 +91,7 @@ void FocusTimer::update(uint32_t nowMs) {
       // auto-start from being placed on a short side.
       if (!kButtonDrivenTimer && orientationInputArmed(nowMs) &&
           isShortSide(stableOrientation_)) {
-        startMode(TimerMode::Touch, nowMs, kTouchDurationMs, stableOrientation_);
+        startMode(TimerMode::Touch, nowMs, selectedTouchDurationMs(), stableOrientation_);
         transitionTo(State::TouchRunning, nowMs);
       }
       break;
@@ -164,7 +170,9 @@ void FocusTimer::update(uint32_t nowMs) {
       if (nowMs - feedbackStartedMs_ >= kFeedbackMs) {
         clearSession();
         resetOrientationStability();
-        transitionTo(imuAvailable_ ? State::GenreSelect : State::Unavailable, nowMs);
+        transitionTo((kButtonDrivenTimer || imuAvailable_) ? State::GenreSelect
+                                                           : State::Unavailable,
+                     nowMs);
       }
       break;
   }
@@ -203,10 +211,48 @@ void FocusTimer::startTouchTimer(uint32_t nowMs) {
   transitionTo(State::TouchRunning, nowMs);
 }
 
+void FocusTimer::cycleTouchDuration() {
+  uint8_t &index = touchDurationByGenre_[genreIdx()];
+  index = static_cast<uint8_t>((index + 1) % kTouchDurationCount);
+}
+
+void FocusTimer::stepTouchDuration(int direction) {
+  uint8_t &index = touchDurationByGenre_[genreIdx()];
+  if (direction > 0 && index < kTouchDurationCount - 1) {
+    ++index;
+  } else if (direction < 0 && index > 0) {
+    --index;
+  }
+}
+
+void FocusTimer::setTouchDurationIndexForGenre(Genre genre, uint8_t index) {
+  const uint8_t genreIndex = static_cast<uint8_t>(genre);
+  if (genreIndex < kGenreCount && index < kTouchDurationCount) {
+    touchDurationByGenre_[genreIndex] = index;
+  }
+}
+
+uint8_t FocusTimer::touchDurationIndex() const { return touchDurationByGenre_[genreIdx()]; }
+
+uint8_t FocusTimer::touchDurationIndexForGenre(Genre genre) const {
+  const uint8_t genreIndex = static_cast<uint8_t>(genre);
+  return genreIndex < kGenreCount ? touchDurationByGenre_[genreIndex] : 0;
+}
+
+uint32_t FocusTimer::selectedTouchDurationMs() const {
+  return kTouchDurations[touchDurationByGenre_[genreIdx()]];
+}
+
+uint8_t FocusTimer::genreIdx() const {
+  const uint8_t index = static_cast<uint8_t>(genre_);
+  return index < kGenreCount ? index : 0;
+}
+
 void FocusTimer::abandon() {
   clearSession();
   resetOrientationStability();
-  state_ = imuAvailable_ ? State::GenreSelect : State::Unavailable;
+  state_ = (kButtonDrivenTimer || imuAvailable_) ? State::GenreSelect
+                                                 : State::Unavailable;
   stateStartedMs_ = millis();
 }
 

--- a/src/timer/FocusTimer.h
+++ b/src/timer/FocusTimer.h
@@ -38,6 +38,9 @@ class FocusTimer {
   void update(uint32_t nowMs);
   void chooseGenre(Genre genre, uint32_t nowMs);
   void cancelActiveTimer(uint32_t nowMs);
+  // Start the touch countdown explicitly (rotary/button-driven boards that have
+  // no place-on-side gesture). No-op unless in the WaitForTouchStart state.
+  void startTouchTimer(uint32_t nowMs);
   void cycleTouchDuration();
   void stepTouchDuration(int direction);
   void setTouchDurationIndexForGenre(Genre genre, uint8_t index);

--- a/variants/lilygo_tlora_pager/pins_arduino.h
+++ b/variants/lilygo_tlora_pager/pins_arduino.h
@@ -1,0 +1,102 @@
+#ifndef Pins_Arduino_h
+#define Pins_Arduino_h
+
+#include <stdint.h>
+
+#ifndef digitalPinToInterrupt
+#define digitalPinToInterrupt(p) (((p) < 48) ? (p) : -1)
+#endif
+
+#define USB_VID          0x303a
+#define USB_PID          0x82D4
+#define USB_MANUFACTURER "LILYGO"
+#define USB_PRODUCT      "T-LoRa-Pager"
+
+// ST7796
+#define DISP_WIDTH  (222)
+#define DISP_HEIGHT (480)
+#define SD_CS       (21)
+
+static const uint8_t TX = 43;
+static const uint8_t RX = 44;
+
+// BHI260,PCF85063,BQ25896,DRV2605L,ES8311 share I2C Bus
+static const uint8_t SDA = 3;
+static const uint8_t SCL = 2;
+
+// Default sd cs pin
+static const uint8_t SS = SD_CS;
+static const uint8_t MOSI = 34;
+static const uint8_t MISO = 33;
+static const uint8_t SCK = 35;
+
+#define KB_INT       (6)
+#define KB_BACKLIGHT (46)
+
+// Rotary
+#define ROTARY_A (40)
+#define ROTARY_B (41)
+#define ROTARY_C (7)
+
+// Interrupt IO port
+#define RTC_INT    (1)
+#define NFC_INT    (5)
+#define SENSOR_INT (8)
+#define NFC_CS     (39)
+
+// ES8311
+#define I2S_WS    (18)
+#define I2S_SCK   (11)
+#define I2S_MCLK  (10)
+#define I2S_SDOUT (45)
+#define I2S_SDIN  (17)
+
+// GPS
+#define GPS_TX  (12)
+#define GPS_RX  (4)
+#define GPS_PPS (13)
+
+// LoRa, SD, ST25R3916 card share SPI bus
+#define LORA_SCK  (SCK)   // share spi bus
+#define LORA_MISO (MISO)  // share spi bus
+#define LORA_MOSI (MOSI)  // share spi bus
+#define LORA_CS   (36)
+#define LORA_RST  (47)
+#define LORA_BUSY (48)
+#define LORA_IRQ  (14)
+
+// SPI interface display
+#define DISP_MOSI (MOSI)
+#define DISP_MISO (MISO)
+#define DISP_SCK  (SCK)
+#define DISP_RST  (-1)
+#define DISP_CS   (38)
+#define DISP_DC   (37)
+#define DISP_BL   (42)
+
+// External expansion chip IO definition
+#define EXPANDS_DRV_EN    (0)
+#define EXPANDS_AMP_EN    (1)
+#define EXPANDS_KB_RST    (2)
+#define EXPANDS_LORA_EN   (3)
+#define EXPANDS_GPS_EN    (4)
+#define EXPANDS_NFC_EN    (5)
+#define EXPANDS_GPS_RST   (7)
+#define EXPANDS_KB_EN     (8)
+#define EXPANDS_GPIO_EN   (9)
+#define EXPANDS_SD_DET    (10)
+#define EXPANDS_SD_PULLEN (11)
+#define EXPANDS_SD_EN     (12)
+
+// Peripheral definition exists
+#define USING_AUDIO_CODEC
+#define USING_XL9555_EXPANDS
+#define USING_PPM_MANAGE
+#define USING_BQ_GAUGE
+#define USING_INPUT_DEV_ROTARY
+#define USING_INPUT_DEV_KEYBOARD
+#define USING_ST25R3916
+#define USING_BHI260_SENSOR
+#define HAS_SD_CARD_SOCKET
+
+#endif /* Pins_Arduino_h */

--- a/wokwi.toml
+++ b/wokwi.toml
@@ -1,0 +1,4 @@
+[wokwi]
+version = 1
+firmware = '.pio/build/t_lora_pager/firmware.bin'
+elf = '.pio/build/t_lora_pager/firmware.elf'


### PR DESCRIPTION
I've little to no experience writing C for the ESP32 family, but with Claude Code I've gotten this working(ish) on a LilyGo T-LoRa-Pager.

It builds, boots, opens books, and works for the basic job of reading. Navigation is adapted to the missing touchscreen: the rotary encoder scrolls and selects (turn to move, press to confirm) and the BOOT button goes back.

Rebased on **v0.0.8**. Everything T-Pager-specific is behind `#ifdef RSVP_BOARD_TPAGER`, so the existing Waveshare builds are unaffected. Build prerequisites (the pioarduino arduino-esp32 3.x core, the sibling LilyGoLib checkouts, and a small LilyGoLib keyboard patch) are documented in `README-tpager.md`.

### Works
- Reading books, chapters, book list
- Reader playback — a deliberate rotary center push toggles play/pause (single tap, since there's no dedicated KEY/BOOT play button)
- Settings
- SD card check
- **Companion app over your WiFi network** — it joins your existing network (with a fallback to its own access point), so you can sync/transfer books from the companion without a dedicated AP hop
- WiFi
- USB file transfer
- On-screen text input via the physical keyboard (needs the LilyGoLib patch noted in the README)
- Focus timer — reworked for this hardware: turn the rotary to set the duration (2–60 min, remembered per genre), press to start/cancel. The original "place it on a side / flip it" motion design needs stable orientations the pager can't rest in, so it's button-driven here.

### Not yet verified / TODO
- Audio / haptic cues — wired, only lightly tested
- Everything else I haven't gotten to yet

The IMU (a Bosch BHI260AP, reached through the LilyGoLib BSP) is wired up but the focus timer no longer depends on it.

I'm leaving this here in case someone wants to pick it up and take it further.
