### PR TITLE
Fix automatic web flashing and sequence firmware publishing

### DIFF
--- a/.github/workflows/ci-android.yml
+++ b/.github/workflows/ci-android.yml
@@ -9,21 +9,25 @@ on:
       - 'build.gradle.kts'
       - 'settings.gradle.kts'
       - 'gradlew'
+      - 'gradle.properties'
+      - 'gradle/libs.versions.toml'
       - 'gradle/wrapper/**'
       - 'RSVPNanoCompanion/conversionCore/**'
       - 'RSVPNanoCompanion/shared/**'
       - 'RSVPNanoCompanion/apps/android/**'
-      - '.github/workflows/**'
+      - '.github/workflows/ci-android.yml'
   pull_request:
     paths:
       - 'build.gradle.kts'
       - 'settings.gradle.kts'
       - 'gradlew'
+      - 'gradle.properties'
+      - 'gradle/libs.versions.toml'
       - 'gradle/wrapper/**'
       - 'RSVPNanoCompanion/conversionCore/**'
       - 'RSVPNanoCompanion/shared/**'
       - 'RSVPNanoCompanion/apps/android/**'
-      - '.github/workflows/**'
+      - '.github/workflows/ci-android.yml'
 
 jobs:
   build:
@@ -35,15 +39,8 @@ jobs:
         with:
           distribution: temurin
           java-version: '17'
-      - name: Cache Gradle
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v6
       - name: Run Android checks
         run: bash ./gradlew checkAndroid --no-daemon
       - name: Upload test results

--- a/.github/workflows/ci-android.yml
+++ b/.github/workflows/ci-android.yml
@@ -5,6 +5,7 @@ env:
 
 on:
   push:
+    branches: [main]
     paths:
       - 'build.gradle.kts'
       - 'settings.gradle.kts'

--- a/.github/workflows/ci-android.yml
+++ b/.github/workflows/ci-android.yml
@@ -34,7 +34,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Set up JDK
         uses: actions/setup-java@v5
         with:
@@ -46,7 +46,7 @@ jobs:
         run: bash ./gradlew checkAndroid --no-daemon
       - name: Upload test results
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: test-results
           path: |
