### PR TITLE
Fix phantom touch from AXS15231B filler frames on Touch LCD 3.49

### DIFF
--- a/src/drivers/touch/axs15231b_touch/axs15231b_touch.cpp
+++ b/src/drivers/touch/axs15231b_touch/axs15231b_touch.cpp
@@ -55,6 +55,15 @@ bool decodePacket(const uint8_t *data, size_t len, uint16_t panelWidth, uint16_t
     return false;
   }
 
+  // Some panels stream filler frames (0x02- or 0xFF-fill) continuously while
+  // idle instead of a proper zero-point packet. A real packet always carries
+  // 0x00 in the gesture byte; anything else would otherwise decode as a
+  // phantom touch pinned to one spot, blocking all real input.
+  if (data[0] != 0x00) {
+    sample.touched = false;
+    return true;
+  }
+
   const uint8_t points = data[1];
   if (points == 0 || points > 4) {
     sample.touched = false;


### PR DESCRIPTION
## Symptom

On some ESP32-S3-Touch-LCD-3.49 units, touch appears broken or barely responsive on every firmware version: taps and swipes are ignored, and the UI behaves as if a finger is already resting on the screen. Likely the same root cause as the ghost-touch reports in #12 and the "unresponsive screen" reports around #123/#124.

## Root cause

I wrote a bare-metal diagnostic (I2C scans + raw packet dumps over USB serial) and captured what the AXS15231B on an affected unit actually returns.

**Idle, hands off the screen** — the controller streams filler frames continuously (400/400 packets over 8 seconds):

```
[touch] pkt: 02 02 02 02 02 02 02 02   -> decodes as "2 points, x=171 y=125"
[touch] pkt: FF FF FF FF FF D4 02 02
```

**While touching** — real, correctly-formatted packets that track the finger:

```
[touch] pkt: 00 02 81 C3 00 44 7B 7C   -> x=68  y=188
[touch] pkt: 00 02 81 C3 00 47 19 1A   -> x=71  y=188
[touch] pkt: 00 01 82 43 00 5D 22 23   -> x=93  y=60
```

Since the INT line isn't wired on this board the driver polls blind, and `decodePacket()` only validates `data[1]` (point count). The `0x02`-fill frames carry a "plausible" point count of 2, so they decode as a phantom touch pinned to one spot — which permanently jams gesture recognition and blocks all real input. This also explains why the behavior varies between units: not every AXS15231B batch emits filler frames when idle.

## Fix

Every real packet observed carries `0x00` in the gesture byte (`data[0]`); every filler frame does not. Reject packets with a nonzero gesture byte, treating them as "no touch" (not as a read failure, so the polling recovery path is unaffected).

Verified on affected hardware: with this change the device is fully usable — all reader gestures and menu navigation work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)