### PR TITLE
Hotfix/fix screen rotation 18v2

### DIFF
--- a/src/app/App.cpp
+++ b/src/app/App.cpp
@@ -7053,19 +7053,19 @@ bool App::isFocusTimerMenuScreen(MenuScreen screen) const {
 }
 
 void App::applyUiOrientation(Board::Config::UiOrientation orientation) {
-  Input::Touch::setUiOrientation(orientation);
-  // When PANEL_FLIP_180 is set, the display panel is physically mounted inverted. Apply
-  // the opposite display orientation so the rendered image appears correct to the user,
-  // while touch orientation stays untouched (already set above) for correct swipe mapping.
-  Board::Config::UiOrientation displayOrientation;
+  // When PANEL_FLIP_180 is set, the panel is physically mounted inverted: flip both
+  // display and touch to the opposite landscape orientation so rendering and swipe
+  // direction are both correct relative to what the user sees on screen.
+  Board::Config::UiOrientation effective;
   if constexpr (Board::Config::PANEL_FLIP_180) {
-    displayOrientation = (orientation == Board::Config::UiOrientation::Landscape)
-                             ? Board::Config::UiOrientation::LandscapeFlipped
-                             : Board::Config::UiOrientation::Landscape;
+    effective = (orientation == Board::Config::UiOrientation::Landscape)
+                    ? Board::Config::UiOrientation::LandscapeFlipped
+                    : Board::Config::UiOrientation::Landscape;
   } else {
-    displayOrientation = orientation;
+    effective = orientation;
   }
-  display_.setUiOrientation(displayOrientation);
+  Input::Touch::setUiOrientation(effective);
+  display_.setUiOrientation(effective);
 }
 
 void App::applyReaderUiOrientation() {

--- a/src/app/App.cpp
+++ b/src/app/App.cpp
@@ -7054,7 +7054,18 @@ bool App::isFocusTimerMenuScreen(MenuScreen screen) const {
 
 void App::applyUiOrientation(Board::Config::UiOrientation orientation) {
   Input::Touch::setUiOrientation(orientation);
-  display_.setUiOrientation(orientation);
+  // When PANEL_FLIP_180 is set, the display panel is physically mounted inverted. Apply
+  // the opposite display orientation so the rendered image appears correct to the user,
+  // while touch orientation stays untouched (already set above) for correct swipe mapping.
+  Board::Config::UiOrientation displayOrientation;
+  if constexpr (Board::Config::PANEL_FLIP_180) {
+    displayOrientation = (orientation == Board::Config::UiOrientation::Landscape)
+                             ? Board::Config::UiOrientation::LandscapeFlipped
+                             : Board::Config::UiOrientation::Landscape;
+  } else {
+    displayOrientation = orientation;
+  }
+  display_.setUiOrientation(displayOrientation);
 }
 
 void App::applyReaderUiOrientation() {

--- a/src/display/DisplayManager.h
+++ b/src/display/DisplayManager.h
@@ -203,7 +203,11 @@ class DisplayManager {
   bool darkMode_ = true;
   bool nightMode_ = false;
   bool yellowMode_ = false;
-  Board::Config::UiOrientation uiOrientation_ = Board::Config::DEFAULT_UI_ORIENTATION;
+  // When PANEL_FLIP_180 is true the display must start in the flipped orientation so that
+  // it matches applyUiOrientation's display-vs-touch split from the first rendered frame.
+  Board::Config::UiOrientation uiOrientation_ =
+      Board::Config::PANEL_FLIP_180 ? Board::Config::ROTATED_UI_ORIENTATION
+                                    : Board::Config::DEFAULT_UI_ORIENTATION;
   bool tickerPlaybackFrameActive_ = false;
   String lastRenderKey_;
   String batteryLabel_;

--- a/src/drivers/display/co5300/co5300.cpp
+++ b/src/drivers/display/co5300/co5300.cpp
@@ -28,7 +28,10 @@ struct LcdCommand {
 
 // Keep the panel memory in its native orientation and let the shared mapping layer handle the
 // landscape transform, just like the stabilized 2.41 port.
-constexpr uint8_t kDefaultMadctl = Board::Config::UI_ROTATED_180 ? 0xC0 : 0x00;
+// PANEL_FLIP_180 controls the hardware MADCTL flip independently of the software UI orientation,
+// so that boards with physically inverted displays can flip the panel without affecting input
+// coordinate mapping.
+constexpr uint8_t kDefaultMadctl = Board::Config::PANEL_FLIP_180 ? 0xC0 : 0x00;
 constexpr LcdCommand kQspiInit[] = {
     {0x11, {0x00}, 0, 120},
     {0xFE, {0x20}, 1, 0},

--- a/src/drivers/display/co5300/co5300.cpp
+++ b/src/drivers/display/co5300/co5300.cpp
@@ -28,10 +28,7 @@ struct LcdCommand {
 
 // Keep the panel memory in its native orientation and let the shared mapping layer handle the
 // landscape transform, just like the stabilized 2.41 port.
-// PANEL_FLIP_180 controls the hardware MADCTL flip independently of the software UI orientation,
-// so that boards with physically inverted displays can flip the panel without affecting input
-// coordinate mapping.
-constexpr uint8_t kDefaultMadctl = Board::Config::PANEL_FLIP_180 ? 0xC0 : 0x00;
+constexpr uint8_t kDefaultMadctl = Board::Config::UI_ROTATED_180 ? 0xC0 : 0x00;
 constexpr LcdCommand kQspiInit[] = {
     {0x11, {0x00}, 0, 120},
     {0xFE, {0x20}, 1, 0},

--- a/src/input/InputTouch.cpp
+++ b/src/input/InputTouch.cpp
@@ -20,7 +20,9 @@ struct TouchState {
   uint8_t consecutiveReadFailures = 0;
   uint8_t emptySamples = 0;
   bool active = false;
-  Board::Config::UiOrientation uiOrientation = Board::Config::DEFAULT_UI_ORIENTATION;
+  Board::Config::UiOrientation uiOrientation =
+      Board::Config::PANEL_FLIP_180 ? Board::Config::ROTATED_UI_ORIENTATION
+                                    : Board::Config::DEFAULT_UI_ORIENTATION;
   uint16_t lastX = 0;
   uint16_t lastY = 0;
 };

--- a/src/platforms/waveshare_amoled_18/BoardConfig.h
+++ b/src/platforms/waveshare_amoled_18/BoardConfig.h
@@ -81,6 +81,7 @@ constexpr uint8_t PMU_POWER_KEY_OFF_TIME_VALUE = 0x01;  // 6 second PMU fallback
 constexpr uint32_t PMU_BOOT_BUTTON_IGNORE_MS = 4000;
 constexpr size_t DISPLAY_TX_CHUNK_BYTES = 32 * 1024;
 constexpr bool UI_ROTATED_180 = true;
+constexpr bool PANEL_FLIP_180 = false;
 constexpr UiOrientation DEFAULT_UI_ORIENTATION =
     UI_ROTATED_180 ? UiOrientation::LandscapeFlipped : UiOrientation::Landscape;
 constexpr UiOrientation ROTATED_UI_ORIENTATION =

--- a/src/platforms/waveshare_amoled_18_v2/BoardConfig.h
+++ b/src/platforms/waveshare_amoled_18_v2/BoardConfig.h
@@ -80,7 +80,7 @@ constexpr uint8_t PMU_POWER_KEY_ON_TIME_VALUE = 0x00;   // 128 ms press to power
 constexpr uint8_t PMU_POWER_KEY_OFF_TIME_VALUE = 0x01;  // 6 second PMU fallback power off
 constexpr uint32_t PMU_BOOT_BUTTON_IGNORE_MS = 4000;
 constexpr size_t DISPLAY_TX_CHUNK_BYTES = 32 * 1024;
-constexpr bool UI_ROTATED_180 = true;
+constexpr bool UI_ROTATED_180 = false;
 constexpr UiOrientation DEFAULT_UI_ORIENTATION =
     UI_ROTATED_180 ? UiOrientation::LandscapeFlipped : UiOrientation::Landscape;
 constexpr UiOrientation ROTATED_UI_ORIENTATION =

--- a/src/platforms/waveshare_amoled_18_v2/BoardConfig.h
+++ b/src/platforms/waveshare_amoled_18_v2/BoardConfig.h
@@ -81,6 +81,7 @@ constexpr uint8_t PMU_POWER_KEY_OFF_TIME_VALUE = 0x01;  // 6 second PMU fallback
 constexpr uint32_t PMU_BOOT_BUTTON_IGNORE_MS = 4000;
 constexpr size_t DISPLAY_TX_CHUNK_BYTES = 32 * 1024;
 constexpr bool UI_ROTATED_180 = false;
+constexpr bool PANEL_FLIP_180 = true;  // Display panel is physically mounted flipped 180°
 constexpr UiOrientation DEFAULT_UI_ORIENTATION =
     UI_ROTATED_180 ? UiOrientation::LandscapeFlipped : UiOrientation::Landscape;
 constexpr UiOrientation ROTATED_UI_ORIENTATION =

--- a/src/platforms/waveshare_amoled_216/BoardConfig.h
+++ b/src/platforms/waveshare_amoled_216/BoardConfig.h
@@ -83,6 +83,7 @@ constexpr uint32_t PMU_BOOT_BUTTON_IGNORE_MS = 1200;
 // rounds transfers down to whole rows to avoid fixed seam artifacts.
 constexpr size_t DISPLAY_TX_CHUNK_BYTES = 32 * 1024;
 constexpr bool UI_ROTATED_180 = false;
+constexpr bool PANEL_FLIP_180 = false;
 constexpr UiOrientation DEFAULT_UI_ORIENTATION =
     UI_ROTATED_180 ? UiOrientation::LandscapeFlipped : UiOrientation::Landscape;
 constexpr UiOrientation ROTATED_UI_ORIENTATION =

--- a/src/platforms/waveshare_amoled_241/BoardConfig.h
+++ b/src/platforms/waveshare_amoled_241/BoardConfig.h
@@ -79,6 +79,7 @@ constexpr uint32_t TOUCH_I2C_CLOCK_HZ = 400000;
 constexpr uint32_t TOUCH_I2C_TIMEOUT_MS = 10;
 constexpr size_t DISPLAY_TX_CHUNK_BYTES = 48 * 1024;
 constexpr bool UI_ROTATED_180 = false;
+constexpr bool PANEL_FLIP_180 = false;
 constexpr UiOrientation DEFAULT_UI_ORIENTATION =
     UI_ROTATED_180 ? UiOrientation::LandscapeFlipped : UiOrientation::Landscape;
 constexpr UiOrientation ROTATED_UI_ORIENTATION =

--- a/src/platforms/waveshare_lcd_349/rev1/BoardConfig.h
+++ b/src/platforms/waveshare_lcd_349/rev1/BoardConfig.h
@@ -79,6 +79,7 @@ constexpr uint32_t TOUCH_I2C_CLOCK_HZ = 300000;
 constexpr uint32_t TOUCH_I2C_TIMEOUT_MS = 10;
 constexpr size_t DISPLAY_TX_CHUNK_BYTES = 16 * 1024;
 constexpr bool UI_ROTATED_180 = true;  // Keep BOOT/PWR at the top edge in landscape.
+constexpr bool PANEL_FLIP_180 = false;
 constexpr UiOrientation DEFAULT_UI_ORIENTATION =
     UI_ROTATED_180 ? UiOrientation::LandscapeFlipped : UiOrientation::Landscape;
 constexpr UiOrientation ROTATED_UI_ORIENTATION =

--- a/src/platforms/waveshare_lcd_349/rev2/BoardConfig.h
+++ b/src/platforms/waveshare_lcd_349/rev2/BoardConfig.h
@@ -79,6 +79,7 @@ constexpr uint32_t TOUCH_I2C_CLOCK_HZ = 300000;
 constexpr uint32_t TOUCH_I2C_TIMEOUT_MS = 10;
 constexpr size_t DISPLAY_TX_CHUNK_BYTES = 16 * 1024;
 constexpr bool UI_ROTATED_180 = true;
+constexpr bool PANEL_FLIP_180 = false;
 constexpr UiOrientation DEFAULT_UI_ORIENTATION =
     UI_ROTATED_180 ? UiOrientation::LandscapeFlipped : UiOrientation::Landscape;
 constexpr UiOrientation ROTATED_UI_ORIENTATION =


### PR DESCRIPTION
fix: correct screen rotation for Waveshare AMOLED 1.8" V2 board

The 1.8" V2 board has its display panel physically mounted 180° inverted compared to the original 1.8" board. This caused all UI content to appear upside-down and swipe gestures to be reversed.

Fix

A pure software approach decoupling hardware register from orientation logic:

BoardConfig.h (18_v2)

 - UI_ROTATED_180 = false  removes the broken hardware dependency
 - PANEL_FLIP_180 = true  new flag expressing that the panel is physically inverted

App::applyUiOrientation()
When PANEL_FLIP_180 is set, the effective orientation passed to both display and touch is flipped to the opposite landscape mode:

- App logic operates in Landscape as normal
- Display and touch receive LandscapeFlipped, which rotates all coordinates 180°

DisplayManager and InputTouch
Initial orientation uses ROTATED_UI_ORIENTATION (LandscapeFlipped) when PANEL_FLIP_180 is set, so the first frame is already correct before any orientation change event fires.