@@ -54,7 +54,7 @@ jobs:
             **/build/test-results/
       - name: Upload shared artifacts
         if: success()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: android-release-apk
           path: RSVPNanoCompanion/apps/android/build/outputs/apk/release/*.apk

--- a/.github/workflows/ci-android.yml
+++ b/.github/workflows/ci-android.yml
@@ -30,6 +30,10 @@ on:
       - 'RSVPNanoCompanion/apps/android/**'
       - '.github/workflows/ci-android.yml'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-ios.yml
+++ b/.github/workflows/ci-ios.yml
@@ -34,7 +34,7 @@ jobs:
   build-ios:
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Set up JDK
         uses: actions/setup-java@v5
         with:
@@ -46,7 +46,7 @@ jobs:
         run: bash ./gradlew checkIos --no-daemon
       - name: Upload Gradle reports
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ios-gradle-reports
           path: |
@@ -56,7 +56,7 @@ jobs:
         run: bash RSVPNanoCompanion/tools/build_shared_xcframework.sh
       - name: Upload shared artifacts
         if: success()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: shared-xcframework
           path: RSVPNanoCompanion/apps/ios/RSVPNanoCompanion/SharedFrameworks/shared.xcframework

--- a/.github/workflows/ci-ios.yml
+++ b/.github/workflows/ci-ios.yml
@@ -5,6 +5,7 @@ env:
 
 on:
   push:
+    branches: [main]
     paths:
       - 'build.gradle.kts'
       - 'settings.gradle.kts'

--- a/.github/workflows/ci-ios.yml
+++ b/.github/workflows/ci-ios.yml
@@ -9,21 +9,25 @@ on:
       - 'build.gradle.kts'
       - 'settings.gradle.kts'
       - 'gradlew'
+      - 'gradle.properties'
+      - 'gradle/libs.versions.toml'
       - 'gradle/wrapper/**'
       - 'RSVPNanoCompanion/conversionCore/**'
       - 'RSVPNanoCompanion/shared/**'
       - 'RSVPNanoCompanion/apps/ios/**'
-      - '.github/workflows/**'
+      - '.github/workflows/ci-ios.yml'
   pull_request:
     paths:
       - 'build.gradle.kts'
       - 'settings.gradle.kts'
       - 'gradlew'
+      - 'gradle.properties'
+      - 'gradle/libs.versions.toml'
       - 'gradle/wrapper/**'
       - 'RSVPNanoCompanion/conversionCore/**'
       - 'RSVPNanoCompanion/shared/**'
       - 'RSVPNanoCompanion/apps/ios/**'
-      - '.github/workflows/**'
+      - '.github/workflows/ci-ios.yml'
 
 jobs:
   build-ios:
@@ -35,6 +39,8 @@ jobs:
         with:
           distribution: temurin
           java-version: '17'
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v6
       - name: Run iOS checks
         run: bash ./gradlew checkIos --no-daemon
       - name: Upload Gradle reports

--- a/.github/workflows/ci-ios.yml
+++ b/.github/workflows/ci-ios.yml
@@ -30,6 +30,10 @@ on:
       - 'RSVPNanoCompanion/apps/ios/**'
       - '.github/workflows/ci-ios.yml'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-ios:
     runs-on: macos-latest

--- a/.github/workflows/firmware-build.yml
+++ b/.github/workflows/firmware-build.yml
@@ -1,0 +1,84 @@
+name: Build firmware assets
+
+on:
+  workflow_call:
+    inputs:
+      firmware_tag:
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      environments: ${{ steps.environments.outputs.value }}
+    steps:
+      - uses: actions/checkout@v6
+      - id: environments
+        run: echo "value=$(python3 tools/export_web_firmware.py --list-envs)" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: matrix
+    strategy:
+      fail-fast: false
+      matrix:
+        environment: ${{ fromJSON(needs.matrix.outputs.environments) }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Cache PlatformIO
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cache/pip
+            ~/.platformio/.cache
+            ~/.platformio/packages
+            ~/.platformio/platforms
+          key: ${{ runner.os }}-pio-${{ hashFiles('platformio.ini', 'boards/**', 'tools/pio_*.py') }}
+          restore-keys: ${{ runner.os }}-pio-
+
+      - name: Install PlatformIO
+        run: pip install platformio
+
+      - name: Export firmware environment
+        env:
+          RSVP_FIRMWARE_TAG: ${{ inputs.firmware_tag }}
+        run: python3 tools/export_web_firmware.py --env "${{ matrix.environment }}"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: firmware-${{ matrix.environment }}
+          path: web/firmware
+          if-no-files-found: error
+
+  assemble:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: firmware-*
+          path: web/firmware
+          merge-multiple: true
+
+      - name: Assemble firmware release
+        run: python3 tools/export_web_firmware.py --assemble
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: firmware-assets
+          path: web/firmware
+          if-no-files-found: error

--- a/.github/workflows/firmware-build.yml
+++ b/.github/workflows/firmware-build.yml
@@ -16,7 +16,7 @@ jobs:
     outputs:
       environments: ${{ steps.environments.outputs.value }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - id: environments
         run: echo "value=$(python3 tools/export_web_firmware.py --list-envs)" >> "$GITHUB_OUTPUT"
 
@@ -29,16 +29,16 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           submodules: recursive
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.12"
 
       - name: Cache PlatformIO
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: |
             ~/.cache/pip
@@ -56,7 +56,7 @@ jobs:
           RSVP_FIRMWARE_TAG: ${{ inputs.firmware_tag }}
         run: python3 tools/export_web_firmware.py --env "${{ matrix.environment }}"
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: firmware-${{ matrix.environment }}
           path: web/firmware
@@ -66,9 +66,9 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           pattern: firmware-*
           path: web/firmware
@@ -77,7 +77,7 @@ jobs:
       - name: Assemble firmware release
         run: python3 tools/export_web_firmware.py --assemble
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: firmware-assets
           path: web/firmware

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,9 +1,6 @@
 name: Pages
 
 on:
-  push:
-    branches:
-      - main
   workflow_run:
     workflows: [Release firmware]
     types: [completed]
@@ -23,6 +20,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -34,6 +33,9 @@ jobs:
         with:
           distribution: temurin
           java-version: "17"
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v6
 
       - name: Download latest release firmware
         if: github.repository == 'ionutdecebal/rsvpnano'

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -19,12 +19,12 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: "3.12"
 
@@ -48,11 +48,11 @@ jobs:
 
       - name: Configure GitHub Pages
         if: github.repository == 'ionutdecebal/rsvpnano'
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
 
       - name: Upload GitHub Pages artifact
         if: github.repository == 'ionutdecebal/rsvpnano'
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: build/webSite
 
@@ -73,4 +73,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -26,7 +26,7 @@ jobs:
       commit_sha: ${{ steps.preview.outputs.commit_sha }}
       title: ${{ steps.preview.outputs.title }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -71,7 +71,7 @@ jobs:
     needs: [prepare, build]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: firmware-assets
           path: web/firmware

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       channel:
-        description: "Preview tag/release name, for example preview-sd-fix"
+        description: "Preview tag, for example preview-sd-fix"
         required: true
         default: "preview-manual"
       label:
@@ -19,16 +19,16 @@ permissions:
   contents: write
 
 jobs:
-  firmware:
+  prepare:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
-
+    outputs:
+      channel: ${{ steps.preview.outputs.channel }}
+      commit_sha: ${{ steps.preview.outputs.commit_sha }}
+      title: ${{ steps.preview.outputs.title }}
     steps:
-      - name: Check out repository
-        uses: actions/checkout@v6
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          submodules: recursive
 
       - name: Set preview metadata
         id: preview
@@ -41,23 +41,14 @@ jobs:
           else
             CHANNEL="$GITHUB_REF_NAME"
           fi
-
-          BUILD_SHA="$(git rev-parse HEAD)"
-
           if ! echo "$CHANNEL" | grep -Eq '^preview-[A-Za-z0-9._-]+$'; then
             echo "::error::Preview channel must look like preview-name, got: ${CHANNEL}"
             exit 1
           fi
 
           echo "channel=${CHANNEL}" >> "$GITHUB_OUTPUT"
-          echo "commit_sha=${BUILD_SHA}" >> "$GITHUB_OUTPUT"
-          echo "RSVP_FIRMWARE_TAG=${CHANNEL}" >> "$GITHUB_ENV"
-
-          if [ -n "$LABEL" ]; then
-            echo "title=${LABEL}" >> "$GITHUB_OUTPUT"
-          else
-            echo "title=Preview ${CHANNEL}" >> "$GITHUB_OUTPUT"
-          fi
+          echo "commit_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+          echo "title=${LABEL:-Preview ${CHANNEL}}" >> "$GITHUB_OUTPUT"
 
       - name: Move preview tag to this commit
         if: github.event_name == 'workflow_dispatch'
@@ -67,23 +58,31 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-
           git tag -f "$RELEASE_TAG" "$BUILD_SHA"
           git push origin "refs/tags/${RELEASE_TAG}" --force
 
-      - name: Install PlatformIO
-        run: pip install platformio
+  build:
+    needs: prepare
+    uses: ./.github/workflows/firmware-build.yml
+    with:
+      firmware_tag: ${{ needs.prepare.outputs.channel }}
 
-      - name: Export firmware assets
-        run: python3 tools/export_web_firmware.py
+  publish:
+    needs: [prepare, build]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: firmware-assets
+          path: web/firmware
 
-      - name: Write preview release notes
+      - name: Write preview notes
         run: |
           cat > release-notes.md <<'NOTES'
           Preview firmware build.
 
-          Tag/channel: `${{ steps.preview.outputs.channel }}`
-          Commit: `${{ steps.preview.outputs.commit_sha }}`
+          Tag/channel: `${{ needs.prepare.outputs.channel }}`
+          Commit: `${{ needs.prepare.outputs.commit_sha }}`
 
           Preview releases are replaceable. Use a versioned release for stable firmware.
           NOTES
@@ -91,19 +90,14 @@ jobs:
       - name: Publish or update preview release
         env:
           GH_TOKEN: ${{ github.token }}
-          RELEASE_TAG: ${{ steps.preview.outputs.channel }}
-          RELEASE_TITLE: ${{ steps.preview.outputs.title }}
-          BUILD_SHA: ${{ steps.preview.outputs.commit_sha }}
+          RELEASE_TAG: ${{ needs.prepare.outputs.channel }}
+          RELEASE_TITLE: ${{ needs.prepare.outputs.title }}
+          BUILD_SHA: ${{ needs.prepare.outputs.commit_sha }}
         run: |
           if ! gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
-            gh release create "$RELEASE_TAG" \
-              --title "$RELEASE_TITLE" \
-              --notes-file release-notes.md \
-              --prerelease
+            gh release create "$RELEASE_TAG" --title "$RELEASE_TITLE" --notes-file release-notes.md --prerelease
           fi
-
           gh release upload "$RELEASE_TAG" web/firmware/*.bin --clobber
-
           gh release edit "$RELEASE_TAG" \
             --title "$RELEASE_TITLE" \
             --notes-file release-notes.md \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,96 +7,76 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "New release tag, for example v0.0.5"
+        description: "Release tag, for example v0.0.9"
         required: true
 
 permissions:
   contents: write
 
 jobs:
-  firmware:
+  prepare:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    outputs:
+      tag: ${{ steps.release.outputs.tag }}
+      commit_sha: ${{ steps.release.outputs.commit_sha }}
     steps:
-      - name: Check out repository
-        uses: actions/checkout@v6
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          submodules: recursive
 
       - name: Set release metadata
         id: release
+        env:
+          DISPATCH_VERSION: ${{ inputs.version }}
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            RELEASE_TAG="${{ inputs.version }}"
+            RELEASE_TAG="$DISPATCH_VERSION"
           else
-            RELEASE_TAG="${GITHUB_REF_NAME}"
+            RELEASE_TAG="$GITHUB_REF_NAME"
           fi
           if ! echo "$RELEASE_TAG" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9._-]+)?$'; then
             echo "::error::Invalid release version: ${RELEASE_TAG}"
-            echo "::error::Use something like v0.0.5 or v0.0.5-beta.1"
             exit 1
           fi
-
-          BUILD_SHA="$(git rev-parse HEAD)"
 
           echo "tag=${RELEASE_TAG}" >> "$GITHUB_OUTPUT"
-          echo "commit_sha=${BUILD_SHA}" >> "$GITHUB_OUTPUT"
-          echo "RSVP_FIRMWARE_TAG=${RELEASE_TAG}" >> "$GITHUB_ENV"
+          echo "commit_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
-      - name: Ensure GitHub release does not already exist
-        env:
-          GH_TOKEN: ${{ github.token }}
-          RELEASE_TAG: ${{ steps.release.outputs.tag }}
-        run: |
-          if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
-            echo "::error::Release ${RELEASE_TAG} already exists. Real releases are immutable."
-            echo "::error::Use a fresh version tag, or use the Preview firmware workflow for replaceable builds."
-            exit 1
-          fi
-
-      - name: Prepare immutable release tag
+      - name: Verify pushed release tag
+        if: github.event_name != 'workflow_dispatch'
         env:
           RELEASE_TAG: ${{ steps.release.outputs.tag }}
           BUILD_SHA: ${{ steps.release.outputs.commit_sha }}
         run: |
           git fetch --tags origin
-
-          if git rev-parse -q --verify "refs/tags/${RELEASE_TAG}" >/dev/null; then
-            TAG_SHA="$(git rev-list -n 1 "${RELEASE_TAG}")"
-
-            if [ "$TAG_SHA" != "$BUILD_SHA" ]; then
-              echo "::error::${RELEASE_TAG} already points at ${TAG_SHA}, but this workflow checked out ${BUILD_SHA}."
-              echo "::error::Real releases are immutable. Use a fresh version tag, or use Preview firmware for mutable builds."
-              exit 1
-            fi
-
-            echo "[release] Existing tag ${RELEASE_TAG} already points at this commit."
-            exit 0
-          fi
-
-          if [ "${{ github.event_name }}" != "workflow_dispatch" ]; then
-            echo "::error::Tag ${RELEASE_TAG} does not exist during a tag-push release."
+          TAG_SHA="$(git rev-list -n 1 "${RELEASE_TAG}")"
+          if [ "$TAG_SHA" != "$BUILD_SHA" ]; then
+            echo "::error::${RELEASE_TAG} points at ${TAG_SHA}, not ${BUILD_SHA}."
             exit 1
           fi
 
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+  build:
+    needs: prepare
+    uses: ./.github/workflows/firmware-build.yml
+    with:
+      firmware_tag: ${{ needs.prepare.outputs.tag }}
 
-          git tag "$RELEASE_TAG" "$BUILD_SHA"
-          git push origin "refs/tags/${RELEASE_TAG}"
+  publish:
+    needs: [prepare, build]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.prepare.outputs.commit_sha }}
 
-          echo "[release] Created immutable tag ${RELEASE_TAG} at ${BUILD_SHA}."
+      - uses: actions/download-artifact@v4
+        with:
+          name: firmware-assets
+          path: web/firmware
 
-      - name: Install PlatformIO
-        run: pip install platformio
-
-      - name: Export firmware assets
-        run: python3 tools/export_web_firmware.py
-
-      - name: Write release notes
+      - name: Load release notes
         env:
-          RELEASE_TAG: ${{ steps.release.outputs.tag }}
+          RELEASE_TAG: ${{ needs.prepare.outputs.tag }}
         run: |
           NOTES_PATH="docs/releases/${RELEASE_TAG}.md"
           if [ ! -f "$NOTES_PATH" ]; then
@@ -108,9 +88,19 @@ jobs:
       - name: Publish GitHub release
         env:
           GH_TOKEN: ${{ github.token }}
-          RELEASE_TAG: ${{ steps.release.outputs.tag }}
-          BUILD_SHA: ${{ steps.release.outputs.commit_sha }}
+          RELEASE_TAG: ${{ needs.prepare.outputs.tag }}
+          BUILD_SHA: ${{ needs.prepare.outputs.commit_sha }}
         run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            git fetch --tags origin
+            git tag -f "$RELEASE_TAG" "$BUILD_SHA"
+            git push origin "refs/tags/${RELEASE_TAG}" --force
+          fi
+
+          if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
+            gh release delete "$RELEASE_TAG" --yes
+          fi
+
           gh release create "$RELEASE_TAG" web/firmware/*.bin \
             --title "$RELEASE_TAG" \
             --notes-file release-notes.md \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       tag: ${{ steps.release.outputs.tag }}
       commit_sha: ${{ steps.release.outputs.commit_sha }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -65,11 +65,11 @@ jobs:
     needs: [prepare, build]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           ref: ${{ needs.prepare.outputs.commit_sha }}
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: firmware-assets
           path: web/firmware

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,16 +10,16 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           submodules: recursive
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.12"
 
       - name: Cache PlatformIO
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: |
             ~/.cache/pip

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,10 @@ on:
     branches: [main]
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   firmware:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,21 @@ jobs:
         with:
           submodules: recursive
 
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Cache PlatformIO
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cache/pip
+            ~/.platformio/.cache
+            ~/.platformio/packages
+            ~/.platformio/platforms
+          key: ${{ runner.os }}-pio-tests-${{ hashFiles('platformio.ini', 'boards/**', 'tools/pio_*.py') }}
+          restore-keys: ${{ runner.os }}-pio-
+
       - name: Install PlatformIO
         run: pip install platformio freetype-py fonttools uharfbuzz lz4
 

--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ RSVPNanoCompanion/testdata/conversion/from-nano/
 *.rdat
 web/firmware/*.bin
 web/firmware/release.json
+web/firmware/versions/
 logs/
 .cache/
 .tmp/

--- a/docs/releases/v0.0.9.md
+++ b/docs/releases/v0.0.9.md
@@ -3,6 +3,12 @@
 v0.0.9 adds the new Kotlin/Wasm web companion, multilingual reading, page reading, installable
 locale and font catalogs, a redesigned device interface, and broader hardware support.
 
+The refreshed v0.0.9 build also fixes browser flashing for Nano variants that expose USB mass
+storage. ESP Web Tools can place an updated Nano into its bootloader automatically, and the web
+companion releases an active USB connection before opening the installer. The first upgrade from
+an older v0.0.9 build may still need one manual BOOT and RESET sequence because the automatic reset
+handler is part of the refreshed firmware.
+
 ## Highlights
 
 - A new responsive web companion now handles setup, flashing, conversion, library management,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,11 +4,13 @@
 #include "board/Board.h"
 #include "logging/Logger.h"
 #include "settings/NvsSecurity.h"
+#include "usb/WebFlasherReset.h"
 
 App app;
 
 void setup() {
     Serial.begin(115200);
+    usb::enableWebFlasherReset();
     Logger::begin();
     delay(50);
     Board::System::begin();

--- a/src/usb/WebFlasherReset.cpp
+++ b/src/usb/WebFlasherReset.cpp
@@ -1,0 +1,27 @@
+#include "usb/WebFlasherReset.h"
+
+#include <Arduino.h>
+#include <sdkconfig.h>
+
+#if SOC_USB_OTG_SUPPORTED && CONFIG_TINYUSB_CDC_ENABLED && !ARDUINO_USB_MODE && ARDUINO_USB_CDC_ON_BOOT
+#include <USBCDC.h>
+#include <esp32-hal-tinyusb.h>
+
+namespace {
+
+    usb::WebFlasherResetSequence resetSequence;
+
+    void onLineState(void*, esp_event_base_t, int32_t, void* eventData) {
+        const auto& lineState = static_cast<arduino_usb_cdc_event_data_t*>(eventData)->line_state;
+        if (resetSequence.update(lineState.dtr, lineState.rts))
+            usb_persist_restart(RESTART_BOOTLOADER);
+    }
+
+} // namespace
+#endif
+
+void usb::enableWebFlasherReset() {
+#if SOC_USB_OTG_SUPPORTED && CONFIG_TINYUSB_CDC_ENABLED && !ARDUINO_USB_MODE && ARDUINO_USB_CDC_ON_BOOT
+    Serial.onEvent(ARDUINO_USB_CDC_LINE_STATE_EVENT, onLineState);
+#endif
+}

--- a/src/usb/WebFlasherReset.h
+++ b/src/usb/WebFlasherReset.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <array>
+#include <cstdint>
+
+namespace usb {
+
+    class WebFlasherResetSequence {
+    public:
+        bool update(bool dtr, bool rts) {
+            const uint8_t signals = static_cast<uint8_t>((dtr ? 2 : 0) | (rts ? 1 : 0));
+            if (signals == kSequence[step_]) {
+                if (++step_ == kSequence.size()) {
+                    step_ = 0;
+                    return true;
+                }
+            } else {
+                step_ = signals == kSequence.front() ? 1 : 0;
+            }
+            return false;
+        }
+
+    private:
+        static constexpr std::array<uint8_t, 4> kSequence{2, 3, 1, 0};
+        uint8_t step_ = 0;
+    };
+
+    void enableWebFlasherReset();
+
+} // namespace usb

--- a/test/test_companion_serial/test_main.cpp
+++ b/test/test_companion_serial/test_main.cpp
@@ -4,6 +4,7 @@
 #include <vector>
 
 #include "companion/serial/CompanionSerialProtocol.h"
+#include "usb/WebFlasherReset.h"
 
 namespace serial = companion::serial;
 
@@ -49,9 +50,24 @@ void test_corrupt_crc_is_skipped_before_next_frame() {
                             static_cast<uint8_t>(frames[0].type));
 }
 
+void test_web_flasher_reset_sequence_matches_esptool_js_only() {
+    usb::WebFlasherResetSequence sequence;
+
+    TEST_ASSERT_FALSE(sequence.update(false, true));
+    TEST_ASSERT_FALSE(sequence.update(true, true));
+    TEST_ASSERT_FALSE(sequence.update(true, false));
+    TEST_ASSERT_FALSE(sequence.update(false, false));
+
+    TEST_ASSERT_FALSE(sequence.update(true, false));
+    TEST_ASSERT_FALSE(sequence.update(true, true));
+    TEST_ASSERT_FALSE(sequence.update(false, true));
+    TEST_ASSERT_TRUE(sequence.update(false, false));
+}
+
 int main(int, char**) {
     UNITY_BEGIN();
     RUN_TEST(test_fragmented_and_coalesced_frames_resynchronize);
     RUN_TEST(test_corrupt_crc_is_skipped_before_next_frame);
+    RUN_TEST(test_web_flasher_reset_sequence_matches_esptool_js_only);
     return UNITY_END();
 }

--- a/tools/export_web_firmware.py
+++ b/tools/export_web_firmware.py
@@ -12,6 +12,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 WEB_FIRMWARE_DIR = ROOT / "web" / "firmware"
 RELEASE_METADATA_PATH = WEB_FIRMWARE_DIR / "release.json"
+VERSION_DIR = WEB_FIRMWARE_DIR / "versions"
 BOOT_APP0_GLOB = "framework-arduinoespressif32*/tools/partitions/boot_app0.bin"
 VERSION_DECLARATION = "inline constexpr char kFirmwareVersion[] = "
 
