### PR TITLE
feat: add continuous menu repeat

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -30,7 +30,9 @@ build_unflags =
 platform = native
 framework =
 test_framework = unity
-test_filter = test_pacing
+test_filter =
+  test_pacing
+  test_menu_repeat
 test_build_src = yes
 build_src_filter = -<*> +<reader/ReadingLoop.cpp>
 build_flags =

--- a/src/app/App.cpp
+++ b/src/app/App.cpp
@@ -10,6 +10,7 @@
 #include <utility>
 #include <vector>
 
+#include "app/MenuRepeat.h"
 #include "board/BoardConfig.h"
 
 #ifndef RSVP_USB_TRANSFER_ENABLED
@@ -168,6 +169,7 @@ constexpr size_t kSettingsDisplayReaderBatteryIndex = 7;
 constexpr size_t kSettingsDisplayReaderChapterIndex = 8;
 constexpr size_t kSettingsDisplayReaderProgressIndex = 9;
 constexpr size_t kSettingsDisplayLanguageIndex = 10;
+constexpr size_t kSettingsDisplayMenuRepeatIndex = 11;
 constexpr size_t kSettingsPacingReadingModeIndex = 1;
 constexpr size_t kSettingsPacingPauseModeIndex = 2;
 constexpr size_t kSettingsPacingWpmIndex = 3;
@@ -225,6 +227,7 @@ constexpr const char *kPrefWifiSsid = "wifi_ssid";
 constexpr const char *kPrefWifiPass = "wifi_pass";
 constexpr const char *kPrefOtaAuto = "ota_auto";
 constexpr const char *kPrefOtaOwner = "ota_owner";
+constexpr const char *kPrefMenuRepeatMs = "menu_rpt";
 constexpr size_t kReaderFontSizeCount = 3;
 constexpr size_t kPhantomBeforeCharTargets[] = {64, 96, 144};
 constexpr size_t kPhantomAfterCharTargets[] = {96, 144, 208};
@@ -309,6 +312,11 @@ int nextCyclicSetting(int value, int minValue, int maxValue, int step = 1) {
     next = minValue;
   }
   return next;
