### PR TITLE
fix(board): support Waveshare 3.49 rev2 backlight

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,6 +356,10 @@ Firmware builds with PlatformIO:
 pio run
 ```
 
+The default firmware target is for Waveshare ESP32-S3-Touch-LCD-3.49 rev1 boards. For V2
+boards with the LCD backlight PWM on GPIO42 and reset on the TCA9554 expander, build or
+upload `waveshare_esp32s3_usb_msc_rev2` or `waveshare_esp32s3_rev2`.
+
 Upload to a connected device:
 
 ```bash

--- a/platformio.ini
+++ b/platformio.ini
@@ -17,6 +17,17 @@ build_flags =
   ${env.build_flags}
   -DRSVP_USB_TRANSFER_ENABLED=0
 
+[waveshare_esp32s3_rev2_pins]
+build_flags =
+  -DRSVP_LCD_RST_PIN=-1
+  -DRSVP_LCD_BACKLIGHT_PIN=42
+  -DRSVP_TCA9554_LCD_RST_PIN=5
+
+[env:waveshare_esp32s3_rev2]
+build_flags =
+  ${env:waveshare_esp32s3.build_flags}
+  ${waveshare_esp32s3_rev2_pins.build_flags}
+
 [env:waveshare_esp32s3_usb_msc]
 build_flags =
   ${env.build_flags}
@@ -25,6 +36,13 @@ build_flags =
   -DRSVP_USB_TRANSFER_ENABLED=1
 build_unflags =
   -DARDUINO_USB_MODE=1
+
+[env:waveshare_esp32s3_usb_msc_rev2]
+build_flags =
+  ${env:waveshare_esp32s3_usb_msc.build_flags}
+  ${waveshare_esp32s3_rev2_pins.build_flags}
+build_unflags =
+  ${env:waveshare_esp32s3_usb_msc.build_unflags}
 
 [env:native_test]
 platform = native

