### PR TITLE
Build EPUB chapter lists from nav and NCX TOCs

### DIFF
--- a/src/converter/EpubContentWriter.cpp
+++ b/src/converter/EpubContentWriter.cpp
@@ -496,11 +496,17 @@ namespace EpubContent {
         return keepGoing;
     }
 
-    RsvpContentWriter::RsvpContentWriter(File& output, size_t& wordCount, size_t maxWords, String& lastChapterTitle) :
+    bool writeChapterDirective(File& output, const String& title, String& lastChapterTitle) {
+        return writeChapterMarker(output, title, lastChapterTitle);
+    }
+
+    RsvpContentWriter::RsvpContentWriter(File& output, size_t& wordCount, size_t maxWords, String& lastChapterTitle,
+                                         bool allowHeadingChapters) :
             output_(output),
             wordCount_(wordCount),
             maxWords_(maxWords),
-            lastChapterTitle_(lastChapterTitle) {
+            lastChapterTitle_(lastChapterTitle),
+            allowHeadingChapters_(allowHeadingChapters) {
         line_.reserve(160);
         heading_.reserve(80);
         tag_.reserve(96);
@@ -615,7 +621,7 @@ namespace EpubContent {
 
         // Headings become RSVP chapter markers instead of body words.
         {
-            if (isHeadingTag(tagInfo.name)) {
+            if (allowHeadingChapters_ && isHeadingTag(tagInfo.name)) {
                 if (tagInfo.closing) {
                     inHeading_ = false;
                     const String cleanedHeading = plainTextFromXmlFragment(heading_);

--- a/src/converter/EpubContentWriter.h
+++ b/src/converter/EpubContentWriter.h
@@ -7,10 +7,12 @@ namespace EpubContent {
 
     String plainTextFromXmlFragment(const String& fragment);
     bool writeBodyLine(File& output, const String& line, size_t& wordCount, size_t maxWords);
+    bool writeChapterDirective(File& output, const String& title, String& lastChapterTitle);
 
     class RsvpContentWriter {
     public:
-        RsvpContentWriter(File& output, size_t& wordCount, size_t maxWords, String& lastChapterTitle);
+        RsvpContentWriter(File& output, size_t& wordCount, size_t maxWords, String& lastChapterTitle,
+                          bool allowHeadingChapters = true);
 
         bool write(const uint8_t* data, size_t length);
         bool finish();
@@ -44,6 +46,7 @@ namespace EpubContent {
         String commentTail_;
         Mode mode_ = Mode::Text;
         bool inHeading_ = false;
+        const bool allowHeadingChapters_;
         bool reachedWordLimit_ = false;
         int skipDepth_ = 0;
     };

--- a/src/converter/EpubConverter.cpp
+++ b/src/converter/EpubConverter.cpp
@@ -3,6 +3,7 @@
 #include <SD_MMC.h>
 #include <algorithm>
 
+#include "converter/EpubContentWriter.h"
 #include "converter/EpubPackage.h"
 #include "converter/EpubZip.h"
 #include "storage/fs/StoragePaths.h"
@@ -11,22 +12,33 @@ namespace {
 
     constexpr size_t kMaxOpfBytes = 256UL * 1024UL;
     constexpr size_t kMaxContainerBytes = 32UL * 1024UL;
+    constexpr size_t kMaxTocBytes = 256UL * 1024UL;
     constexpr const char* kConverterVersion = "stream-v6";
 
     using EpubPackage::basenameWithoutExtension;
     using EpubPackage::directoryForPath;
     using EpubPackage::findManifestItem;
+    using EpubPackage::findNavDocumentPath;
+    using EpubPackage::findNcxDocumentPath;
     using EpubPackage::isContentDocument;
     using EpubPackage::ManifestItem;
     using EpubPackage::parseDcMetadata;
     using EpubPackage::parseManifestItems;
+    using EpubPackage::parseNavTocEntries;
+    using EpubPackage::parseNcxTocEntries;
     using EpubPackage::parseRootfilePath;
     using EpubPackage::parseSpineIds;
+    using EpubPackage::TocEntry;
 
     struct PackageDocuments {
         String opfXml;
         String opfPath;
         String opfBaseDir;
+    };
+
+    struct ReadingItem {
+        String path;
+        String chapterTitle;
     };
 
     struct ConversionPaths {
@@ -61,6 +73,71 @@ namespace {
 
     int contentProgressPercent(size_t completedItems, size_t itemCount) {
         return 25 + static_cast<int>((completedItems * 70UL) / itemCount);
+    }
+
+    bool hasSectionKeyword(const String& loweredValue, const char* keyword) {
+        return loweredValue == keyword || loweredValue.startsWith(String(keyword) + " ")
+            || loweredValue.endsWith(String(" ") + keyword) || loweredValue.indexOf(String(" ") + keyword + " ") >= 0;
+    }
+
+    bool shouldFilterNonReadingSection(const String& path, const String& tocTitle) {
+        const String loweredPath = EpubPackage::toLowerCopy(path);
+        const String loweredTitle = EpubPackage::toLowerCopy(tocTitle);
+
+        if (loweredPath.indexOf("next-reads") >= 0 || loweredPath.indexOf("_nav_") >= 0) {
+            return true;
+        }
+
+        if (loweredPath.indexOf("_cvi_") >= 0 || loweredPath.indexOf("_cop_") >= 0 || loweredPath.indexOf("_map_") >= 0
+            || loweredPath.indexOf("_toc_") >= 0 || loweredPath.indexOf("_tp_") >= 0) {
+            return true;
+        }
+
+        return hasSectionKeyword(loweredTitle, "cover") || loweredTitle == "title page"
+            || hasSectionKeyword(loweredTitle, "copyright") || loweredTitle == "contents"
+            || loweredTitle == "table of contents" || loweredTitle == "maps" || loweredTitle == "map"
+            || loweredTitle == "what's next on your reading list?"
+            || loweredTitle == "what’s next on your reading list?" || loweredTitle == "what is next on your reading list?"
+            || loweredTitle.indexOf("next on your reading list") >= 0;
+    }
+
+    const TocEntry* findTocEntryForPath(const std::vector<TocEntry>& entries, const String& path) {
+        const auto entry = std::find_if(entries.begin(), entries.end(), [&](const TocEntry& candidate) {
+            return candidate.path == path;
+        });
+        return entry == entries.end() ? nullptr : &(*entry);
+    }
+
+    std::vector<TocEntry> readPrimaryTocEntries(EpubZip::Archive& zip, const std::vector<ManifestItem>& manifest,
+                                                const String& opfXml, const EpubConverter::Options& options) {
+        typedef std::vector<TocEntry> (*TocParser)(const String&, const String&);
+
+        const auto readTocEntries = [&](const String& tocPath, const char* label, TocParser parser) {
+            if (tocPath.isEmpty()) {
+                return std::vector<TocEntry>{};
+            }
+
+            reportProgress(options, "Opening EPUB", label, 18);
+            String tocXml;
+            Serial.printf("[epub] Reading %s: %s\n", label, tocPath.c_str());
+            if (!zip.extractToString(tocPath, tocXml, kMaxTocBytes)) {
+                Serial.printf("[epub] Could not read %s: %s\n", label, tocPath.c_str());
+                return std::vector<TocEntry>{};
+            }
+            std::vector<TocEntry> entries = parser(tocXml, directoryForPath(tocPath));
+            Serial.printf("[epub] Parsed %u TOC entries from %s\n", static_cast<unsigned int>(entries.size()),
+                          tocPath.c_str());
+            return entries;
+        };
+
+        const String navPath = findNavDocumentPath(manifest);
+        std::vector<TocEntry> entries = readTocEntries(navPath, "Reading navigation", parseNavTocEntries);
+        if (!entries.empty()) {
+            return entries;
+        }
+
+        const String ncxPath = findNcxDocumentPath(opfXml, manifest);
+        return readTocEntries(ncxPath, "Reading NCX", parseNcxTocEntries);
     }
 
     bool readPackageDocuments(EpubZip::Archive& zip, const EpubConverter::Options& options,
@@ -122,20 +199,50 @@ namespace {
         return order;
     }
 
-    std::vector<String> buildReadingOrder(const String& opfXml, const String& opfBaseDir,
-                                          const EpubConverter::Options& options) {
+    std::vector<ReadingItem> buildReadingOrder(const std::vector<ManifestItem>& manifest,
+                                               const std::vector<String>& spineIds,
+                                               const std::vector<TocEntry>& tocEntries,
+                                               const EpubConverter::Options& options) {
+        std::vector<String> paths = [&]() {
+            std::vector<String> order = contentDocumentsInSpineOrder(manifest, spineIds);
+            return order.empty() ? allContentDocuments(manifest) : order;
+        }();
+
+        std::vector<ReadingItem> order;
+        order.reserve(paths.size());
+
+        std::for_each(paths.begin(), paths.end(), [&](const String& path) {
+            serviceBackground();
+
+            const TocEntry* tocEntry = findTocEntryForPath(tocEntries, path);
+            const String title = tocEntry == nullptr ? String("") : tocEntry->title;
+            if (shouldFilterNonReadingSection(path, title)) {
+                Serial.printf("[epub] Filtering non-reading section: %s title=%s\n", path.c_str(), title.c_str());
+                return;
+            }
+
+            ReadingItem item;
+            item.path = path;
+            item.chapterTitle = title;
+            order.push_back(item);
+        });
+
+        reportProgress(options, "Opening EPUB", "Building reading order", 20);
+        return order;
+    }
+
+    std::vector<ReadingItem> buildReadingOrder(const String& opfXml, const String& opfBaseDir,
+                                               EpubZip::Archive& zip, const EpubConverter::Options& options,
+                                               bool& usingPrimaryTocChapters) {
         const std::vector<ManifestItem> manifest = parseManifestItems(opfXml, opfBaseDir);
         const std::vector<String> spineIds = parseSpineIds(opfXml);
+        const std::vector<TocEntry> tocEntries = readPrimaryTocEntries(zip, manifest, opfXml, options);
 
         Serial.printf("[epub] Package parsed: manifest=%u spine=%u base=%s\n",
                       static_cast<unsigned int>(manifest.size()), static_cast<unsigned int>(spineIds.size()),
                       opfBaseDir.c_str());
-
-        reportProgress(options, "Opening EPUB", "Building reading order", 20);
-        return [&]() {
-            std::vector<String> order = contentDocumentsInSpineOrder(manifest, spineIds);
-            return order.empty() ? allContentDocuments(manifest) : order;
-        }();
+        usingPrimaryTocChapters = !tocEntries.empty();
+        return buildReadingOrder(manifest, spineIds, tocEntries, options);
     }
 
     void writeRsvpHeader(File& output, const String& epubPath, const String& opfXml) {
@@ -159,15 +266,17 @@ namespace {
         output.println();
     }
 
-    void reportReadingOrderReady(const EpubConverter::Options& options, const std::vector<String>& readingOrder) {
+    void reportReadingOrderReady(const EpubConverter::Options& options, const std::vector<ReadingItem>& readingOrder,
+                                 bool usingPrimaryTocChapters) {
         Serial.printf("[epub] Reading order contains %u content files\n",
                       static_cast<unsigned int>(readingOrder.size()));
-        const String foundDetail = String(readingOrder.size()) + " content files";
+        const String foundDetail = String(readingOrder.size()) + " content files"
+                                 + (usingPrimaryTocChapters ? " with TOC chapters" : " with heading fallback");
         reportProgress(options, "Opening EPUB", foundDetail.c_str(), 25);
     }
 
-    void streamReadingOrder(EpubZip::Archive& zip, File& output, const std::vector<String>& readingOrder,
-                            const EpubConverter::Options& options, size_t& wordCount) {
+    void streamReadingOrder(EpubZip::Archive& zip, File& output, const std::vector<ReadingItem>& readingOrder,
+                            bool usingPrimaryTocChapters, const EpubConverter::Options& options, size_t& wordCount) {
         String lastChapterTitle;
 
         const auto withinWordLimit = [&]() {
@@ -184,15 +293,19 @@ namespace {
 
             reportItemProgress("Extracting content", i);
 
+            if (usingPrimaryTocChapters && !readingOrder[i].chapterTitle.isEmpty()) {
+                EpubContent::writeChapterDirective(output, readingOrder[i].chapterTitle, lastChapterTitle);
+            }
+
             const EpubZip::ContentExtractStatus extractStatus =
-                zip.extractContentToRsvp(readingOrder[i], output, wordCount, options.maxWords, lastChapterTitle,
-                                         options, i, readingOrder.size());
+                zip.extractContentToRsvp(readingOrder[i].path, output, wordCount, options.maxWords, lastChapterTitle,
+                                         !usingPrimaryTocChapters, options, i, readingOrder.size());
 
             reportItemProgress("Parsed content", i + 1);
 
             if (extractStatus == EpubZip::ContentExtractStatus::Unsupported
                 || extractStatus == EpubZip::ContentExtractStatus::Failed) {
-                Serial.printf("[epub] Skipping unreadable content file: %s\n", readingOrder[i].c_str());
+                Serial.printf("[epub] Skipping unreadable content file: %s\n", readingOrder[i].path.c_str());
                 continue;
             }
 
@@ -233,12 +346,14 @@ namespace {
             return failWithClosedZip();
         }
 
-        const std::vector<String> readingOrder = buildReadingOrder(documents.opfXml, documents.opfBaseDir, options);
+        bool usingPrimaryTocChapters = false;
+        const std::vector<ReadingItem> readingOrder =
+            buildReadingOrder(documents.opfXml, documents.opfBaseDir, zip, options, usingPrimaryTocChapters);
         if (readingOrder.empty()) {
             Serial.println("[epub] No readable XHTML spine items found");
             return failWithClosedZip();
         }
-        reportReadingOrderReady(options, readingOrder);
+        reportReadingOrderReady(options, readingOrder, usingPrimaryTocChapters);
 
         SD_MMC.remove(tempPath);
         File output = SD_MMC.open(tempPath, FILE_WRITE);
@@ -250,7 +365,7 @@ namespace {
         writeRsvpHeader(output, epubPath, documents.opfXml);
 
         size_t wordCount = 0;
-        streamReadingOrder(zip, output, readingOrder, options, wordCount);
+        streamReadingOrder(zip, output, readingOrder, usingPrimaryTocChapters, options, wordCount);
 
         const String finishingDetail = wordCountDetail(wordCount);
         reportProgress(options, "Finishing EPUB", finishingDetail.c_str(), 96);

--- a/src/converter/EpubPackage.cpp
+++ b/src/converter/EpubPackage.cpp
@@ -151,6 +151,61 @@ namespace EpubPackage {
             return "";
         }
 
+        bool attributeValueContainsToken(const String& tag, const char* name, const char* token) {
+            String value = attributeValue(tag, name);
+            value.toLowerCase();
+
+            String tokenValue(token);
+            tokenValue.toLowerCase();
+
+            int start = 0;
+            while (start >= 0 && static_cast<size_t>(start) < value.length()) {
+                start = skipAsciiWhitespace(value, start);
+                if (static_cast<size_t>(start) >= value.length()) {
+                    break;
+                }
+
+                int end = start;
+                while (static_cast<size_t>(end) < value.length() && !AsciiText::isWhitespace(value[end])) {
+                    ++end;
+                }
+
+                if (value.substring(start, end) == tokenValue) {
+                    return true;
+                }
+                start = end + 1;
+            }
+
+            return false;
+        }
+
+        void pushUniqueTocEntry(std::vector<TocEntry>& entries, const String& path, const String& title) {
+            if (path.isEmpty()) {
+                return;
+            }
+
+            String cleanedTitle = EpubContent::plainTextFromXmlFragment(title);
+            cleanedTitle.trim();
+            if (cleanedTitle.isEmpty()) {
+                return;
+            }
+
+            const auto existing = std::find_if(entries.begin(), entries.end(), [&](const TocEntry& entry) {
+                return entry.path == path;
+            });
+            if (existing != entries.end()) {
+                if (existing->title.isEmpty()) {
+                    existing->title = cleanedTitle;
+                }
+                return;
+            }
+
+            TocEntry entry;
+            entry.path = path;
+            entry.title = cleanedTitle;
+            entries.push_back(entry);
+        }
+
     } // namespace
 
     String toLowerCopy(String value) {
@@ -297,6 +352,7 @@ namespace EpubPackage {
             item.id = attributeValue(tag, "id");
             item.path = resolveZipPath(opfBaseDir, attributeValue(tag, "href"));
             item.mediaType = attributeValue(tag, "media-type");
+            item.properties = attributeValue(tag, "properties");
 
             if (!item.id.isEmpty() && !item.path.isEmpty()) {
                 items.push_back(item);
@@ -333,6 +389,133 @@ namespace EpubPackage {
         }
 
         return ids;
+    }
+
+    String findNavDocumentPath(const std::vector<ManifestItem>& items) {
+        const auto item = std::find_if(items.begin(), items.end(), [&](const ManifestItem& candidate) {
+            String properties = candidate.properties;
+            properties.toLowerCase();
+            return properties == "nav" || properties.startsWith("nav ") || properties.endsWith(" nav")
+                || properties.indexOf(" nav ") >= 0;
+        });
+        return item == items.end() ? String("") : item->path;
+    }
+
+    String findNcxDocumentPath(const String& opfXml, const std::vector<ManifestItem>& items) {
+        int position = opfXml.indexOf("<spine");
+        if (position >= 0) {
+            const int end = opfXml.indexOf('>', position);
+            if (end >= 0) {
+                const String tag = opfXml.substring(position, end + 1);
+                const String tocId = attributeValue(tag, "toc");
+                if (!tocId.isEmpty()) {
+                    const ManifestItem* item = findManifestItem(items, tocId);
+                    if (item != nullptr) {
+                        return item->path;
+                    }
+                }
+            }
+        }
+
+        const auto item = std::find_if(items.begin(), items.end(), [&](const ManifestItem& candidate) {
+            return toLowerCopy(candidate.mediaType) == "application/x-dtbncx+xml";
+        });
+        return item == items.end() ? String("") : item->path;
+    }
+
+    std::vector<TocEntry> parseNavTocEntries(const String& navXml, const String& navBaseDir) {
+        std::vector<TocEntry> entries;
+        int position = 0;
+
+        while (position >= 0) {
+            position = navXml.indexOf("<nav", position);
+            if (position < 0) {
+                break;
+            }
+
+            const int openEnd = navXml.indexOf('>', position);
+            if (openEnd < 0) {
+                break;
+            }
+
+            const String openTag = navXml.substring(position, openEnd + 1);
+            const bool isTocNav = attributeValueContainsToken(openTag, "epub:type", "toc")
+                               || attributeValueContainsToken(openTag, "type", "toc");
+            const int closeStart = navXml.indexOf("</nav>", openEnd + 1);
+            if (closeStart < 0) {
+                break;
+            }
+
+            if (isTocNav) {
+                const String body = navXml.substring(openEnd + 1, closeStart);
+                int anchorPosition = 0;
+                while (anchorPosition >= 0) {
+                    anchorPosition = body.indexOf("<a", anchorPosition);
+                    if (anchorPosition < 0) {
+                        break;
+                    }
+
+                    const int anchorOpenEnd = body.indexOf('>', anchorPosition);
+                    if (anchorOpenEnd < 0) {
+                        break;
+                    }
+                    const int anchorCloseStart = body.indexOf("</a>", anchorOpenEnd + 1);
+                    if (anchorCloseStart < 0) {
+                        break;
+                    }
+
+                    const String anchorTag = body.substring(anchorPosition, anchorOpenEnd + 1);
+                    const String href = attributeValue(anchorTag, "href");
+                    if (!href.isEmpty()) {
+                        pushUniqueTocEntry(entries, resolveZipPath(navBaseDir, href),
+                                           body.substring(anchorOpenEnd + 1, anchorCloseStart));
+                    }
+
+                    anchorPosition = anchorCloseStart + 4;
+                }
+                break;
+            }
+
+            position = closeStart + 6;
+        }
+
+        return entries;
+    }
+
+    std::vector<TocEntry> parseNcxTocEntries(const String& ncxXml, const String& ncxBaseDir) {
+        std::vector<TocEntry> entries;
+        int position = 0;
+
+        while (position >= 0) {
+            position = ncxXml.indexOf("<navPoint", position);
+            if (position < 0) {
+                break;
+            }
+
+            const int closeStart = ncxXml.indexOf("</navPoint>", position);
+            if (closeStart < 0) {
+                break;
+            }
+
+            const String body = ncxXml.substring(position, closeStart);
+            const int textOpen = body.indexOf("<text");
+            const int textTagEnd = textOpen < 0 ? -1 : body.indexOf('>', textOpen);
+            const int textClose = textTagEnd < 0 ? -1 : body.indexOf("</text>", textTagEnd + 1);
+            const int contentOpen = body.indexOf("<content");
+            const int contentEnd = contentOpen < 0 ? -1 : body.indexOf('>', contentOpen);
+            if (textTagEnd >= 0 && textClose >= 0 && contentEnd >= 0) {
+                const String contentTag = body.substring(contentOpen, contentEnd + 1);
+                const String src = attributeValue(contentTag, "src");
+                if (!src.isEmpty()) {
+                    pushUniqueTocEntry(entries, resolveZipPath(ncxBaseDir, src),
+                                       body.substring(textTagEnd + 1, textClose));
+                }
+            }
+
+            position = closeStart + 11;
+        }
+
+        return entries;
     }
 
     const ManifestItem* findManifestItem(const std::vector<ManifestItem>& items, const String& id) {

--- a/src/converter/EpubPackage.h
+++ b/src/converter/EpubPackage.h
@@ -9,6 +9,12 @@ namespace EpubPackage {
         String id;
         String path;
         String mediaType;
+        String properties;
+    };
+
+    struct TocEntry {
+        String path;
+        String title;
     };
 
     String toLowerCopy(String value);
@@ -21,6 +27,10 @@ namespace EpubPackage {
     String parseDcMetadata(const String& opfXml, const char* tagName);
     std::vector<ManifestItem> parseManifestItems(const String& opfXml, const String& opfBaseDir);
     std::vector<String> parseSpineIds(const String& opfXml);
+    String findNavDocumentPath(const std::vector<ManifestItem>& items);
+    String findNcxDocumentPath(const String& opfXml, const std::vector<ManifestItem>& items);
+    std::vector<TocEntry> parseNavTocEntries(const String& navXml, const String& navBaseDir);
+    std::vector<TocEntry> parseNcxTocEntries(const String& ncxXml, const String& ncxBaseDir);
     const ManifestItem* findManifestItem(const std::vector<ManifestItem>& items, const String& id);
 
 } // namespace EpubPackage

--- a/src/converter/EpubZip.cpp
+++ b/src/converter/EpubZip.cpp
@@ -332,6 +332,7 @@ namespace EpubZip {
 
     ContentExtractStatus Archive::extractContentToRsvp(const String& name, File& output, size_t& wordCount,
                                                        size_t maxWords, String& lastChapterTitle,
+                                                       bool allowHeadingChapters,
                                                        const EpubConverter::Options& options, size_t itemIndex,
                                                        size_t itemCount) {
         const ZipEntry* entry = find(name);
@@ -339,7 +340,8 @@ namespace EpubZip {
             Serial.printf("[epub-zip] Content entry not found: %s\n", name.c_str());
             return ContentExtractStatus::Failed;
         }
-        return extractContentToRsvp(*entry, output, wordCount, maxWords, lastChapterTitle, options, itemIndex,
+        return extractContentToRsvp(*entry, output, wordCount, maxWords, lastChapterTitle, allowHeadingChapters,
+                                    options, itemIndex,
                                     itemCount);
     }
 
@@ -584,6 +586,7 @@ namespace EpubZip {
 
     ContentExtractStatus Archive::extractContentToRsvp(const ZipEntry& entry, File& output, size_t& wordCount,
                                                        size_t maxWords, String& lastChapterTitle,
+                                                       bool allowHeadingChapters,
                                                        const EpubConverter::Options& options, size_t itemIndex,
                                                        size_t itemCount) {
         Serial.printf("[epub-zip] Extract content: %s method=%u flags=0x%04x c=%lu u=%lu\n", entry.name.c_str(),
@@ -604,7 +607,8 @@ namespace EpubZip {
             return ContentExtractStatus::Failed;
         }
 
-        EpubContent::RsvpContentWriter writer(output, wordCount, maxWords, lastChapterTitle);
+        EpubContent::RsvpContentWriter writer(output, wordCount, maxWords, lastChapterTitle,
+                                             allowHeadingChapters);
         uint32_t totalOutputBytes = 0;
         uint32_t lastProgressBytes = 0;
         ContentExtractStatus result = ContentExtractStatus::Complete;

--- a/src/converter/EpubZip.h
+++ b/src/converter/EpubZip.h
@@ -32,7 +32,8 @@ namespace EpubZip {
 
         bool extractToString(const String& name, String& output, size_t maxBytes);
         ContentExtractStatus extractContentToRsvp(const String& name, File& output, size_t& wordCount, size_t maxWords,
-                                                  String& lastChapterTitle, const EpubConverter::Options& options,
+                                                  String& lastChapterTitle, bool allowHeadingChapters,
+                                                  const EpubConverter::Options& options,
                                                   size_t itemIndex, size_t itemCount);
 
     private:
@@ -41,6 +42,7 @@ namespace EpubZip {
         bool extractToString(const ZipEntry& entry, String& output, size_t maxBytes);
         ContentExtractStatus extractContentToRsvp(const ZipEntry& entry, File& output, size_t& wordCount,
                                                   size_t maxWords, String& lastChapterTitle,
+                                                  bool allowHeadingChapters,
                                                   const EpubConverter::Options& options, size_t itemIndex,
                                                   size_t itemCount);
 


### PR DESCRIPTION
Problem:
Some EPUBs, including Artemis by Andy Weir, convert into RSVP with an incorrect chapter list even though the book package contains a complete table of contents. Artemis exposes Chapter 1 through Chapter 17 in its EPUB nav and NCX documents, but the converted book only produced a few markers such as Contents, Double Homicide in Artemis, About the Author, and the end-of-book recommendation page. The root cause was that chapter generation depended primarily on "<h 1>-<h 6>" tags found inside content documents. Some EPUBs store chapter boundaries in nav/NCX metadata or image-based chapter openers rather than heading tags, so real chapter boundaries were lost while incidental headings inside body content could be promoted as fake chapters.

Summary of changes:
Add EPUB TOC parsing for both EPUB3 nav documents and NCX files in the package layer, including manifest property support and path resolution for TOC targets.

Use TOC entries as the primary source of chapter markers during conversion by mapping TOC labels onto spine items and emitting @chapter directives before each matching content document.

Keep heading-based chapter extraction only as a fallback path when no usable nav/NCX TOC is present, and disable heading-driven chapter markers when TOC metadata is available so incidental headings do not override the book structure.
Assume this was for other Articles (not tested with this content)

Filter obvious non-reading sections out of the converted reading order, including cover, title page, contents, copyright pages, map pages, generated nav pages, and promotional next-reads content.

Design notes:
The fix keeps the existing spine-based reading order so content sequence still follows the publisher-defined reading flow, while chapter labels now come from the publisher-defined TOC when available.

Filtering happens at reading-order construction time so non-reading sections are excluded both from chapter menus and from converted RSVP text, reducing noise for books that bundle marketing or front-matter helpers in the spine.

The fallback preserves compatibility with simpler EPUBs and potentially articale (not tested) that rely on inline headings and do not provide a clean nav or NCX structure.