### PR TITLE
fix(web): release USB before firmware install

### DIFF
--- a/RSVPNanoCompanion/apps/web/build.gradle.kts
+++ b/RSVPNanoCompanion/apps/web/build.gradle.kts
@@ -44,6 +44,7 @@ kotlin {
 
         wasmJsTest.dependencies {
             implementation(kotlin("test"))
+            implementation(libs.kotlinx.coroutines.test)
         }
     }
 }

--- a/RSVPNanoCompanion/apps/web/src/wasmJsMain/kotlin/com/rsvpnano/web/SetupWizard.kt
+++ b/RSVPNanoCompanion/apps/web/src/wasmJsMain/kotlin/com/rsvpnano/web/SetupWizard.kt
@@ -62,6 +62,7 @@ import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import com.rsvpnano.app.NanoConnectionTransport
 import com.rsvpnano.ui.CompanionPresenter
 import com.rsvpnano.ui.CompanionUiState
 import io.github.vinceglb.filekit.BrowserFile
@@ -119,6 +120,7 @@ internal fun SetupWizard(presenter: CompanionPresenter, state: CompanionUiState,
     val board = InstallerBoards.firstOrNull { it.id == boardId } ?: InstallerBoards.first()
     val serialAvailable = supportsWebSerial()
     val secure = isSecureContext()
+    val installerReady = state.connectionState.transport != NanoConnectionTransport.Usb
     val firmwarePicker = rememberFilePickerLauncher(FileKitType.File(listOf("bin"))) { file ->
         val browserFile = (file?.webFile as? WebFile.FileWrapper)?.file
         selectedFirmware = if (file != null && browserFile != null) SelectedFirmware(file.name, browserFile) else null
@@ -141,6 +143,12 @@ internal fun SetupWizard(presenter: CompanionPresenter, state: CompanionUiState,
                 if (reconnectAuthorizedUsb(presenter)) return@LaunchedEffect
                 delay(3_000)
             }
+        }
+    }
+
+    androidx.compose.runtime.LaunchedEffect(step, state.connectionState.transport) {
+        if (step == 1 && state.connectionState.transport == NanoConnectionTransport.Usb) {
+            BrowserSerial.releaseForInstaller(presenter)
         }
     }
 