--- a/src/board/BoardConfig.cpp
+++ b/src/board/BoardConfig.cpp
@@ -12,7 +12,7 @@ namespace {
 constexpr uint8_t kTca9554OutputReg = 0x01;
 constexpr uint8_t kTca9554ConfigReg = 0x03;
 bool gBatteryPowerHoldEnabled = false;
-bool gBatteryAdcPathEnabled = false;
+bool gBacklightEnableConfigured = false;
 constexpr float kBatteryDividerRatio = 3.0f;
 constexpr float kBatteryVoltageOffset = 0.0f;
 
@@ -77,30 +77,35 @@ void holdBatteryPowerIfAvailable() {
   Serial.println("[board] Battery power hold enabled");
 }
 
-void enableBatteryAdcPathIfAvailable() {
-  if (gBatteryAdcPathEnabled) {
+void enableBacklightIfAvailable() {
+  if (gBacklightEnableConfigured) {
     return;
   }
 
-  if (!configureTca9554OutputPin(TCA9554_PIN_BATTERY_ADC_ENABLE, false)) {
-    Serial.println("[board] TCA9554 battery ADC gate not configured");
+  // EXIO1 gates AP3032 BL_EN; keep it enabled while LCD_BL provides PWM dimming.
+  if (!configureTca9554OutputPin(TCA9554_PIN_BACKLIGHT_ENABLE, true)) {
+    Serial.println("[board] TCA9554 backlight enable not configured");
     return;
   }
 
-  gBatteryAdcPathEnabled = true;
-  Serial.println("[board] Battery ADC path enabled");
+  gBacklightEnableConfigured = true;
+  Serial.println("[board] Backlight enable configured");
 }
 
-void disableBatteryAdcPathIfAvailable() {
-  // Keep the battery divider gate off outside short samples; it shares the board expander.
-  if (!configureTca9554OutputPin(TCA9554_PIN_BATTERY_ADC_ENABLE, true)) {
-    if (gBatteryAdcPathEnabled) {
-      Serial.println("[board] TCA9554 battery ADC gate disable failed");
-    }
-    return;
+bool setLcdResetLevel(bool high) {
+  if (PIN_LCD_RST >= 0) {
+    pinMode(PIN_LCD_RST, OUTPUT);
+    digitalWrite(PIN_LCD_RST, high ? HIGH : LOW);
+    return true;
   }
 
-  gBatteryAdcPathEnabled = false;
+  if (TCA9554_PIN_LCD_RST >= 0 &&
+      configureTca9554OutputPin(static_cast<uint8_t>(TCA9554_PIN_LCD_RST), high)) {
+    return true;
+  }
+
+  Serial.println("[board] LCD reset not configured");
+  return false;
 }
 
 uint8_t batteryPercentForVoltage(float voltage) {
@@ -158,7 +163,7 @@ void begin() {
   Wire1.setClock(300000);
   Wire1.setTimeOut(10);
   holdBatteryPowerIfAvailable();
-  disableBatteryAdcPathIfAvailable();
+  enableBacklightIfAvailable();
 
   pinMode(PIN_BATTERY_ADC, INPUT);
   analogReadResolution(12);
@@ -173,6 +178,17 @@ void lightSleepUntilBootButton() {
   esp_light_sleep_start();
   gpio_wakeup_disable(static_cast<gpio_num_t>(PIN_BOOT_BUTTON));
   esp_sleep_disable_wakeup_source(ESP_SLEEP_WAKEUP_GPIO);
+}
+
+void resetLcdPanel() {
+  if (!setLcdResetLevel(true)) {
+    return;
+  }
+  delay(30);
+  setLcdResetLevel(false);
+  delay(250);
+  setLcdResetLevel(true);
+  delay(30);
 }
 
 void holdBacklightOffForDeepSleep() {
@@ -191,7 +207,6 @@ void holdBacklightOffForDeepSleep() {
 
 bool readBatteryStatus(BatteryStatus &status) {
   status = BatteryStatus{};
-  enableBatteryAdcPathIfAvailable();
   delay(12);
 
   constexpr uint8_t kMaxSamples = 24;
@@ -229,8 +244,6 @@ bool readBatteryStatus(BatteryStatus &status) {
         static_cast<float>(trimmedTotal) / static_cast<float>(std::max<uint8_t>(1, trimmedSamples));
     status.voltage = (pinMillivolts * kBatteryDividerRatio / 1000.0f) + kBatteryVoltageOffset;
   }
-  disableBatteryAdcPathIfAvailable();
-
   status.present = status.voltage >= 2.5f && status.voltage <= 4.6f;
   if (!status.present) {
     status.percent = 0;

--- a/src/board/BoardConfig.h
+++ b/src/board/BoardConfig.h
@@ -2,6 +2,18 @@
 
 #include <Arduino.h>
 
+#ifndef RSVP_LCD_BACKLIGHT_PIN
+#define RSVP_LCD_BACKLIGHT_PIN 8
+#endif
+
+#ifndef RSVP_LCD_RST_PIN
+#define RSVP_LCD_RST_PIN 21
+#endif
+
+#ifndef RSVP_TCA9554_LCD_RST_PIN
+#define RSVP_TCA9554_LCD_RST_PIN -1
+#endif
+
 namespace BoardConfig {
 
 enum class UiOrientation : uint8_t {
@@ -21,8 +33,11 @@ constexpr int PIN_LCD_DATA0 = 11;
 constexpr int PIN_LCD_DATA1 = 12;
 constexpr int PIN_LCD_DATA2 = 13;
 constexpr int PIN_LCD_DATA3 = 14;
-constexpr int PIN_LCD_RST = 21;
-constexpr int PIN_LCD_BACKLIGHT = 8;
+constexpr int PIN_LCD_RST = RSVP_LCD_RST_PIN;
+constexpr int PIN_LCD_BACKLIGHT = RSVP_LCD_BACKLIGHT_PIN;
+static_assert(PIN_LCD_BACKLIGHT >= 0, "LCD backlight pin must be configured");
+static_assert(PIN_LCD_RST >= 0 || RSVP_TCA9554_LCD_RST_PIN >= 0,
+              "LCD reset pin must be configured");
 
 constexpr int PANEL_NATIVE_WIDTH = 172;
 constexpr int PANEL_NATIVE_HEIGHT = 640;
@@ -39,7 +54,8 @@ constexpr int PIN_TOUCH_SDA = 17;
 constexpr int PIN_TOUCH_SCL = 18;
 
 constexpr int TCA9554_ADDRESS = 0x20;
-constexpr uint8_t TCA9554_PIN_BATTERY_ADC_ENABLE = 1;
+constexpr uint8_t TCA9554_PIN_BACKLIGHT_ENABLE = 1;
+constexpr int TCA9554_PIN_LCD_RST = RSVP_TCA9554_LCD_RST_PIN;
 constexpr uint8_t TCA9554_PIN_SYS_EN = 6;
 constexpr uint8_t TCA9554_PIN_AUDIO_ENABLE = 7;
 
@@ -58,6 +74,7 @@ struct BatteryStatus {
 
 void begin();
 void lightSleepUntilBootButton();
+void resetLcdPanel();
 void holdBacklightOffForDeepSleep();
 bool readBatteryStatus(BatteryStatus &status);
 bool releaseBatteryPowerHold();

--- a/src/display/axs15231b.cpp
+++ b/src/display/axs15231b.cpp
@@ -85,13 +85,7 @@ void setColumnWindow(uint16_t x1, uint16_t x2) {
 void axs15231bInit() {
   setBacklight(false);
 
-  pinMode(BoardConfig::PIN_LCD_RST, OUTPUT);
-  digitalWrite(BoardConfig::PIN_LCD_RST, HIGH);
-  delay(30);
-  digitalWrite(BoardConfig::PIN_LCD_RST, LOW);
-  delay(250);
-  digitalWrite(BoardConfig::PIN_LCD_RST, HIGH);
-  delay(30);
+  BoardConfig::resetLcdPanel();
 
   if (!gBusReady) {
     spi_bus_config_t busConfig = {};


### PR DESCRIPTION
## Summary

This adds explicit firmware targets for the Waveshare ESP32-S3-Touch-LCD-3.49 V2 board revision while keeping the existing/default V1 behavior unchanged.

The V2 board moves the LCD backlight PWM from GPIO8 to GPIO42, and its LCD reset is driven through the TCA9554 I/O expander rather than GPIO21. Without these pin differences, V2 builds can boot with a non-working or improperly reset display/backlight path.

## What changed

- Added V2 PlatformIO environments:
  - `waveshare_esp32s3_rev2`
  - `waveshare_esp32s3_usb_msc_rev2`
- Kept existing/default environments on the current V1 pin map.
- Added configurable board pins for:
  - LCD backlight PWM
  - direct LCD reset GPIO
  - optional TCA9554 LCD reset pin
- Routed LCD reset through `BoardConfig::resetLcdPanel()` so V1 can keep direct GPIO reset while V2 uses TCA9554 EXIO5.
- Renamed TCA9554 EXIO1 to represent its backlight-enable role and enabled it during board init.
- Documented the V2 build targets in the README build section.

## Why this shape

I looked for a safe single-firmware auto-detection path, but the useful revision differences are output/control paths rather than readable board identifiers.

The newly published Waveshare V2 examples show:

- V2 backlight PWM: GPIO42
- V2 GPIO8: TCA9554 interrupt input
- V2 LCD reset: TCA9554 EXIO5

Because GPIO8 is not spare on V2, mirroring PWM to both GPIO8 and GPIO42 would risk driving the TCA9554 interrupt line. Since the firmware also cannot directly observe whether a backlight pin successfully lit the display, runtime probing would be unreliable. Separate explicit V2 build targets keep the change predictable and avoid broad board-profile churn.

## Review guide

- `platformio.ini`: V2 targets inherit the existing base envs and add only the V2 pin overrides.
- `src/board/BoardConfig.h`: V1 defaults remain GPIO8 backlight and GPIO21 reset.
- `src/board/BoardConfig.cpp`: board-level LCD reset now supports either direct GPIO or TCA9554 reset.
- `src/display/axs15231b.cpp`: display init delegates panel reset to `BoardConfig`.
- No web flasher, release artifact, or PWM frequency changes are included.

## Validation

Built both existing and V2 firmware targets:

- `rtk pio run -e waveshare_esp32s3_usb_msc_rev2`
- `rtk pio run -e waveshare_esp32s3_usb_msc`
- `rtk pio run -e waveshare_esp32s3_rev2`
- `rtk pio run -e waveshare_esp32s3`
