### PR TITLE
ci: stop checking multilingual corpus fixtures

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,6 @@ jobs:
         run: |
           python localization/generate_localization.py --check
           python localization/generate_locale_packs.py --check
-          python RSVPNanoCompanion/tools/generate_multilingual_corpus.py --check
           python -m unittest localization/test_locale_packs.py
           python -m unittest discover -s fonts -p "test_*.py"
 

--- a/RSVPNanoCompanion/tools/generate_multilingual_corpus.py
+++ b/RSVPNanoCompanion/tools/generate_multilingual_corpus.py
@@ -186,7 +186,6 @@ def vertical_rsvp() -> str:
 
 def write_zip(archive: zipfile.ZipFile, name: str, data: bytes, compression: int) -> None:
     info = zipfile.ZipInfo(name, (2026, 1, 1, 0, 0, 0))
-    info.create_system = 0
     info.compress_type = compression
     info.external_attr = 0o644 << 16
     archive.writestr(info, data)

--- a/localization/test_locale_packs.py
+++ b/localization/test_locale_packs.py
@@ -9,7 +9,6 @@ import tomllib
 import unittest
 import zipfile
 from dataclasses import replace
-from datetime import datetime
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
@@ -86,21 +85,12 @@ class LocalePackTest(unittest.TestCase):
 					if language.ui_font is not None
 					else None
 				)
-				generated_at = datetime(*archive.infolist()[0].date_time).timestamp()
 				self.assertTrue(
 					all(
 						info.date_time == archive.infolist()[0].date_time
 						for info in archive.infolist()
 					)
 				)
-
-			self.assertLessEqual(
-				abs(
-					(DEFAULT_OUTPUT / f"{language.code}.zip").stat().st_mtime
-					- generated_at
-				),
-				10,
-			)
 
 			self.assertEqual(manifest["id"], language.code)
 			self.assertEqual(manifest["schema_version"], 2)


### PR DESCRIPTION
## Summary

- stop treating generated multilingual fixture archives as a CI freshness invariant
- remove the temporary ZIP metadata workaround from the previous PR
- remove the locale-pack test that compared embedded ZIP timestamps with checkout file mtimes
- retain converter, archive structure, manifest, hash, font, and string-table contract coverage

## Validation

- 9 locale-pack contract tests pass
- 15 font tests pass
- git diff checks pass