@@ -96,6 +97,10 @@ OTA_EXPORTS = (
         "binary": "rsvp-nano-esp32-s3-touch-amoled-2.41-ota.bin",
         "label": "RSVP Nano Touch AMOLED 2.41 OTA firmware",
     },
+)
+
+REQUIRED_ENVS = tuple(
+    sorted({export["env"] for export in FLASH_EXPORTS} | {export["env"] for export in OTA_EXPORTS})
 )
 
 
@@ -209,6 +214,34 @@ def write_release_metadata(version: str, firmware: dict[str, str]) -> None:
     RELEASE_METADATA_PATH.write_text(json.dumps(metadata, indent=2) + "\n", encoding="utf-8")
 
 
+def write_version_marker(env: str, version: str) -> None:
+    VERSION_DIR.mkdir(parents=True, exist_ok=True)
+    (VERSION_DIR / f"{env}.txt").write_text(version + "\n", encoding="utf-8")
+
+
+def assemble_release() -> None:
+    missing_markers = [env for env in REQUIRED_ENVS if not (VERSION_DIR / f"{env}.txt").exists()]
+    if missing_markers:
+        raise SystemExit(f"Missing firmware version markers: {', '.join(missing_markers)}")
+
+    versions = {
+        (VERSION_DIR / f"{env}.txt").read_text(encoding="utf-8").strip()
+        for env in REQUIRED_ENVS
+    }
+    if len(versions) != 1 or not next(iter(versions)):
+        raise SystemExit(f"Firmware jobs produced different versions: {', '.join(sorted(versions))}")
+
+    for export in (*FLASH_EXPORTS, *OTA_EXPORTS):
+        path = WEB_FIRMWARE_DIR / export["binary"]
+        if not path.exists():
+            raise SystemExit(f"Missing exported firmware: {path}")
+
+    version = versions.pop()
+    write_release_metadata(version, {export["id"]: export["binary"] for export in FLASH_EXPORTS})
+    shutil.rmtree(VERSION_DIR)
+    print(f"Firmware release assembled in {WEB_FIRMWARE_DIR}")
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description="Build merged binaries for the web flasher.")
     parser.add_argument(
@@ -216,12 +249,20 @@ def main() -> int:
         action="store_true",
         help="Use existing .pio build outputs instead of running PlatformIO first.",
     )
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument("--env", choices=REQUIRED_ENVS, help="Build and export one PlatformIO environment.")
+    mode.add_argument("--list-envs", action="store_true", help="Print the build environment matrix as JSON.")
+    mode.add_argument("--assemble", action="store_true", help="Assemble artifacts exported by --env jobs.")
     args = parser.parse_args()
 
