### PR TITLE
fix(web): restore the browser context menu

### DIFF
--- a/companion/apps/web/src/wasmJsMain/resources/index.html
+++ b/companion/apps/web/src/wasmJsMain/resources/index.html
@@ -120,8 +120,11 @@
 
       function waitForComposeCanvas() {
         const hosts = document.querySelectorAll("#webApp *");
-        const ready = Array.from(hosts).some(host => host.shadowRoot?.querySelector("canvas"));
-        if (ready) requestAnimationFrame(hideStartupSurface);
+        const canvasHost = Array.from(hosts).find(host => host.shadowRoot?.querySelector("canvas"));
+        if (canvasHost) {
+          canvasHost.shadowRoot.addEventListener("contextmenu", event => event.stopPropagation(), { capture: true });
+          requestAnimationFrame(hideStartupSurface);
+        }
         else if (document.getElementById("startup-surface")) requestAnimationFrame(waitForComposeCanvas);
       }
     </script>


### PR DESCRIPTION
## Summary

- allow the browser's native context menu on the Compose canvas
- keep Compose pointer handling unchanged for all other events

## Validation

- `checkWeb`
- generated-site browser check confirmed `contextmenu defaultPrevented=false`