### PR TITLE
Reverse change back to : Power off immediately on long press

### DIFF
--- a/src/app/App.cpp
+++ b/src/app/App.cpp
@@ -181,12 +181,6 @@ enum UpdateConfirmItem : size_t {
   UpdateConfirmItemCount,
 };
 
-enum PowerOffConfirmItem : size_t {
-  PowerOffConfirmNo,
-  PowerOffConfirmYes,
-  PowerOffConfirmItemCount,
-};
-
 enum QuickSettingsItem : size_t {
   QuickSettingsBrightness,
   QuickSettingsTheme,
@@ -204,7 +198,6 @@ enum QuickSyncItem : size_t {
 constexpr size_t kRestartConfirmHeaderRows = 1;
 constexpr size_t kSdCardRepairConfirmHeaderRows = 1;
 constexpr size_t kUpdateConfirmHeaderRows = 2;
-constexpr size_t kPowerOffConfirmHeaderRows = 1;
 constexpr size_t kSettingsBackIndex = 0;
 constexpr size_t kSettingsHomePacingIndex = 1;
 constexpr size_t kSettingsHomeDisplayIndex = 2;
@@ -1386,7 +1379,7 @@ void App::handlePowerButton(uint32_t nowMs) {
     if (powerButton_.isHeld() && powerButton_.heldDurationMs(nowMs) >= kPowerOffHoldMs) {
       powerButtonLongPressHandled_ = true;
       if (Board::Config::SUPPORTS_SOFTWARE_POWEROFF) {
-        openPowerOffConfirm(nowMs);
+        enterPowerOff(nowMs);
       } else {
         enterStandby(nowMs);
       }
@@ -1433,7 +1426,7 @@ void App::handlePowerButton(uint32_t nowMs) {
   if (logicalPowerButtonUsesVirtualState() && Board::Buttons::consumeVirtualPowerLongPress()) {
     powerButtonLongPressHandled_ = true;
     if (Board::Config::SUPPORTS_SOFTWARE_POWEROFF) {
-      openPowerOffConfirm(nowMs);
+      enterPowerOff(nowMs);
     } else {
       enterStandby(nowMs);
     }
@@ -1456,7 +1449,7 @@ void App::handlePowerButton(uint32_t nowMs) {
   if (powerButton_.isHeld() && nowMs - powerButton_.lastEdgeMs() >= kPowerOffHoldMs) {
     powerButtonLongPressHandled_ = true;
     if (Board::Config::SUPPORTS_SOFTWARE_POWEROFF) {
-      openPowerOffConfirm(nowMs);
+      enterPowerOff(nowMs);
     } else {
       enterStandby(nowMs);
     }
@@ -1546,8 +1539,6 @@ void App::toggleMenuFromPowerButton(uint32_t nowMs) {
   if (state_ == AppState::Menu) {
     if (menuScreen_ == MenuScreen::Main) {
       setState(AppState::Paused, nowMs);
-    } else if (menuScreen_ == MenuScreen::PowerOffConfirm) {
-      cancelPowerOffConfirm(nowMs);
     } else if (menuScreen_ == MenuScreen::QuickSync) {
       menuScreen_ = MenuScreen::QuickSettings;
       renderQuickSettings();
@@ -3082,10 +3073,6 @@ bool App::navigateBackInMenu(uint32_t nowMs) {
       selectUpdateConfirmItem(nowMs);
       return true;
 
-    case MenuScreen::PowerOffConfirm:
-      cancelPowerOffConfirm(nowMs);
-      return true;
-
     case MenuScreen::QuickSync:
       menuScreen_ = MenuScreen::QuickSettings;
       renderQuickSettings();
@@ -3138,9 +3125,6 @@ bool App::moveMenuSelection(int direction, bool wrap) {
   } else if (menuScreen_ == MenuScreen::UpdateConfirm) {
     selectedIndex = &updateConfirmSelectedIndex_;
     itemCount = UpdateConfirmItemCount;
-  } else if (menuScreen_ == MenuScreen::PowerOffConfirm) {
-    selectedIndex = &powerOffConfirmSelectedIndex_;
-    itemCount = PowerOffConfirmItemCount;
   } else if (menuScreen_ == MenuScreen::QuickSettings) {
     selectedIndex = &quickSettingsSelectedIndex_;
     itemCount = QuickSettingsItemCount;
@@ -3210,10 +3194,6 @@ bool App::moveMenuSelection(int direction, bool wrap) {
     const String selectedLabel =
         updateConfirmSelectedIndex_ == UpdateConfirmUpdate ? "Update" : "Skip for now";
     Serial.printf("[ota] selected=%s\n", selectedLabel.c_str());
-  } else if (menuScreen_ == MenuScreen::PowerOffConfirm) {
-    const String selectedLabel =
-        powerOffConfirmSelectedIndex_ == PowerOffConfirmYes ? "Yes" : "Cancel";
-    Serial.printf("[power-off] selected=%s\n", selectedLabel.c_str());
   } else if (menuScreen_ == MenuScreen::QuickSettings) {
     String selectedLabel = "Brightness";
     switch (quickSettingsSelectedIndex_) {
@@ -3346,10 +3326,6 @@ void App::selectMenuItem(uint32_t nowMs) {
   }
   if (menuScreen_ == MenuScreen::UpdateConfirm) {
     selectUpdateConfirmItem(nowMs);
-    return;
-  }
-  if (menuScreen_ == MenuScreen::PowerOffConfirm) {
-    selectPowerOffConfirmItem(nowMs);
     return;
   }
   if (menuScreen_ == MenuScreen::QuickSettings) {
@@ -5465,56 +5441,6 @@ void App::selectUpdateConfirmItem(uint32_t nowMs) {
   runFirmwareUpdate(preferredOtaConfig(), false, nowMs);
 }
 
-void App::openPowerOffConfirm(uint32_t nowMs) {
-  powerOffConfirmReturnState_ = state_;
-  powerOffConfirmReturnScreen_ = state_ == AppState::Menu ? menuScreen_ : MenuScreen::Main;
-  powerOffConfirmSelectedIndex_ = PowerOffConfirmNo;
-  pausedTouch_.active = false;
-  pausedTouchIntent_ = TouchIntent::None;
-  wpmFeedbackVisible_ = false;
-  contextViewVisible_ = false;
-
-  if (state_ != AppState::Menu) {
-    saveReadingPosition(true);
-  }
-
-  menuScreen_ = MenuScreen::PowerOffConfirm;
-  if (state_ == AppState::Menu) {
-    renderPowerOffConfirm();
-  } else {
-    setState(AppState::Menu, nowMs);
-  }
-}
-
-void App::cancelPowerOffConfirm(uint32_t nowMs) {
-  Serial.println("[power-off] cancelled by user");
-  const AppState returnState = powerOffConfirmReturnState_;
-  const MenuScreen returnScreen = powerOffConfirmReturnScreen_;
-  menuScreen_ = returnScreen;
-
-  if (returnState == AppState::Menu) {
-    renderMenu();
-    return;
-  }
-
-  if (returnState == AppState::Playing) {
-    setState(AppState::Paused, nowMs);
-    return;
-  }
-
-  setState(returnState, nowMs);
-}
-
-void App::selectPowerOffConfirmItem(uint32_t nowMs) {
-  if (powerOffConfirmSelectedIndex_ != PowerOffConfirmYes) {
-    cancelPowerOffConfirm(nowMs);
-    return;
-  }
-
-  Serial.println("[power-off] confirmed by user");
-  enterPowerOff(nowMs);
-}
-
 void App::enterCompanionSync(uint32_t nowMs) {
   if (blockNetworkActionForOtaCheck("Sync", nowMs)) {
     return;
@@ -6386,8 +6312,6 @@ void App::renderMenu() {
     renderSdCardRepairConfirm();
   } else if (menuScreen_ == MenuScreen::UpdateConfirm) {
     renderUpdateConfirm();
-  } else if (menuScreen_ == MenuScreen::PowerOffConfirm) {
-    renderPowerOffConfirm();
   } else if (menuScreen_ == MenuScreen::QuickSettings) {
     renderQuickSettings();
   } else if (menuScreen_ == MenuScreen::QuickSync) {
@@ -6525,16 +6449,6 @@ void App::renderUpdateConfirm() {
   items.push_back("Update");
 
   display_.renderMenu(items, updateConfirmSelectedIndex_ + kUpdateConfirmHeaderRows);
-}
-
-void App::renderPowerOffConfirm() {
-  std::vector<String> items;
-  items.reserve(PowerOffConfirmItemCount + kPowerOffConfirmHeaderRows);
-  items.push_back("Power off?");
-  items.push_back("Cancel");
-  items.push_back("Yes");
-
-  display_.renderMenu(items, powerOffConfirmSelectedIndex_ + kPowerOffConfirmHeaderRows);
 }
 
 void App::renderQuickSettings() {

--- a/src/app/App.h
+++ b/src/app/App.h
@@ -101,7 +101,6 @@ class App {
     RestartConfirm,
     SdCardRepairConfirm,
     UpdateConfirm,
-    PowerOffConfirm,
     QuickSettings,
     QuickSync,
     FocusTimerGenres,
@@ -330,9 +329,6 @@ class App {
   void runSdCardCheck(uint32_t nowMs);
   void openUpdateConfirm();
   void selectUpdateConfirmItem(uint32_t nowMs);
-  void openPowerOffConfirm(uint32_t nowMs);
-  void cancelPowerOffConfirm(uint32_t nowMs);
-  void selectPowerOffConfirmItem(uint32_t nowMs);
   void enterCompanionSync(uint32_t nowMs);
   void updateCompanionSync(uint32_t nowMs);
   void exitCompanionSync(uint32_t nowMs);
@@ -386,7 +382,6 @@ class App {
   void renderRestartConfirm();
   void renderSdCardRepairConfirm();
   void renderUpdateConfirm();
-  void renderPowerOffConfirm();
   void renderQuickSettings();
   void renderQuickSync();
   void renderFocusTimerGenres();
@@ -464,7 +459,6 @@ class App {
 
   AppState state_ = AppState::Booting;
   AppState standbyReturnState_ = AppState::Paused;
-  AppState powerOffConfirmReturnState_ = AppState::Paused;
   DisplayManager display_;
   FocusTimer focusTimer_;
   ReadingLoop reader_;
@@ -514,7 +508,6 @@ class App {
   size_t restartConfirmSelectedIndex_ = 0;
   size_t sdCardRepairConfirmSelectedIndex_ = 0;
   size_t updateConfirmSelectedIndex_ = 0;
-  size_t powerOffConfirmSelectedIndex_ = 0;
   size_t quickSettingsSelectedIndex_ = 0;
   size_t quickSyncSelectedIndex_ = 0;
   size_t focusTimerGenreSelectedIndex_ = 0;
@@ -529,7 +522,6 @@ class App {
   size_t typographyPreviewSampleIndex_ = 0;
   MenuScreen menuScreen_ = MenuScreen::Main;
   MenuScreen restartConfirmReturnScreen_ = MenuScreen::Main;
-  MenuScreen powerOffConfirmReturnScreen_ = MenuScreen::Main;
   QueueHandle_t otaCheckQueue_ = nullptr;
   std::vector<String> settingsMenuItems_;
   std::vector<String> focusTimerGenreMenuItems_;


### PR DESCRIPTION
As I got caught out with an unresponsive touch screen situation and could not power off the device , I wanted the original feature of a long power press would not cause a menu option to ask for confirmation.

Problem:
A long press of the power button currently opens a confirmation menu that asks the user to choose between cancel and power off. That adds an extra interaction to a hardware gesture that is already deliberate and time-based, and it slows down shutdown in the exact case where the user has explicitly held the power button to turn the device off. The expected behavior for this feature is that a long press of the power button should shut the device down immediately when software power-off is supported.

Summary of changes:
Replace all long-press power-button paths that previously opened the Power Off confirmation screen with direct calls to enterPowerOff().

Remove the dedicated PowerOffConfirm menu screen and its related menu item selection handling, render path, back-navigation behavior, and temporary return-state bookkeeping from App.cpp and App.h.

Keep the existing short-press power-button behavior unchanged, so a short press still handles standby and menu interactions the same way as before.

Design notes:
The change intentionally affects only the long-press shutdown path. Menu-based Power Off still uses the existing direct shutdown path, and non-software-power-off targets still fall back to standby as before.

Removing the confirmation screen from the menu state machine avoids leaving unreachable UI branches and keeps power-button handling simpler and more predictable.

 