@@ -179,6 +187,7 @@ internal fun SetupWizard(presenter: CompanionPresenter, state: CompanionUiState,
                             state = state,
                             secure = secure,
                             serialAvailable = serialAvailable,
+                            installerReady = installerReady,
                             stagedFirmware = stagedFirmware,
                             deployedRelease = deployedRelease,
                             releaseError = releaseError,
@@ -215,6 +224,7 @@ internal fun SetupWizard(presenter: CompanionPresenter, state: CompanionUiState,
                                 state = state,
                                 secure = secure,
                                 serialAvailable = serialAvailable,
+                                installerReady = installerReady,
                                 stagedFirmware = stagedFirmware,
                                 deployedRelease = deployedRelease,
                                 releaseError = releaseError,
@@ -288,6 +298,7 @@ private fun WizardStage(
     state: CompanionUiState,
     secure: Boolean,
     serialAvailable: Boolean,
+    installerReady: Boolean,
     stagedFirmware: String?,
     deployedRelease: DeployedRelease?,
     releaseError: String?,
@@ -327,6 +338,7 @@ private fun WizardStage(
                         board = board,
                         secure = secure,
                         serialAvailable = serialAvailable,
+                        installerReady = installerReady,
                         stagedFirmware = stagedFirmware,
                         deployedRelease = deployedRelease,
                         releaseError = releaseError,
@@ -366,6 +378,7 @@ private fun InstallPage(
     board: InstallerBoard,
     secure: Boolean,
     serialAvailable: Boolean,
+    installerReady: Boolean,
     stagedFirmware: String?,
     deployedRelease: DeployedRelease?,
     releaseError: String?,
@@ -381,6 +394,7 @@ private fun InstallPage(
         WizardIntro("FIRMWARE", "Install RSVP Nano", "Plug in ${board.name}, then choose it when your browser asks.")
         if (!secure) Text("Open this page over HTTPS before installing.", color = MaterialTheme.colorScheme.error)
         if (!serialAvailable) Text("Use Chrome or Edge on a computer to install over USB.", color = MaterialTheme.colorScheme.tertiary)
+        if (!installerReady) Text("Preparing USB for the installer...", color = MaterialTheme.colorScheme.tertiary)
         if (deployedRelease != null && stagedFirmware == null) {
             Text("The latest release does not include this Nano yet.", color = MaterialTheme.colorScheme.tertiary)
         } else if (releaseError != null) {
@@ -391,13 +405,13 @@ private fun InstallPage(
             val stacked = maxWidth < 620.dp
             if (stacked) {
                 Column(verticalArrangement = Arrangement.spacedBy(18.dp)) {
-                    LatestInstallChoice(deployedRelease, secure && serialAvailable && stagedFirmware != null, onInstallLatest)
-                    LocalInstallChoice(selectedFirmware, board, secure, serialAvailable, onChooseFile, onInstallFile)
+                    LatestInstallChoice(deployedRelease, secure && serialAvailable && installerReady && stagedFirmware != null, onInstallLatest)
+                    LocalInstallChoice(selectedFirmware, board, secure, serialAvailable && installerReady, onChooseFile, onInstallFile)
                 }
             } else {
                 Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(26.dp)) {
                     Column(Modifier.weight(1f)) {
-                        LatestInstallChoice(deployedRelease, secure && serialAvailable && stagedFirmware != null, onInstallLatest)
+                        LatestInstallChoice(deployedRelease, secure && serialAvailable && installerReady && stagedFirmware != null, onInstallLatest)
                     }
                     Column(
                         Modifier.weight(1f).border(
@@ -406,7 +420,7 @@ private fun InstallPage(
                             shape = RoundedCornerShape(18.dp),
                         ).padding(18.dp),
                     ) {
-                        LocalInstallChoice(selectedFirmware, board, secure, serialAvailable, onChooseFile, onInstallFile)
+                        LocalInstallChoice(selectedFirmware, board, secure, serialAvailable && installerReady, onChooseFile, onInstallFile)
                     }
                 }
             }

--- a/RSVPNanoCompanion/apps/web/src/wasmJsMain/kotlin/com/rsvpnano/web/WebSerialNanoApi.kt
+++ b/RSVPNanoCompanion/apps/web/src/wasmJsMain/kotlin/com/rsvpnano/web/WebSerialNanoApi.kt
@@ -74,6 +74,11 @@ internal object BrowserSerial {
             }
             .getOrDefault(false)
     }
+
+    suspend fun releaseForInstaller(presenter: CompanionPresenter) {
+        api.release()
+        presenter.cancelNanoSelection()
+    }
 }
 
 internal fun requestUsbConnection(presenter: CompanionPresenter) = BrowserSerial.connect(presenter)
@@ -84,6 +89,7 @@ internal class WebSerialNanoApi : NanoApi {
     private val json = Json { ignoreUnknownKeys = true; encodeDefaults = true; explicitNulls = false }
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
     private val requestMutex = Mutex()
+    private val sessionMutex = Mutex()
     private val writeMutex = Mutex()
     private var frames = Channel<SerialFrame>(Channel.UNLIMITED)
     private var readerJob: Job? = null
@@ -91,7 +97,7 @@ internal class WebSerialNanoApi : NanoApi {
     private var nextRequestId = 1u
     private var opened = false
 
-    suspend fun open(authorizedOnly: Boolean = false): Boolean {
+    suspend fun open(authorizedOnly: Boolean = false): Boolean = sessionMutex.withLock {
         closeSession()
         if (authorizedOnly) {
             if (!bridgeOpenAuthorized()) return false
@@ -122,15 +128,19 @@ internal class WebSerialNanoApi : NanoApi {
                     runCatching { sendFrame(SerialFrame(SerialFrameType.Ping)) }
                 }
             }
-            return true
+            true
         } catch (error: Throwable) {
             bridgeCloseIgnoringErrors()
             throw error
         }
     }
 
+    suspend fun release() = sessionMutex.withLock {
+        closeSession()
+    }
+
     override fun close() {
-        scope.launch { closeSession() }
+        scope.launch { release() }
     }
 
     override suspend fun fetchDevice(baseUrl: String): NanoInfo = get("/api/v2/device", NanoInfo.serializer())

--- a/RSVPNanoCompanion/apps/web/src/wasmJsTest/kotlin/com/rsvpnano/web/WebSerialNanoApiTest.kt
+++ b/RSVPNanoCompanion/apps/web/src/wasmJsTest/kotlin/com/rsvpnano/web/WebSerialNanoApiTest.kt
@@ -1,0 +1,63 @@
+@file:OptIn(ExperimentalWasmJsInterop::class, kotlin.io.encoding.ExperimentalEncodingApi::class)
+
+package com.rsvpnano.web
+
+import kotlin.io.encoding.Base64
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
+import kotlin.coroutines.resume
+
+class WebSerialNanoApiTest {
+    @Test
+    fun companionConnectionReleasesPortForInstaller() = runTest {
+        withContext(Dispatchers.Default.limitedParallelism(1)) {
+            val deviceBody = """{"ssid":"RSVP-Nano","firmwareVersion":"0.0.9","otaAsset":"nano-ota.bin"}""".encodeToByteArray()
+            val responseMetadata = """{"status":200,"contentType":"application/json","totalBytes":${deviceBody.size}}"""
+            val response =
+                SerialFrameCodec.encode(SerialFrame(SerialFrameType.Response, 1u, payload = responseMetadata.encodeToByteArray())) +
+                    SerialFrameCodec.encode(SerialFrame(SerialFrameType.Data, 1u, payload = deviceBody)) +
+                    SerialFrameCodec.encode(SerialFrame(SerialFrameType.End, 1u))
+            val reads = listOf("RSVPNANO/COMPANION/1 READY\n".encodeToByteArray(), response)
+                .joinToString("|") { Base64.encode(it) }
+            installFakeSerial(reads)
+            val api = WebSerialNanoApi()
+
+            assertTrue(api.open())
+            assertFalse(installerCanOpenFakeSerial())
+
+            val device = api.fetchDevice("usb://active")
+            assertEquals("RSVP-Nano", device.ssid)
+            assertEquals("0.0.9", device.firmwareVersion)
+
+            api.release()
+
+            assertTrue(installerCanOpenFakeSerial())
+            assertEquals(2, fakeSerialOpenCount())
+            assertEquals(2, fakeSerialCloseCount())
+        }
+    }
+}
+
+@JsFun("""(encodedReads) => { const decode = encoded => { const text = atob(encoded); const bytes = new Uint8Array(text.length); for (let i = 0; i < text.length; i++) bytes[i] = text.charCodeAt(i); return bytes; }; const reads = encodedReads.split('|').map(decode); const state = { opened: false, opens: 0, closes: 0, reads }; const port = { getInfo: () => ({ usbVendorId: 0x303a, usbProductId: 0x1001 }), open: async () => { if (state.opened) throw new Error('Port is already open'); state.opened = true; state.opens++; }, close: async () => { state.opened = false; state.closes++; }, readable: { getReader: () => ({ read: async () => ({ value: state.reads.shift() || new Uint8Array(), done: false }), cancel: async () => {}, releaseLock: () => {} }) }, writable: { getWriter: () => ({ write: async () => {}, close: async () => {}, releaseLock: () => {} }) } }; state.port = port; globalThis.rsvpNanoFakeSerial = state; Object.defineProperty(navigator, 'serial', { configurable: true, value: { getPorts: async () => [port], requestPort: async () => port } }); localStorage.removeItem('rsvpnano.web.usbDevice'); }""")
+private external fun installFakeSerial(encodedReads: String)
+
+private suspend fun installerCanOpenFakeSerial(): Boolean = suspendCancellableCoroutine { continuation ->
+    tryOpenFakeSerial { opened ->
+        if (continuation.isActive) continuation.resume(opened)
+    }
+}
+
+@JsFun("""(done) => { (async () => { const state = globalThis.rsvpNanoFakeSerial; try { await state.port.open({ baudRate: 115200 }); await state.port.close(); done(true); } catch (_) { done(false); } })(); }""")
+private external fun tryOpenFakeSerial(done: (Boolean) -> Unit)
+
+@JsFun("""() => globalThis.rsvpNanoFakeSerial.opens""")
+private external fun fakeSerialOpenCount(): Int
+
+@JsFun("""() => globalThis.rsvpNanoFakeSerial.closes""")
+private external fun fakeSerialCloseCount(): Int

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -34,6 +34,7 @@ compose-runtime = { module = "org.jetbrains.compose.runtime:runtime", version.re
 navigationevent-compose = { module = "org.jetbrains.androidx.navigationevent:navigationevent-compose", version.ref = "navigationevent" }
 filekit-dialogs-compose = { module = "io.github.vinceglb:filekit-dialogs-compose", version.ref = "filekit" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }
+kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }
 kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "datetime" }
 kotlinx-serialization-core = { module = "org.jetbrains.kotlinx:kotlinx-serialization-core", version.ref = "serialization" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "serialization" }


### PR DESCRIPTION
## Summary
- release an active companion USB session before the setup wizard starts ESP Web Tools
- keep install actions disabled until the serial port handoff completes
- serialize Web Serial open and close operations
- cover the companion handshake, device-info request, and installer port takeover in a browser test

## Validation
- `:webApp:wasmJsBrowserTest`
- `:checkWeb`
- `uvx platformio test -e native_test -f test_companion_serial`