### PR TITLE
fix: prevent stale library and workflow state

### DIFF
--- a/.github/workflows/cleanup-runs.yml
+++ b/.github/workflows/cleanup-runs.yml
@@ -36,8 +36,8 @@ jobs:
               continue
             fi
 
-            echo "Cancelling run ${run_id} from ${head_sha}."
-            gh api --method POST "repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}/cancel" >/dev/null 2>&1 || true
+            echo "Force-cancelling run ${run_id} from ${head_sha}."
+            gh api --method POST "repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}/force-cancel" >/dev/null 2>&1 || true
           done < <(list_runs)
 
           for attempt in {1..12}; do

--- a/src/ui/screens/LibraryScreen.cpp
+++ b/src/ui/screens/LibraryScreen.cpp
@@ -159,7 +159,7 @@ namespace screens {
                 const int16_t height = spineHeight(items[index], index);
                 const int16_t x = static_cast<int16_t>(viewport.x + left + offset_);
                 left = static_cast<int16_t>(left + width + kGap);
-                if (x + width < viewport.x || x > viewport.x + viewport.w)
+                if (x < viewport.x || x + width > viewport.x + viewport.w)
                     continue;
                 const bool active = index == selectedIndex_;
                 const int16_t y = static_cast<int16_t>(viewport.y + viewport.h - height - (active ? 8 : 0));


### PR DESCRIPTION
- Keep partially visible book spines from drawing outside the Library shelf.
- Force-cancel stale workflow runs so cleanup does not fail after the one-minute wait.