+}
+
+String menuRepeatDelayLabel(uint16_t delayMs) {
+  delayMs = MenuRepeat::sanitizeDelayMs(delayMs);
+  return delayMs == 0 ? String("Off") : String(delayMs) + " ms";
 }
 
 uint16_t nextReaderWpmSetting(uint16_t value) {
@@ -636,6 +644,8 @@ void App::begin() {
   if (readerFontSizeIndex_ >= kReaderFontSizeCount) {
     readerFontSizeIndex_ = 0;
   }
+  menuRepeatDelayMs_ = MenuRepeat::sanitizeDelayMs(
+      preferences_.getUShort(kPrefMenuRepeatMs, MenuRepeat::kDefaultDelayMs));
   switch (preferences_.getUChar(kPrefFooterMetricMode,
                                 static_cast<uint8_t>(footerMetricMode_))) {
     case static_cast<uint8_t>(FooterMetricMode::ChapterTime):
@@ -1302,6 +1312,8 @@ void App::reloadRuntimePreferences(uint32_t nowMs, bool rerender) {
   if (readerFontSizeIndex_ >= kReaderFontSizeCount) {
     readerFontSizeIndex_ = 0;
   }
+  menuRepeatDelayMs_ = MenuRepeat::sanitizeDelayMs(
+      preferences_.getUShort(kPrefMenuRepeatMs, MenuRepeat::kDefaultDelayMs));
 
   switch (preferences_.getUChar(kPrefFooterMetricMode,
                                 static_cast<uint8_t>(footerMetricMode_))) {
@@ -2203,6 +2215,10 @@ void App::applyMenuTouchGesture(const TouchEvent &event, uint32_t nowMs) {
     pausedTouch_.lastY = event.y;
     pausedTouch_.startMs = nowMs;
     pausedTouch_.lastMs = nowMs;
+    menuRepeatGestureConsumed_ = false;
+    menuRepeatMoved_ = false;
+    menuRepeatDirection_ = 0;
+    menuRepeatNextMs_ = 0;
     return;
   }
 
@@ -2214,21 +2230,54 @@ void App::applyMenuTouchGesture(const TouchEvent &event, uint32_t nowMs) {
   pausedTouch_.lastY = event.y;
   pausedTouch_.lastMs = nowMs;
 
-  if (event.phase != TouchPhase::End) {
-    return;
-  }
-
-  pausedTouch_.active = false;
-
   const int deltaX = static_cast<int>(pausedTouch_.lastX) - static_cast<int>(pausedTouch_.startX);
   const int deltaY = static_cast<int>(pausedTouch_.lastY) - static_cast<int>(pausedTouch_.startY);
   const int absDeltaX = abs(deltaX);
   const int absDeltaY = abs(deltaY);
 
+  if (event.phase != TouchPhase::End) {
+    if (menuScreen_ == MenuScreen::TextEntry || menuRepeatDelayMs_ == 0) {
+      return;
+    }
+
+    const int repeatDirection =
+        MenuRepeat::directionForDrag(deltaX, deltaY, kSwipeThresholdPx, kAxisBiasPx);
+    if (repeatDirection == 0) {
+      menuRepeatDirection_ = 0;
+      return;
+    }
+
+    if (!menuRepeatGestureConsumed_ || repeatDirection != menuRepeatDirection_ ||
+        nowMs >= menuRepeatNextMs_) {
+      menuRepeatGestureConsumed_ = true;
+      menuRepeatMoved_ = moveMenuSelection(repeatDirection, false) || menuRepeatMoved_;
+      menuRepeatDirection_ = repeatDirection;
+      menuRepeatNextMs_ = nowMs + menuRepeatDelayMs_;
+    }
+    return;
+  }
+
+  pausedTouch_.active = false;
+  menuRepeatDirection_ = 0;
+
   if (menuScreen_ == MenuScreen::TextEntry) {
     if (absDeltaX <= static_cast<int>(kTapSlopPx) && absDeltaY <= static_cast<int>(kTapSlopPx)) {
       handleTextEntryTap(event.x, event.y, nowMs);
     }
+    return;
+  }
+
+  if (menuRepeatGestureConsumed_) {
+    const bool quickEdgeSwipe =
+        !menuRepeatMoved_ && (nowMs - pausedTouch_.startMs) < menuRepeatDelayMs_;
+    const int releaseDirection =
+        MenuRepeat::directionForDrag(deltaX, deltaY, kSwipeThresholdPx, kAxisBiasPx);
+    if (quickEdgeSwipe && releaseDirection != 0) {
+      moveMenuSelection(releaseDirection, true);
+    }
+    menuRepeatGestureConsumed_ = false;
+    menuRepeatMoved_ = false;
+    menuRepeatNextMs_ = 0;
     return;
   }
 
@@ -2241,7 +2290,7 @@ void App::applyMenuTouchGesture(const TouchEvent &event, uint32_t nowMs) {
 
   if (absDeltaY >= static_cast<int>(kSwipeThresholdPx) &&
       absDeltaY > absDeltaX + static_cast<int>(kAxisBiasPx)) {
-    moveMenuSelection(deltaY < 0 ? -1 : 1);
+    moveMenuSelection(deltaY < 0 ? -1 : 1, true);
     return;
   }
 
@@ -2400,9 +2449,9 @@ void App::selectFocusTimerGenre(uint32_t nowMs) {
   renderFocusTimerSession();
 }
 
-void App::moveMenuSelection(int direction) {
+bool App::moveMenuSelection(int direction, bool wrap) {
   if (direction == 0 || menuScreen_ == MenuScreen::TextEntry) {
-    return;
+    return false;
   }
 
   size_t *selectedIndex = &menuSelectedIndex_;
@@ -2438,16 +2487,14 @@ void App::moveMenuSelection(int direction) {
   }
 
   if (itemCount == 0) {
-    return;
+    return false;
   }
 
-  const int next = static_cast<int>(*selectedIndex) + direction;
-  if (next < 0) {
-    *selectedIndex = itemCount - 1;
-  } else if (next >= static_cast<int>(itemCount)) {
-    *selectedIndex = 0;
-  } else {
-    *selectedIndex = static_cast<size_t>(next);
+  const MenuRepeat::MoveResult move =
+      MenuRepeat::movedIndex(*selectedIndex, itemCount, direction, wrap);
+  *selectedIndex = move.index;
+  if (!move.changed) {
+    return false;
   }
 
   renderMenu();
@@ -2531,6 +2578,8 @@ void App::moveMenuSelection(int direction) {
     }
     Serial.printf("[menu] selected=%s\n", selectedLabel.c_str());
   }
+
+  return true;
 }
 
 void App::selectMenuItem(uint32_t nowMs) {
@@ -2763,6 +2812,12 @@ void App::selectSettingsItem(uint32_t nowMs) {
         return;
       case kSettingsDisplayLanguageIndex:
         cycleUiLanguage(nowMs);
+        return;
+      case kSettingsDisplayMenuRepeatIndex:
+        menuRepeatDelayMs_ = MenuRepeat::nextDelayMs(menuRepeatDelayMs_);
+        preferences_.putUShort(kPrefMenuRepeatMs, menuRepeatDelayMs_);
+        rebuildSettingsMenuItems();
+        renderSettings();
         return;
       default:
         return;
@@ -3375,6 +3430,7 @@ void App::rebuildSettingsMenuItems() {
     settingsMenuItems_.push_back("Reading percent: " +
                                  onOffLabel(readerProgressVisibleWhilePlaying_));
     settingsMenuItems_.push_back(uiText(UiText::Language) + ": " + uiLanguageLabel());
+    settingsMenuItems_.push_back("Menu repeat: " + menuRepeatDelayLabel(menuRepeatDelayMs_));
   } else if (menuScreen_ == MenuScreen::SettingsPacing) {
     settingsMenuItems_.push_back(uiText(UiText::Back));
     settingsMenuItems_.push_back("Reading mode: " + readerModeLabel());

--- a/src/app/App.h
+++ b/src/app/App.h
@@ -9,6 +9,7 @@
 
 #include "app/AppState.h"
 #include "app/Localization.h"
+#include "app/MenuRepeat.h"
 #include "audio/AudioManager.h"
 #include "display/DisplayManager.h"
 #include "input/ButtonHandler.h"
@@ -221,7 +222,7 @@ class App {
   void renderContextBrowsePreview(size_t currentIndex, uint16_t scrollProgressPermille);
   void applyMenuTouchGesture(const TouchEvent &event, uint32_t nowMs);
   void applyFocusTimerTouch(const TouchEvent &event, uint32_t nowMs);
-  void moveMenuSelection(int direction);
+  bool moveMenuSelection(int direction, bool wrap);
   void selectMenuItem(uint32_t nowMs);
   void openFocusTimer();
   void updateFocusTimer(uint32_t nowMs);
@@ -455,6 +456,7 @@ class App {
   size_t focusTimerGenreSelectedIndex_ = 0;
   uint8_t brightnessLevelIndex_ = 4;
   uint8_t readerFontSizeIndex_ = 0;
+  uint16_t menuRepeatDelayMs_ = MenuRepeat::kDefaultDelayMs;
   uint16_t pacingLongWordDelayMs_ = 200;
   uint16_t pacingComplexWordDelayMs_ = 200;
   uint16_t pacingPunctuationDelayMs_ = 200;
@@ -510,6 +512,8 @@ class App {
   uint16_t lastReaderTapY_ = 0;
   bool touchInitialized_ = false;
   bool touchPlayHeld_ = false;
+  bool menuRepeatGestureConsumed_ = false;
+  bool menuRepeatMoved_ = false;
   bool playLocked_ = false;
   bool pauseAtSentenceEndRequested_ = false;
   bool lastReaderTapValid_ = false;
@@ -533,6 +537,8 @@ class App {
   bool usingStorageBook_ = false;
   bool storageReady_ = false;
   bool pendingBootBookLoad_ = false;
+  int menuRepeatDirection_ = 0;
+  uint32_t menuRepeatNextMs_ = 0;
   bool pendingBootBookLegacyFallback_ = false;
   bool batteryPresent_ = false;
   bool batterySampleInitialized_ = false;

--- a/src/app/MenuRepeat.h
+++ b/src/app/MenuRepeat.h
@@ -1,0 +1,73 @@
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+namespace MenuRepeat {
+
+struct MoveResult {
+  size_t index = 0;
+  bool changed = false;
+};
+
+constexpr uint16_t kDefaultDelayMs = 250;
+constexpr uint16_t kDelayOptionsMs[] = {0, 150, 250, 350, 500};
+
+inline uint16_t sanitizeDelayMs(uint16_t delayMs) {
+  for (uint16_t option : kDelayOptionsMs) {
+    if (delayMs == option) {
+      return option;
+    }
+  }
+  return kDefaultDelayMs;
+}
+
+inline uint16_t nextDelayMs(uint16_t delayMs) {
+  const uint16_t current = sanitizeDelayMs(delayMs);
+  constexpr size_t kOptionCount = sizeof(kDelayOptionsMs) / sizeof(kDelayOptionsMs[0]);
+  for (size_t i = 0; i < kOptionCount; ++i) {
+    if (kDelayOptionsMs[i] == current) {
+      return kDelayOptionsMs[(i + 1) % kOptionCount];
+    }
+  }
+  return kDefaultDelayMs;
+}
+
+inline int directionForDrag(int deltaX, int deltaY, uint16_t swipeThresholdPx,
+                            uint16_t axisBiasPx) {
+  const int absDeltaX = abs(deltaX);
+  const int absDeltaY = abs(deltaY);
+  if (absDeltaY < static_cast<int>(swipeThresholdPx) ||
+      absDeltaY <= absDeltaX + static_cast<int>(axisBiasPx)) {
+    return 0;
+  }
+
+  return deltaY < 0 ? -1 : 1;
+}
+
+inline MoveResult movedIndex(size_t selectedIndex, size_t itemCount, int direction, bool wrap) {
+  MoveResult result;
+  result.index = selectedIndex;
+  if (direction == 0 || itemCount == 0) {
+    return result;
+  }
+
+  int next = static_cast<int>(selectedIndex) + direction;
+  if (wrap && next < 0) {
+    next = static_cast<int>(itemCount) - 1;
+  } else if (wrap && next >= static_cast<int>(itemCount)) {
+    next = 0;
+  } else if (next < 0) {
+    next = 0;
+  } else if (next >= static_cast<int>(itemCount)) {
+    next = static_cast<int>(itemCount) - 1;
+  }
+
+  const size_t nextIndex = static_cast<size_t>(next);
+  result.index = nextIndex;
+  result.changed = nextIndex != selectedIndex;
+  return result;
+}
+
+}  // namespace MenuRepeat

--- a/test/test_menu_repeat/test_main.cpp
+++ b/test/test_menu_repeat/test_main.cpp
@@ -1,0 +1,89 @@
+#include <unity.h>
+
+#include "app/MenuRepeat.h"
+
+namespace {
+
+constexpr uint16_t kSwipeThresholdPx = 40;
+constexpr uint16_t kAxisBiasPx = 12;
+
+}  // namespace
+
+void test_repeat_delay_sanitizes_to_default(void) {
+  TEST_ASSERT_EQUAL_UINT16(250u, MenuRepeat::sanitizeDelayMs(1));
+  TEST_ASSERT_EQUAL_UINT16(250u, MenuRepeat::sanitizeDelayMs(149));
+  TEST_ASSERT_EQUAL_UINT16(250u, MenuRepeat::sanitizeDelayMs(700));
+}
+
+void test_repeat_delay_accepts_configured_options(void) {
+  TEST_ASSERT_EQUAL_UINT16(0u, MenuRepeat::sanitizeDelayMs(0));
+  TEST_ASSERT_EQUAL_UINT16(150u, MenuRepeat::sanitizeDelayMs(150));
+  TEST_ASSERT_EQUAL_UINT16(250u, MenuRepeat::sanitizeDelayMs(250));
+  TEST_ASSERT_EQUAL_UINT16(350u, MenuRepeat::sanitizeDelayMs(350));
+  TEST_ASSERT_EQUAL_UINT16(500u, MenuRepeat::sanitizeDelayMs(500));
+}
+
+void test_repeat_delay_cycles_through_ui_options(void) {
+  TEST_ASSERT_EQUAL_UINT16(150u, MenuRepeat::nextDelayMs(0));
+  TEST_ASSERT_EQUAL_UINT16(250u, MenuRepeat::nextDelayMs(150));
+  TEST_ASSERT_EQUAL_UINT16(350u, MenuRepeat::nextDelayMs(250));
+  TEST_ASSERT_EQUAL_UINT16(500u, MenuRepeat::nextDelayMs(350));
+  TEST_ASSERT_EQUAL_UINT16(0u, MenuRepeat::nextDelayMs(500));
+  TEST_ASSERT_EQUAL_UINT16(350u, MenuRepeat::nextDelayMs(999));
+}
+
+void test_drag_direction_uses_vertical_threshold_and_bias(void) {
+  TEST_ASSERT_EQUAL_INT(0, MenuRepeat::directionForDrag(0, 39, kSwipeThresholdPx, kAxisBiasPx));
+  TEST_ASSERT_EQUAL_INT(1, MenuRepeat::directionForDrag(0, 40, kSwipeThresholdPx, kAxisBiasPx));
+  TEST_ASSERT_EQUAL_INT(-1, MenuRepeat::directionForDrag(0, -40, kSwipeThresholdPx, kAxisBiasPx));
+  TEST_ASSERT_EQUAL_INT(0, MenuRepeat::directionForDrag(35, 46, kSwipeThresholdPx, kAxisBiasPx));
+  TEST_ASSERT_EQUAL_INT(1, MenuRepeat::directionForDrag(20, 40, kSwipeThresholdPx, kAxisBiasPx));
+}
+
+void test_moved_index_wraps_for_quick_swipe_behavior(void) {
+  MenuRepeat::MoveResult move = MenuRepeat::movedIndex(0, 3, -1, true);
+  TEST_ASSERT_EQUAL_UINT32(2u, move.index);
+  TEST_ASSERT_TRUE(move.changed);
+
+  move = MenuRepeat::movedIndex(2, 3, 1, true);
+  TEST_ASSERT_EQUAL_UINT32(0u, move.index);
+  TEST_ASSERT_TRUE(move.changed);
+}
+
+void test_moved_index_clamps_for_hold_repeat_behavior(void) {
+  MenuRepeat::MoveResult move = MenuRepeat::movedIndex(0, 3, -1, false);
+  TEST_ASSERT_EQUAL_UINT32(0u, move.index);
+  TEST_ASSERT_FALSE(move.changed);
+
+  move = MenuRepeat::movedIndex(2, 3, 1, false);
+  TEST_ASSERT_EQUAL_UINT32(2u, move.index);
+  TEST_ASSERT_FALSE(move.changed);
+
+  move = MenuRepeat::movedIndex(0, 3, 1, false);
+  TEST_ASSERT_EQUAL_UINT32(1u, move.index);
+  TEST_ASSERT_TRUE(move.changed);
+}
+
+void test_moved_index_ignores_empty_or_zero_direction(void) {
+  MenuRepeat::MoveResult move = MenuRepeat::movedIndex(4, 0, 1, false);
+  TEST_ASSERT_EQUAL_UINT32(4u, move.index);
+  TEST_ASSERT_FALSE(move.changed);
+
+  move = MenuRepeat::movedIndex(1, 3, 0, true);
+  TEST_ASSERT_EQUAL_UINT32(1u, move.index);
+  TEST_ASSERT_FALSE(move.changed);
+}
+
+int main(void) {
+  UNITY_BEGIN();
+
+  RUN_TEST(test_repeat_delay_sanitizes_to_default);
+  RUN_TEST(test_repeat_delay_accepts_configured_options);
+  RUN_TEST(test_repeat_delay_cycles_through_ui_options);
+  RUN_TEST(test_drag_direction_uses_vertical_threshold_and_bias);
+  RUN_TEST(test_moved_index_wraps_for_quick_swipe_behavior);
+  RUN_TEST(test_moved_index_clamps_for_hold_repeat_behavior);
+  RUN_TEST(test_moved_index_ignores_empty_or_zero_direction);
+
+  return UNITY_END();
+}


### PR DESCRIPTION
## Overview
Adds continuous up/down menu movement while a touch is held and dragged vertically. The feature applies to list-style menus and keeps tap-to-select plus quick swipe behavior intact.

## Implementation
- Adds a persisted Display setting for menu repeat delay: Off, 150 ms, 250 ms, 350 ms, and 500 ms.
- Tracks menu repeat state during touch gestures so crossing the vertical threshold moves once immediately, then repeats at the configured delay while held.
- Keeps continuous repeat clamped at the first/last item while preserving existing wraparound for quick swipe release behavior.
- Extracts repeat delay, drag direction, and index movement logic into `MenuRepeat` for native test coverage.

## Review Guide
- Check `App::applyMenuTouchGesture` for the gesture state flow: start reset, move repeat, release cleanup.
- Check `App::moveMenuSelection` and `MenuRepeat::movedIndex` for wrapped quick-swipe versus clamped hold-repeat behavior.
- Check the Display settings menu for the new `Menu repeat` option and persisted `menu_rpt` preference.
- Check `test_menu_repeat` for the pure repeat logic coverage.

## Validation
- `rtk pio test -e native_test`
- `rtk pio run -e waveshare_esp32s3_usb_msc`
- `rtk git diff --check`