-    required_envs = sorted(
-        {export["env"] for export in FLASH_EXPORTS}
-        | {export["env"] for export in OTA_EXPORTS}
-    )
+    if args.list_envs:
+        print(json.dumps(REQUIRED_ENVS))
+        return 0
+    if args.assemble:
+        assemble_release()
+        return 0
+
+    required_envs = [args.env] if args.env else list(REQUIRED_ENVS)
 
     if not args.skip_build:
         pio = pio_command()
@@ -234,16 +275,24 @@ def main() -> int:
     WEB_FIRMWARE_DIR.mkdir(parents=True, exist_ok=True)
 
     for export in FLASH_EXPORTS:
+        if export["env"] not in required_envs:
+            continue
         output = WEB_FIRMWARE_DIR / export["binary"]
         print(f"Exporting {export['label']} -> {output}")
         merge_firmware(export["env"], output)
 
-    write_release_metadata(version, {export["id"]: export["binary"] for export in FLASH_EXPORTS})
-
     for export in OTA_EXPORTS:
+        if export["env"] not in required_envs:
+            continue
         ota_output = WEB_FIRMWARE_DIR / export["binary"]
         print(f"Exporting {export['label']} -> {ota_output}")
         export_ota_binary(export["env"], ota_output)
+
+    if args.env:
+        write_version_marker(args.env, version)
+    else:
+        write_release_metadata(version, {export["id"]: export["binary"] for export in FLASH_EXPORTS})
+        shutil.rmtree(VERSION_DIR, ignore_errors=True)
 
     print(f"Web firmware exported to {WEB_FIRMWARE_DIR}")
     return 0


### PR DESCRIPTION
## Summary

- recognize the ESP Web Tools DTR/RTS reset sequence on TinyUSB CDC boards and enter the ROM bootloader
- build the seven firmware environments in parallel and assemble one validated release artifact
- deploy Pages only after the matching Release firmware workflow succeeds
- replace v0.0.9 only after all firmware builds complete
- use official Gradle caching and narrower app workflow triggers

## Validation

- 194 native test cases pass
- LCD 3.49 rev1 firmware build passes
- AMOLED 2.41 firmware build passes
- actionlint passes
- exporter Python compilation, environment listing, and single-environment export pass